### PR TITLE
multiple fixes

### DIFF
--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -125,6 +125,10 @@ namespace Clap
 #if WIN
     if (_handle && !_selfcontained)
     {
+      if (_pluginEntry)
+      {
+        _pluginEntry->deinit();
+      }
       FreeLibrary(_handle);
     }
     _handle = 0;

--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -8,6 +8,7 @@ WrappedView::WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* g
   , IPlugView()
   , _plugin(plugin)
   , _extgui(gui)
+  , _onDestroy(onDestroy)
 {
   
 }

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -117,6 +117,7 @@ public:
 	tresult PLUGIN_API setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns,
 		Vst::SpeakerArrangement* outputs,
 		int32 numOuts) override;
+	tresult PLUGIN_API getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement& arr) override;
 	tresult PLUGIN_API activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index,
 		TBool state) override;
 

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -201,6 +201,7 @@ SMTG_EXPORT_SYMBOL IPluginFactory* PLUGIN_API GetPluginFactory() {
 
 		gPluginFactory = new Steinberg::CPluginFactory(factoryInfo);		
 		// resize the classInfo vector
+		gCreationContexts.clear();
 		gCreationContexts.reserve(gClapLibrary.plugins.size());
 		int numPlugins = static_cast<int>(gClapLibrary.plugins.size());
 		LOGDETAIL("number of plugins in factory: {}", numPlugins);


### PR DESCRIPTION
fixed: reusing library ended in crash (creationContexts weren't cleared)
fixed: destructor callback wasn't initialized and therefore not called
fixed: illegal paramIDs lead to crash
fixed: improved robustness against bugs in VST3TestingHost