### PR TITLE
Handle Clap ID > 2^31 consistently

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -758,9 +758,9 @@ void ClapAsVst3::onIdle()
       break;
     case queueEvent::type_t::editvalue:
       {
-        auto param = (Vst3Parameter*)(parameters.getParameter(n._data._value.param_id));
+        auto param = (Vst3Parameter*)(parameters.getParameter(n._data._value.param_id & 0x7FFFFFFF));
         auto v = n._data._value.value;
-        performEdit(n._data._value.param_id, param->asVst3Value(v));
+        performEdit(param->getInfo().id, param->asVst3Value(v));
       }
       break;
     case queueEvent::type_t::editend:


### PR DESCRIPTION
A mask was in one spot but not consistently in all. I think with this diff I consistently use the getInfo().id for vst side and param_id for the clap side and mask between them

Closes #48