### PR TITLE
temporarily use vst3 sdk version 3.7.7

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -34,6 +34,8 @@ jobs:
           git clone https://github.com/free-audio/clap
           git clone https://github.com/steinbergmedia/vst3sdk
           cd vst3sdk
+          # temporary workaround, switch to vst3 sdk 3.7.7
+          git switch --detach v3.7.7_build_19
           git submodule update --init --recursive
           cd ../..
 


### PR DESCRIPTION
3.7.8 breaks the ability to build windows DLL plugins