### PR TITLE
Fix issue #37 - Pitchwheel does not work correctly

### DIFF
--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -25,7 +25,7 @@ Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint
 	, channel(channel)
 	, controller(cc)
 {
-	if (channel == Vst::ControllerNumbers::kPitchBend)
+	if (cc == Vst::ControllerNumbers::kPitchBend)
 	{
 		max_value = 16383;
 	}


### PR DESCRIPTION
code completion typo... of course cc and not channel must be checked.