### PR TITLE
Convert VST3 noteOnEvent.tuning to a CLAP Note Expression

### DIFF
--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -51,7 +51,9 @@ namespace Clap
 
 		void setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params, 
 			Steinberg::Vst::BusList& numInputs, Steinberg::Vst::BusList& numOutputs,
-			uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs, Steinberg::Vst::ParameterContainer& params, Steinberg::Vst::IComponentHandler* componenthandler, IAutomation* automation, bool enablePolyPressure);
+			uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
+         Steinberg::Vst::ParameterContainer& params, Steinberg::Vst::IComponentHandler* componenthandler,
+         IAutomation* automation, bool enablePolyPressure, bool supportsTuningNoteExpression);
 		void process(Steinberg::Vst::ProcessData& data);
 		void flush();
 		void processOutputParams(Steinberg::Vst::ProcessData& data);
@@ -112,6 +114,7 @@ namespace Clap
 		std::vector<size_t> _eventindices;
 
 		bool _supportsPolyPressure = false;
+      bool _supportsTuningNoteExpression = false;
 
 	};
 

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -169,7 +169,7 @@ tresult PLUGIN_API ClapAsVst3::setProcessing(TBool state)
         this->_largestBlocksize,
         this->eventInputs.size(), this->eventOutputs.size(),
         parameters, componentHandler, this,
-        supportsnoteexpression);
+        supportsnoteexpression, _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
       updateAudioBusses();
 
 
@@ -778,7 +778,7 @@ void ClapAsVst3::onIdle()
     {
       // setup a ProcessAdapter just for flush with no audio
       Clap::ProcessAdapter pa;
-      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0, this->parameters, componentHandler, nullptr, false);
+      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0, this->parameters, componentHandler, nullptr, false, false);
       pa.flush();
     }
   }


### PR DESCRIPTION
If the VST3 noteOnEvent.tuning field exists, and if the target wrapped clap supports note expressions, convert the tuning to the appropriate note expression. Among other things, this allows dorico to work with a wrapped surge xt clap in microtonal mode.