### PR TITLE
Allow a CMake Argument for the VST3 TUID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,16 @@ set_target_properties(${pluginname} PROPERTIES LIBRARY_OUTPUT_NAME "${CLAP_WRAPP
 target_link_libraries(${pluginname} PRIVATE clap-core sdk clap-wrapper-extensions)
 message(STATUS " current source dir: ${CMAKE_CURRENT_SOURCE_DIR} ")
 target_include_directories(${pluginname} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_compile_options(${pluginname} PRIVATE -DCLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS=$<IF:$<BOOL:${CLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS}>,1,0>)
+target_compile_options(${pluginname} PRIVATE
+		-DCLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS=$<IF:$<BOOL:${CLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS}>,1,0>
+		)
+
+if (NOT ${CLAP_VST3_TUID_STRING} STREQUAL "")
+	message(STATUS "Using cmake-specified VST3 TUID ${CLAP_VST3_TUID_STRING}")
+	target_compile_options(${pluginname} PRIVATE
+			-DCLAP_VST3_TUID_STRING="${CLAP_VST3_TUID_STRING}"
+			)
+endif()
 
 if (APPLE)
 	target_link_libraries (${pluginname} PUBLIC "-framework Foundation" "-framework CoreFoundation")

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -227,20 +227,29 @@ SMTG_EXPORT_SYMBOL IPluginFactory* PLUGIN_API GetPluginFactory() {
 				pluginvendor = vst3info->vendor;
 			}
 
-			// make id or take it from vst3 info --------------
-			std::string id(clapdescr->id);
-			Crypto::uuid_object g;
-			if (vst3info && vst3info->componentId)
-			{
-				memcpy(&g, vst3info->componentId, sizeof(g));
-			}
-			else
-			{
-				g = Crypto::create_sha1_guid_from_name(id.c_str(), id.size());
-			}
+         TUID lcid;
+         Crypto::uuid_object g;
 
-			TUID lcid;
-			memcpy(&lcid, &g, sizeof(TUID));
+#ifdef CLAP_VST3_TUID_STRING
+         Steinberg::FUID f;
+         if (f.fromString(CLAP_VST3_TUID_STRING))
+         {
+            memcpy(&g, f.toTUID(), sizeof(TUID));
+            memcpy(&lcid, &g, sizeof(TUID));
+         }
+         else
+#endif
+         {
+            // make id or take it from vst3 info --------------
+            std::string id(clapdescr->id);
+            if (vst3info && vst3info->componentId) {
+               memcpy(&g, vst3info->componentId, sizeof(g));
+            } else {
+               g = Crypto::create_sha1_guid_from_name(id.c_str(), id.size());
+            }
+
+            memcpy(&lcid, &g, sizeof(TUID));
+         }
 
 			// features ----------------------------------------
 			std::string features;


### PR DESCRIPTION
If you add -DCLAP_VST3_TUID_STRING=ABCDEF019182FAEB566D3333AAAAFFFF to your cmake command line, you can explicitly specify the TUID you want the component and so on to bear as a VST3, rather than implementing the extension.