### PR TITLE
fix: release `bundleURL` after last use of `_bundle`

### DIFF
--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -107,14 +107,16 @@ namespace Clap
              CFURLCreateWithFileSystemPath(kCFAllocatorDefault, cs, kCFURLPOSIXPathStyle, true);
 
      _bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
-     CFRelease(bundleURL);
-     CFRelease(cs);
 
      if (!_bundle) {
-        return false;
+         CFRelease(bundleURL);
+         CFRelease(cs);
+         return false;
      }
 
      auto db = CFBundleGetDataPointerForName(_bundle, CFSTR("clap_entry"));
+     CFRelease(bundleURL);
+     CFRelease(cs);
 
      _pluginEntry = (const clap_plugin_entry *)db;
 


### PR DESCRIPTION
 `bundleURL` is referenced, not copied, by `_bundle` which is why it shouldn't be released before the last use of `_bundle`.