### PR TITLE
Rework the CMake setup

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -19,8 +19,8 @@ jobs:
             name: win
           - os: macos-latest
             name: mac
-        #  - os: ubuntu-latest
-        #    name: linux
+          - os: ubuntu-latest
+            name: linux
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ ignore/
 #df habit
 build/
 out/
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ target_compile_options(${pluginname_vst3} PRIVATE
 		)
 
 if (NOT "${CLAP_VST3_TUID_STRING}" STREQUAL "")
-	message(STATUS "Using cmake-specified VST3 TUID ${CLAP_VST3_TUID_STRING}")
+	message(STATUS "clap-wrapper: Using cmake-specified VST3 TUID ${CLAP_VST3_TUID_STRING}")
 	target_compile_options(${pluginname_vst3} PRIVATE
 			-DCLAP_VST3_TUID_STRING="${CLAP_VST3_TUID_STRING}"
 			)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,25 @@
 #	clap-wrapper project
 #
 #   Copyright (c) 2022 Timo Kaluza (defiantnerd)
-#					   Paul Walker
+#					   Paul Walker (baconpaul)
 #
-#	
-
+# There are a variety of advanced options to configure and build this wrapper, but
+# for the simple case of single plugin in a single clap, here are some relevant
+# cmake-time options which this wrapper will use. See the documentation for a more
+# complete description
+#
+# CLAP_WRAPPER_OUTPUT_NAME   The name of the resulting .vst3 or .component
+# CLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS  The wrapper will forward all VST3 note expressions to your CLAP
+# CLAP_VST3_TUID_STRING  The VST3 component ::iid as a string; absent this wrapper hashes clap id
+# CLAP_WRAPPER_BUNDLE_IDENTIFIER the macOS Bundle Identifier. Absent this it is 'org.cleveraudio.wrapper.(name)'
+# CLAP_WRAPPER_BUNDLE_VERSION the macOS Bundle Version. Defaults to 1.0
+#
 
 cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0091 NEW)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version")
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build Universal Always")
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>") # Statically link the MSVC Runtime
 
 # If your clap supports note expressions you *can* implement the wrapper extension here or you
 # can just build with this turned on and it will forward all note expressions to your CLAP
@@ -22,110 +32,85 @@ project(clap-wrapper
 	DESCRIPTION "CLAP-as-X wrappers"
 )
 
-if (APPLE)
-	if (NOT (${CMAKE_GENERATOR} STREQUAL "Xcode"))
-		message(WARNING "Building the VST Wrapper on macOS with a generator other than Xcode creates invalid bundles. You selected ${CMAKE_GENERATOR}")
-	endif()
-endif()
-
-## configuring VST3 SDK
-# plugin UI will be provided by the CLAP
-set(SMTG_ADD_VSTGUI OFF)
-
-# we want a BUNDLE, not the folder format
-set(SMTG_CREATE_MODULE_INFO OFF)
-
-# we want a DLL, not the folder format
-set(SMTG_CREATE_BUNDLE_FOR_WINDOWS OFF)
-
-# not now - but can be useful to activate
-set(SMTG_RUN_VST_VALIDATOR OFF)
-
-# create plugin link
-set(SMTG_CREATE_PLUGIN_LINK ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
 # discover the plugin paths and enable them
 include(cmake/enable_sdks.cmake)
+message(STATUS "clap-wrapper: executing at ${CMAKE_CURRENT_SOURCE_DIR}")
+message(STATUS "clap-wrapper: platform is ${PLATFORM}")
 
-# ------------------------------------------------------------------------------
-
-set(CMAKE_CXX_STANDARD 17)
-
-# set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Build for 10.15")
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# ------------------------------------------------------------------------------
-
-
-if(NOT CMAKE_BUILD_TYPE)
-    message(STATUS "CMAKE_BUILD_TYPE Type Unspecified; picking Release")
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+# provide the CLAP_WRAPPER_OUTPUT_NAME to specify the matching plugin name. This defines two
+# variables: pluginname which is a target and clapname which is the actual output result name
+if((NOT CLAP_WRAPPER_OUTPUT_NAME ) OR (CLAP_WRAPPER_OUTPUT_NAME STREQUAL ""))
+	set(pluginname "clapasvst3")
+	set(clapname ${pluginname})
+	message(WARNING "clap-wrapper: CLAP_WRAPPER_OUTPUT_NAME not set - continuing with a default name `clapasvst3`")
+else()
+	string(MAKE_C_IDENTIFIER ${CLAP_WRAPPER_OUTPUT_NAME} pluginname)
+	set(clapname ${CLAP_WRAPPER_OUTPUT_NAME})
 endif()
 
-message(STATUS "executing at ${CMAKE_CURRENT_SOURCE_DIR}")
+# Generate a VST3 target name (prepare for AU)
+set(pluginname_vst3 ${pluginname}_as_vst3)
+message(STATUS "clap-wrapper: VST3 plugin target is '${pluginname_vst3}' generating target '${clapname}.vst3'")
 
-# ------------------------------------------------------------------------------
 
+# Define the extensions target
 add_library(clap-wrapper-extensions INTERFACE)
 target_include_directories(clap-wrapper-extensions INTERFACE include)
 
-# ------------------------------------------------------------------------------
+# Define the VST3 plugin name and include the sources directly
+add_library(${pluginname_vst3} MODULE ${wrappersources_vst3} ${vst3sources})
+target_include_directories(${pluginname_vst3} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(${pluginname_vst3} PRIVATE ${VST3_SDK_ROOT} ${VST3_SDK_ROOT}/public.sdk ${VST3_SDK_ROOT}/pluginterfaces)
+target_compile_definitions(${pluginname_vst3} PRIVATE -D${PLATFORM}=1)
+set_target_properties(${pluginname_vst3} PROPERTIES LIBRARY_OUTPUT_NAME "${CLAP_WRAPPER_OUTPUT_NAME}")
 
-# provide the CLAP_WRAPPER_OUTPUT_NAME to specify the matching plugin name
-if((NOT CLAP_WRAPPER_OUTPUT_NAME ) OR (CLAP_WRAPPER_OUTPUT_NAME STREQUAL ""))
-  set(pluginname "clapasvst3")
-  message(WARNING "CLAP_WRAPPER_OUTPUT_NAME not set - continuing with a default name `clapasvst3`")
-else()
-  string(MAKE_C_IDENTIFIER ${CLAP_WRAPPER_OUTPUT_NAME} pluginname)  
-  message(STATUS "plugin name is ${CLAP_WRAPPER_OUTPUT_NAME}")
-endif()
+# Link to the clap libraryes
+target_link_libraries(${pluginname_vst3} PRIVATE clap-core clap-wrapper-extensions)
 
-set(pluginname ${pluginname}_as_vst3)
-
-add_definitions(-D${PLATFORM}=1)
-
-message(STATUS "platform is ${PLATFORM}")
-#
-smtg_enable_vst3_sdk()
-
-set(SRCLIST 
-	${wrappersources_vst3}
-	${VST3_SDK_ROOT}/public.sdk/source/vst/vstsinglecomponenteffect.cpp
-	${VST3_SDK_ROOT}/public.sdk/source/vst/vstsinglecomponenteffect.h
-)
-
-smtg_add_vst3plugin(${pluginname} 
-	PACKAGE_NAME ${CLAP_WRAPPER_OUTPUT_NAME}
-	SOURCES_LIST ${SRCLIST}
-)
-
-smtg_target_add_library_main(${pluginname})
-
-set_target_properties(${pluginname} PROPERTIES LIBRARY_OUTPUT_NAME "${CLAP_WRAPPER_OUTPUT_NAME}")
-
-# link both SDKs, CLAP and VST3
-target_link_libraries(${pluginname} PRIVATE clap-core sdk clap-wrapper-extensions)
-message(STATUS " current source dir: ${CMAKE_CURRENT_SOURCE_DIR} ")
-target_include_directories(${pluginname} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_compile_options(${pluginname} PRIVATE
+# Support some of the options at cmake time
+target_compile_options(${pluginname_vst3} PRIVATE
 		-DCLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS=$<IF:$<BOOL:${CLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS}>,1,0>
 		)
 
-if (NOT ${CLAP_VST3_TUID_STRING} STREQUAL "")
+if (NOT "${CLAP_VST3_TUID_STRING}" STREQUAL "")
 	message(STATUS "Using cmake-specified VST3 TUID ${CLAP_VST3_TUID_STRING}")
-	target_compile_options(${pluginname} PRIVATE
+	target_compile_options(${pluginname_vst3} PRIVATE
 			-DCLAP_VST3_TUID_STRING="${CLAP_VST3_TUID_STRING}"
 			)
 endif()
 
-if (APPLE)
-	target_link_libraries (${pluginname} PUBLIC "-framework Foundation" "-framework CoreFoundation")
-endif()
 
-if (UNIX AND NOT APPLE)
-	target_link_libraries(${pluginname} PUBLIC "-ldl")
-	target_link_libraries(${pluginname} PRIVATE "-Wl,--no-undefined")
+if (APPLE)
+	if ("${CLAP_WRAPPER_BUNDLE_IDENTIFIER}" STREQUAL "")
+		set(CLAP_WRAPPER_BUNDLE_IDENTIFIER "org.cleveraudio.wrapper.${pluginname}.vst3")
+	endif()
+
+	if ("${CLAP_WRAPPER_BUNDLE_VERSION}" STREQUAL "")
+		set(CLAP_WRAPPER_BUNDLE_VERSION "1.0")
+	endif()
+
+	target_link_libraries (${pluginname_vst3} PUBLIC "-framework Foundation" "-framework CoreFoundation")
+	set_target_properties(${pluginname_vst3} PROPERTIES
+			BUNDLE True
+			BUNDLE_EXTENSION vst3
+			MACOSX_BUNDLE_GUI_IDENTIFIER ${CLAP_WRAPPER_BUNDLE_IDENTIFIER}
+			MACOSX_BUNDLE_BUNDLE_NAME ${clapname}
+			MACOSX_BUNDLE_BUNDLE_VERSION ${CLAP_WRAPPER_BUNDLE_VERSION}
+			MACOSX_BUNDLE_SHORT_VERSION_STRING ${CLAP_WRAPPER_BUNDLE_VERSION}
+			MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/VST3_Info.plist.in
+			)
+	add_custom_command(TARGET ${pluginname_vst3} POST_BUILD
+			WORKING_DIRECTORY $<TARGET_PROPERTY:${pluginname_vst3},RUNTIME_OUTPUT_DIRECTORY>
+			COMMAND SetFile -a B "$<TARGET_PROPERTY:${pluginname_vst3},MACOSX_BUNDLE_BUNDLE_NAME>.$<TARGET_PROPERTY:${pluginname_vst3},BUNDLE_EXTENSION>")
+elseif(UNIX)
+	target_link_libraries(${pluginname_vst3} PUBLIC "-ldl")
+	target_link_libraries(${pluginname_vst3} PRIVATE "-Wl,--no-undefined")
+else()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ if (NOT "${CLAP_VST3_TUID_STRING}" STREQUAL "")
 			)
 endif()
 
+target_compile_options(${pluginname_vst3} PRIVATE $<IF:$<CONFIG:Debug>,-DDEVELOPMENT=1,-DRELEASE=1>) # work through steinbergs alternate choices for these
 
 if (APPLE)
 	if ("${CLAP_WRAPPER_BUNDLE_IDENTIFIER}" STREQUAL "")
@@ -118,8 +119,6 @@ if (APPLE)
 elseif(UNIX)
 	target_link_libraries(${pluginname_vst3} PUBLIC "-ldl")
 	target_link_libraries(${pluginname_vst3} PRIVATE "-Wl,--no-undefined")
-
-	target_compile_options(${pluginname_vst3} PRIVATE $<IF:$<CONFIG:Debug>,-DDEVELOPMENT=1,-DRELEASE=1>) # work through steinbergs alternate choices for these
 
 	add_custom_command(TARGET ${pluginname_vst3} PRE_BUILD
 			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,15 @@ elseif(UNIX)
 	target_link_libraries(${pluginname_vst3} PUBLIC "-ldl")
 	target_link_libraries(${pluginname_vst3} PRIVATE "-Wl,--no-undefined")
 
+	target_compile_options(${pluginname_vst3} PRIVATE $<IF:$<CONFIG:Debug>,-DDEVELOPMENT=1,-DRELEASE=1>) # work through steinbergs alternate choices for these
 
+	add_custom_command(TARGET ${pluginname_vst3} PRE_BUILD
+			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+			COMMAND ${CMAKE_COMMAND} -E make_directory "${clapname}.vst3/Contents/x86_64-linux"
+	)
+	set_target_properties(${pluginname_vst3} PROPERTIES
+			LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${clapname}.vst3/Contents/x86_64-linux"
+			SUFFIX ".so" PREFIX "")
 else()
 	add_custom_command(TARGET ${pluginname_vst3} PRE_BUILD
 			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ cmake_policy(SET CMP0091 NEW)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version")
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build Universal Always")
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>") # Statically link the MSVC Runtime
+set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 # If your clap supports note expressions you *can* implement the wrapper extension here or you
 # can just build with this turned on and it will forward all note expressions to your CLAP
@@ -35,14 +36,14 @@ project(clap-wrapper
 	DESCRIPTION "CLAP-as-X wrappers"
 )
 
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
 if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
-	message(FATAL_ERROR "Clap Wrapper requires a 64 bit build")
+	# a 32 bit build is odd enough that it might be an error. Chirp.
+	message(STATUS "clap-wrapper: configured as 32 bit build. Intentional?")
 endif()
 
 # discover the plugin paths and enable them
@@ -113,9 +114,11 @@ if (APPLE)
 			MACOSX_BUNDLE_SHORT_VERSION_STRING ${CLAP_WRAPPER_BUNDLE_VERSION}
 			MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/VST3_Info.plist.in
 			)
-	add_custom_command(TARGET ${pluginname_vst3} POST_BUILD
-			WORKING_DIRECTORY $<TARGET_PROPERTY:${pluginname_vst3},RUNTIME_OUTPUT_DIRECTORY>
-			COMMAND SetFile -a B "$<TARGET_PROPERTY:${pluginname_vst3},MACOSX_BUNDLE_BUNDLE_NAME>.$<TARGET_PROPERTY:${pluginname_vst3},BUNDLE_EXTENSION>")
+	if (NOT ${CMAKE_GENERATOR} STREQUAL "Xcode")
+		add_custom_command(TARGET ${pluginname_vst3} POST_BUILD
+				WORKING_DIRECTORY $<TARGET_PROPERTY:${pluginname_vst3},LIBRARY_OUTPUT_DIRECTORY>
+				COMMAND SetFile -a B "$<TARGET_PROPERTY:${pluginname_vst3},MACOSX_BUNDLE_BUNDLE_NAME>.$<TARGET_PROPERTY:${pluginname_vst3},BUNDLE_EXTENSION>")
+	endif()
 elseif(UNIX)
 	target_link_libraries(${pluginname_vst3} PUBLIC "-ldl")
 	target_link_libraries(${pluginname_vst3} PRIVATE "-Wl,--no-undefined")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,15 @@ project(clap-wrapper
 	DESCRIPTION "CLAP-as-X wrappers"
 )
 
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+
+if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
+	message(FATAL_ERROR "Clap Wrapper requires a 64 bit build")
+endif()
 
 # discover the plugin paths and enable them
 include(cmake/enable_sdks.cmake)
@@ -116,13 +121,13 @@ elseif(UNIX)
 
 
 else()
-	set_target_properties(${pluginname_vst3} PROPERTIES
-			LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${clapname}.vst3/Contents/x86_64-win"
-			SUFFIX ".vst3")
 	add_custom_command(TARGET ${pluginname_vst3} PRE_BUILD
 			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 			COMMAND ${CMAKE_COMMAND} -E make_directory "${clapname}.vst3/Contents/x86_64-win"
 			)
+	set_target_properties(${pluginname_vst3} PROPERTIES
+			LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${clapname}.vst3/Contents/x86_64-win"
+			SUFFIX ".vst3")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@
 # cmake-time options which this wrapper will use. See the documentation for a more
 # complete description
 #
+# CLAP_SDK_ROOT The location of the clap library. Defaults to ../clap
+# VST3_SDK_ROOT The location of the VST3 sdk. Defaults tp ../vst3sdk
+#
 # CLAP_WRAPPER_OUTPUT_NAME   The name of the resulting .vst3 or .component
 # CLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS  The wrapper will forward all VST3 note expressions to your CLAP
 # CLAP_VST3_TUID_STRING  The VST3 component ::iid as a string; absent this wrapper hashes clap id
@@ -110,7 +113,16 @@ if (APPLE)
 elseif(UNIX)
 	target_link_libraries(${pluginname_vst3} PUBLIC "-ldl")
 	target_link_libraries(${pluginname_vst3} PRIVATE "-Wl,--no-undefined")
+
+
 else()
+	set_target_properties(${pluginname_vst3} PROPERTIES
+			LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${clapname}.vst3/Contents/x86_64-win"
+			SUFFIX ".vst3")
+	add_custom_command(TARGET ${pluginname_vst3} PRE_BUILD
+			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+			COMMAND ${CMAKE_COMMAND} -E make_directory "${clapname}.vst3/Contents/x86_64-win"
+			)
 endif()
 
 

--- a/cmake/VST3_Info.plist.in
+++ b/cmake/VST3_Info.plist.in
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleGetInfoString</key>
+	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
+	<key>CFBundleIconFile</key>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+</dict>
+</plist>

--- a/cmake/enable_sdks.cmake
+++ b/cmake/enable_sdks.cmake
@@ -73,39 +73,44 @@ function(DetectVST3SDK)
 endfunction()
 
 function(DefineCLAPASVST3Sources)
+	file(GLOB VST3_GLOB
+			${VST3_SDK_ROOT}/base/source/*.cpp
+			${VST3_SDK_ROOT}/base/thread/source/*.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/common/*.cpp
+			${VST3_SDK_ROOT}/pluginterfaces/base/*.cpp
+			)
+
+	if (APPLE)
+		set(vst3platform ${VST3_SDK_ROOT}/public.sdk/source/main/macmain.cpp)
+	elseif (UNIX)
+		set(vst3platform ${VST3_SDK_ROOT}/public.sdk/source/main/linuxmain.cpp)
+	else()
+		set(vst3platform ${VST3_SDK_ROOT}/public.sdk/source/main/dllmain.cpp)
+	endif()
+
 	set(vst3sources
-		${VST3_SDK_ROOT}/public.sdk/source/main/pluginfactory.cpp
+			${VST3_GLOB}
+			${vst3platform}
+			${VST3_SDK_ROOT}/public.sdk/source/main/pluginfactory.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/main/moduleinit.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/vstinitiids.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/vstnoteexpressiontypes.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/vstsinglecomponenteffect.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/vstaudioeffect.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/vstcomponent.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/vstsinglecomponenteffect.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/vstcomponentbase.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/vstbus.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/vstparameters.cpp
+			${VST3_SDK_ROOT}/public.sdk/source/vst/utility/stringconvert.cpp
+			PARENT_SCOPE
+			)
 
-		${VST3_SDK_ROOT}/public.sdk/source/common/commoniids.cpp
-		${VST3_SDK_ROOT}/public.sdk/source/common/memorystream.cpp
-		${VST3_SDK_ROOT}/public.sdk/source/common/pluginview.cpp
-
-		${VST3_SDK_ROOT}/public.sdk/source/vst/vstinitiids.cpp
-		${VST3_SDK_ROOT}/public.sdk/source/vst/vstaudioeffect.cpp
-		${VST3_SDK_ROOT}/public.sdk/source/vst/vstcomponentbase.cpp
-		${VST3_SDK_ROOT}/public.sdk/source/vst/vstcomponent.cpp
-		${VST3_SDK_ROOT}/public.sdk/source/vst/vstsinglecomponenteffect.cpp
-		${VST3_SDK_ROOT}/public.sdk/source/vst/vstsinglecomponenteffect.h
-		#${VST3_SDK_ROOT}/public.sdk/source/vst/vsteditcontroller.cpp
-		${VST3_SDK_ROOT}/public.sdk/source/vst/vstbus.cpp
-		${VST3_SDK_ROOT}/public.sdk/source/vst/vstparameters.cpp
-
-		${VST3_SDK_ROOT}/pluginterfaces/base/funknown.cpp
-		${VST3_SDK_ROOT}/pluginterfaces/base/coreiids.cpp
-		${VST3_SDK_ROOT}/pluginterfaces/base/ustring.cpp
-
-		${VST3_SDK_ROOT}/base/source/baseiids.cpp
-		${VST3_SDK_ROOT}/base/source/fobject.cpp
-		${VST3_SDK_ROOT}/base/source/fstring.cpp
-		${VST3_SDK_ROOT}/base/source/fbuffer.cpp
-		${VST3_SDK_ROOT}/base/source/fdynlib.cpp
-		${VST3_SDK_ROOT}/base/source/fdebug.cpp
-		${VST3_SDK_ROOT}/base/source/updatehandler.cpp
-		${VST3_SDK_ROOT}/base/thread/source/flock.cpp
-		${VST3_SDK_ROOT}/base/thread/source/fcondition.cpp
-	
-		PARENT_SCOPE
-	)
+	if( UNIX AND NOT APPLE )
+		# Sigh - ${VST3_SDK_ROOT} ships with non-working code if you has it
+		get_filename_component(full_path_test_cpp ${VST3_SDK_ROOT}/base/source/timer.cpp ABSOLUTE)
+		list(REMOVE_ITEM vst3sources "${full_path_test_cpp}")
+	endif()
 
 	if(WIN32)
 		set(os_wrappersources src/detail/os/windows.cpp)
@@ -171,9 +176,6 @@ DetectVST3SDK()
 if(NOT EXISTS "${VST3_SDK_ROOT}/public.sdk")
     message(FATAL_ERROR "There is no VST3 SDK at ${VST3_SDK_ROOT} ")
 endif()
-
-message(STATUS "Configuring VST3 SDK")
-add_subdirectory(${VST3_SDK_ROOT} vst3sdk EXCLUDE_FROM_ALL) 
 
 DefineCLAPASVST3Sources() 
 

--- a/cmake/enable_sdks.cmake
+++ b/cmake/enable_sdks.cmake
@@ -163,7 +163,7 @@ if (NOT TARGET clap-core)
 	DetectCLAP()
 
 	if(NOT EXISTS "${CLAP_SDK_ROOT}/include/clap/clap.h")
-		message(FATAL_ERROR "There is no CLAP SDK at ${CLAP_SDK_ROOT} ")
+		message(FATAL_ERROR "There is no CLAP SDK at ${CLAP_SDK_ROOT}. Please set CLAP_SDK_ROOT appropriately ")
 	endif()
 
 	message(STATUS "clap-wrapper: Configuring CLAP SDK")

--- a/cmake/enable_sdks.cmake
+++ b/cmake/enable_sdks.cmake
@@ -10,21 +10,21 @@ set(VST3_SDK_ROOT "" CACHE STRING "Path to VST3 SDK")
 
 function(DetectCLAP)
   if(CLAP_SDK_ROOT STREQUAL "")
-	message(STATUS "searching CLAP SDK in \"${CMAKE_CURRENT_SOURCE_DIR}\"...")
+	message(STATUS "clap-wrapper: searching CLAP SDK in \"${CMAKE_CURRENT_SOURCE_DIR}\"...")
 
 	if ( CLAP_SDK_ROOT STREQUAL "" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/clap")
 	  set(CLAP_SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/libs/clap")
-	  message(STATUS "CLAP SDK detected in libs subdirectory")
+	  message(STATUS "clap-wrapper: CLAP SDK detected in libs subdirectory")
 	endif()
 
 		if ( CLAP_SDK_ROOT STREQUAL "" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/clap")
 	  set(CLAP_SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/clap")
-	  message(STATUS "CLAP SDK detected in subdirectory")
+	  message(STATUS "clap-wrapper: CLAP SDK detected in subdirectory")
 	endif()
 	
 	if ( CLAP_SDK_ROOT STREQUAL "" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../clap")
 	  set(CLAP_SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../clap")
-	  message(STATUS "CLAP SDK detected in parent subdirectory")
+	  message(STATUS "clap-wrapper: CLAP SDK detected in parent subdirectory")
 	endif()
 
 	if(CLAP_SDK_ROOT STREQUAL "")
@@ -33,7 +33,7 @@ function(DetectCLAP)
 
 	cmake_path(CONVERT "${CLAP_SDK_ROOT}" TO_CMAKE_PATH_LIST CLAP_SDK_ROOT)
 
-	message(STATUS "CLAP SDK at ${CLAP_SDK_ROOT}")
+	message(STATUS "clap-wrapper: CLAP SDK at ${CLAP_SDK_ROOT}")
 	set(CLAP_SDK_ROOT "${CLAP_SDK_ROOT}" PARENT_SCOPE)
 
   endif()
@@ -43,21 +43,21 @@ endfunction(DetectCLAP)
 function(DetectVST3SDK)
   
   if(VST3_SDK_ROOT STREQUAL "")
-	message(STATUS "searching VST3 SDK in \"${CMAKE_CURRENT_SOURCE_DIR}\"...")
+	message(STATUS "clap-wrapper: searching VST3 SDK in \"${CMAKE_CURRENT_SOURCE_DIR}\"...")
 
 	if ( VST3_SDK_ROOT STREQUAL "" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libs/vst3sdk")
 	  set(VST3_SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/libs/vst3sdk")
-	  message(STATUS "VST3 SDK detected in libs subdirectory")
+	  message(STATUS "clap-wrapper: VST3 SDK detected in libs subdirectory")
 	endif()
 
 	if ( VST3_SDK_ROOT STREQUAL "" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vst3sdk")
 	  set(VST3_SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/vst3sdk")
-	  message(STATUS "VST3 SDK detected in subdirectory")
+	  message(STATUS "clap-wrapper: VST3 SDK detected in subdirectory")
 	endif()
 
 	if ( VST3_SDK_ROOT STREQUAL "" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../vst3sdk")
 	  set(VST3_SDK_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../vst3sdk")
-	  message(STATUS "VST3 SDK detected in parent directory")
+	  message(STATUS "clap-wrapper: VST3 SDK detected in parent directory")
 	endif()
 
 	if(VST3_SDK_ROOT STREQUAL "")
@@ -67,7 +67,7 @@ function(DetectVST3SDK)
   endif()
 
   cmake_path(CONVERT "${VST3_SDK_ROOT}" TO_CMAKE_PATH_LIST VST3_SDK_ROOT)
-  message(STATUS "VST3 SDK location: ${VST3_SDK_ROOT}")
+  message(STATUS "clap-wrapper: VST3 SDK location: ${VST3_SDK_ROOT}")
   set(VST3_SDK_ROOT "${VST3_SDK_ROOT}" PARENT_SCOPE)
 
 endfunction()
@@ -166,7 +166,7 @@ if (NOT TARGET clap-core)
 		message(FATAL_ERROR "There is no CLAP SDK at ${CLAP_SDK_ROOT} ")
 	endif()
 
-	message(STATUS "Configuring CLAP SDK")
+	message(STATUS "clap-wrapper: Configuring CLAP SDK")
 	add_subdirectory(${CLAP_SDK_ROOT} clap EXCLUDE_FROM_ALL)
 endif()
 

--- a/src/detail/os/windows.cpp
+++ b/src/detail/os/windows.cpp
@@ -117,7 +117,7 @@ namespace os
 		memset(&wc, 0, sizeof(wc));
 		wc.cbSize = sizeof(wc);
 		wc.hInstance = ghInst;
-		wc.lpfnWndProc = &Wndproc;
+		wc.lpfnWndProc = (WNDPROC)&Wndproc;
 		wc.lpszClassName = modulename;
 		auto a = RegisterClassEx(&wc);
 


### PR DESCRIPTION
This set of CMake changes updates the build system to

1. Not use the steinberg cmake library
2. Fix several problems from using the above, include symbol hiding properly on macos and linux, not requiring the xcode generator, making the lin/win bundle code more explicit
3. Turn on linux in the pipeline / ci check also.

I didn't squash these yet since I'm sure ther ewill be review comments and I'll add more.