### PR TITLE
Build a shell AU with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@
 # CLAP_WRAPPER_BUNDLE_IDENTIFIER the macOS Bundle Identifier. Absent this it is 'org.cleveraudio.wrapper.(name)'
 # CLAP_WRAPPER_BUNDLE_VERSION the macOS Bundle Version. Defaults to 1.0
 # CLAP_WRAPPER_WINDOWS_SINGLE_FILE if set to TRUE (default) the windows .vst3 is a single file; false a 3.7 spec folder
+# CLAP_WRAPPER_BUILD_AUV2 on macOS also build an AUV2
 #
 
 cmake_minimum_required(VERSION 3.20)
@@ -31,6 +32,7 @@ set(CMAKE_COLOR_DIAGNOSTICS ON)
 # can just build with this turned on and it will forward all note expressions to your CLAP
 option(CLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS "Does the underlying CLAP support note expressions" OFF)
 option(CLAP_WRAPPER_WINDOWS_SINGLE_FILE "Build a single fine (rather than folder) on windows" ON)
+option(CLAP_WRAPPER_BUILD_AUV2 "Build an AUV2 on macOS" OFF)
 
 project(clap-wrapper
 	LANGUAGES C CXX
@@ -64,9 +66,14 @@ else()
 	set(clapname ${CLAP_WRAPPER_OUTPUT_NAME})
 endif()
 
-# Generate a VST3 target name (prepare for AU)
+# Generate an AU and VST3
 set(pluginname_vst3 ${pluginname}_as_vst3)
 message(STATUS "clap-wrapper: VST3 plugin target is '${pluginname_vst3}' generating target '${clapname}.vst3'")
+
+if (${CLAP_WRAPPER_BUILD_AUV2})
+	set(pluginname_auv2 ${pluginname}_as_auv2)
+	message(STATUS "clap-wrapper: AUV2 plugin target is '${pluginname_auv2}' generating target '${clapname}.component'")
+endif()
 
 
 # Define the extensions target
@@ -99,7 +106,7 @@ target_compile_options(${pluginname_vst3} PRIVATE $<IF:$<CONFIG:Debug>,-DDEVELOP
 
 if (APPLE)
 	if ("${CLAP_WRAPPER_BUNDLE_IDENTIFIER}" STREQUAL "")
-		set(CLAP_WRAPPER_BUNDLE_IDENTIFIER "org.cleveraudio.wrapper.${pluginname}.vst3")
+		set(CLAP_WRAPPER_BUNDLE_IDENTIFIER "org.cleveraudio.wrapper.${pluginname}")
 	endif()
 
 	if ("${CLAP_WRAPPER_BUNDLE_VERSION}" STREQUAL "")
@@ -110,7 +117,7 @@ if (APPLE)
 	set_target_properties(${pluginname_vst3} PROPERTIES
 			BUNDLE True
 			BUNDLE_EXTENSION vst3
-			MACOSX_BUNDLE_GUI_IDENTIFIER ${CLAP_WRAPPER_BUNDLE_IDENTIFIER}
+			MACOSX_BUNDLE_GUI_IDENTIFIER "${CLAP_WRAPPER_BUNDLE_IDENTIFIER}.vst3"
 			MACOSX_BUNDLE_BUNDLE_NAME ${clapname}
 			MACOSX_BUNDLE_BUNDLE_VERSION ${CLAP_WRAPPER_BUNDLE_VERSION}
 			MACOSX_BUNDLE_SHORT_VERSION_STRING ${CLAP_WRAPPER_BUNDLE_VERSION}
@@ -152,4 +159,34 @@ else()
 	endif()
 endif()
 
+if (${CLAP_WRAPPER_BUILD_AUV2})
+	add_library(${pluginname_auv2} MODULE src/wrapasauv2.cpp)
+	set_target_properties(${pluginname_auv2} PROPERTIES LIBRARY_OUTPUT_NAME "${CLAP_WRAPPER_OUTPUT_NAME}")
+
+	target_link_libraries(${pluginname_auv2} PRIVATE auv2_sdk)
+
+	if ("${CLAP_WRAPPER_BUNDLE_IDENTIFIER}" STREQUAL "")
+		set(CLAP_WRAPPER_BUNDLE_IDENTIFIER "org.cleveraudio.wrapper.${pluginname}")
+	endif()
+
+	if ("${CLAP_WRAPPER_BUNDLE_VERSION}" STREQUAL "")
+		set(CLAP_WRAPPER_BUNDLE_VERSION "1.0")
+	endif()
+
+	target_link_libraries (${pluginname_auv2} PUBLIC "-framework Foundation" "-framework CoreFoundation" "-framework AudioToolbox")
+	set_target_properties(${pluginname_auv2} PROPERTIES
+			BUNDLE True
+			BUNDLE_EXTENSION component
+			MACOSX_BUNDLE_GUI_IDENTIFIER "${CLAP_WRAPPER_BUNDLE_IDENTIFIER}.component"
+			MACOSX_BUNDLE_BUNDLE_NAME ${clapname}
+			MACOSX_BUNDLE_BUNDLE_VERSION ${CLAP_WRAPPER_BUNDLE_VERSION}
+			MACOSX_BUNDLE_SHORT_VERSION_STRING ${CLAP_WRAPPER_BUNDLE_VERSION}
+			MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/auv2_Info.plist.in
+			)
+	if (NOT ${CMAKE_GENERATOR} STREQUAL "Xcode")
+		add_custom_command(TARGET ${pluginname_auv2} POST_BUILD
+				WORKING_DIRECTORY $<TARGET_PROPERTY:${pluginname_auv2},LIBRARY_OUTPUT_DIRECTORY>
+				COMMAND SetFile -a B "$<TARGET_PROPERTY:${pluginname_auv2},MACOSX_BUNDLE_BUNDLE_NAME>.$<TARGET_PROPERTY:${pluginname_auv2},BUNDLE_EXTENSION>")
+	endif()
+endif()
 

--- a/cmake/auv2_Info.plist.in
+++ b/cmake/auv2_Info.plist.in
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+    <key>CFBundleIdentifier</key>
+    <string>${MACOSX_BUNDLE_INFO_STRING}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+    <key>NSPrincipalClass</key>
+    <string/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>AudioComponents</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>Free Audio : ${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+        <key>description</key>
+        <string>${MACOSX_BUNDLE_BUNDLE_NAME} Clap to AU Wrapper</string>
+        <key>factoryFunction</key>
+        <string>wrapAsAUV2Factory</string>
+        <key>manufacturer</key>
+        <string>FrAD</string>
+        <key>subtype</key>
+        <string>WRPR</string>
+        <key>type</key>
+        <string>aumu</string>
+        <key>version</key>
+        <integer>1</integer>
+        <key>resourceUsage</key>
+        <dict>
+          <key>network.client</key>
+          <true/>
+          <key>temporary-exception.files.all.read-write</key>
+          <true/>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1,0 +1,24 @@
+//
+//  EmptyPlugIns.cpp
+//  EmptyPlugIns - this is just the empty plugin shell from the SDK for now
+//
+
+#include <AudioUnitSDK/MusicDeviceBase.h>
+
+#if !defined(CLAP_AUSDK_BASE_CLASS)
+#define CLAP_AUSDK_BASE_CLASS ausdk::MusicDeviceBase
+#endif
+
+struct wrapAsAUV2 : public CLAP_AUSDK_BASE_CLASS
+{
+    using Base = CLAP_AUSDK_BASE_CLASS;
+
+    wrapAsAUV2(AudioComponentInstance ci) : Base{ci, 1, 1} {}
+    bool StreamFormatWritable(AudioUnitScope, AudioUnitElement) override { return true; }
+    bool CanScheduleParameters() const override { return false; }
+
+
+
+};
+
+AUSDK_COMPONENT_ENTRY(ausdk::AUMusicDeviceFactory, wrapAsAUV2)


### PR DESCRIPTION
If (1) CMAKE_WRAPPER_BUILD_AUV2 is set and (2) we can find the AUDIOUNIT_SDK_ROOT using the same pattern as the rest, then build a stub AUV2.

This AUV2 isn't usable. And to complete this work will require a bunch of information to fill out the info.plist. But it will scan in auval and show up as an audio unit.

So commit this to 'next' as an off-by-default starting point for AUV2