### PR TITLE
Make macOS use gulrak filesystem; support back to 10.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0091 NEW)
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.11 CACHE STRING "Minimum macOS version")
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build Universal Always")
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>") # Statically link the MSVC Runtime
 set(CMAKE_COLOR_DIAGNOSTICS ON)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,32 @@
+set(CPM_DOWNLOAD_VERSION 0.36.0)
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+function(download_cpm)
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD
+       https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endfunction()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  download_cpm()
+else()
+  # resume download if it previously failed
+  file(READ ${CPM_DOWNLOAD_LOCATION} check)
+  if("${check}" STREQUAL "")
+    download_cpm()
+  endif()
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/enable_sdks.cmake
+++ b/cmake/enable_sdks.cmake
@@ -8,6 +8,8 @@
 set(CLAP_SDK_ROOT "" CACHE STRING "Path to CLAP SDK")
 set(VST3_SDK_ROOT "" CACHE STRING "Path to VST3 SDK")
 
+# make CPM available
+include(cmake/CPM.cmake)
 
 function(LibrarySearchPath)
 	set(oneValueArgs SDKDIR RESULT)
@@ -186,6 +188,13 @@ elseif(WIN32)
 	set(PLATFORM "WIN")
 endif()
 
+
+# Setup a filesystem replacement on apple
+if (APPLE)
+	message(STATUS "cmake-wrapper: Downloading Gulrak Filesystem as a macOS < 10.15 stub")
+	CPMAddPackage("gh:gulrak/filesystem#v1.5.14")
+endif()
+
 # define libraries
 function(target_add_vst3_wrapper)
 	set(oneValueArgs
@@ -228,11 +237,15 @@ function(target_add_vst3_wrapper)
 
 		# clap-wrapper-extensions are PUBLIC, so a clap linking the library can access the clap-wrapper-extensions
 		target_compile_definitions(clap-wrapper-vst3-${V3_TARGET} PUBLIC -D${PLATFORM}=1)
-		target_link_libraries(clap-wrapper-vst3-${V3_TARGET} PRIVATE clap-wrapper-extensions)
+		target_link_libraries(clap-wrapper-vst3-${V3_TARGET} PUBLIC clap-wrapper-extensions)
 
 		target_compile_options(clap-wrapper-vst3-${V3_TARGET} PRIVATE
 				-DCLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS=$<IF:$<BOOL:${V3_SUPPORTS_ALL_NOTE_EXPRESSIONS}>,1,0>
 				)
+
+		if (APPLE)
+			target_link_libraries(clap-wrapper-vst3-${V3_TARGET} PUBLIC ghc_filesystem)
+		endif()
 	endif()
 
 
@@ -360,7 +373,7 @@ if (APPLE)
 
 				# clap-wrapper-extensions are PUBLIC, so a clap linking the library can access the clap-wrapper-extensions
 				target_compile_definitions(clap-wrapper-auv2-${AUV2_TARGET} INTERFACE -D${PLATFORM}=1)
-				target_link_libraries(clap-wrapper-auv2-${AUV2_TARGET} INTERFACE clap-wrapper-extensions)
+				target_link_libraries(clap-wrapper-auv2-${AUV2_TARGET} INTERFACE clap-wrapper-extensions ghc_filesystem)
 			endif()
 
 			set_target_properties(${AUV2_TARGET} PROPERTIES LIBRARY_OUTPUT_NAME "${AUV2_OUTPUT_NAME}")
@@ -410,3 +423,4 @@ if(${CMAKE_SIZEOF_VOID_P} EQUAL 4)
 	message(STATUS "clap-wrapper: configured as 32 bit build. Intentional?")
 endif()
 message(STATUS "clap-wrapper: source dir is ${CMAKE_CURRENT_SOURCE_DIR}, platform is ${PLATFORM}")
+

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -39,19 +39,19 @@ namespace Clap
   }
 #endif
 
-  std::vector<std::filesystem::path> getValidCLAPSearchPaths()
+  std::vector<fs::path> getValidCLAPSearchPaths()
   {
-    std::vector<std::filesystem::path> res;
+    std::vector<fs::path> res;
 
 #if MAC
-    extern std::vector<std::filesystem::path> getMacCLAPSearchPaths();
+    extern std::vector<fs::path> getMacCLAPSearchPaths();
     res = getMacCLAPSearchPaths();
     // getSystemPaths(res);
 #endif
 
 #if LIN
     res.emplace_back("/usr/lib/clap");
-    res.emplace_back(std::filesystem::path(getenv("HOME")) / std::filesystem::path(".clap"));
+    res.emplace_back(fs::path(getenv("HOME")) / fs::path(".clap"));
 #endif
 
 #if WIN
@@ -60,12 +60,12 @@ namespace Clap
       auto p = getEnvVariable("COMMONPROGRAMFILES");
       if (!p.empty())
       {
-        res.emplace_back(std::filesystem::path{ p } / "CLAP");
+        res.emplace_back(fs::path{ p } / "CLAP");
       }
       auto q = getEnvVariable("LOCALAPPDATA");
       if (!q.empty())
       {
-        res.emplace_back(std::filesystem::path{ q } / "Programs" / "Common" / "CLAP");
+        res.emplace_back(fs::path{ q } / "Programs" / "Common" / "CLAP");
       }
     }
     auto cp = getEnvVariable("CLAP_PATH");
@@ -87,10 +87,10 @@ namespace Clap
       {
         auto item = cp.substr(0, pos);
         cp = cp.substr(pos + 1);
-        res.emplace_back(std::filesystem::path{ item });
+        res.emplace_back(fs::path{ item });
       }
       if (cp.size())
-        res.emplace_back(std::filesystem::path{ cp });
+        res.emplace_back(fs::path{ cp });
     }
 
     return res;

--- a/src/detail/clap/fsutil.h
+++ b/src/detail/clap/fsutil.h
@@ -10,8 +10,15 @@
 
 #pragma once
 
-#include <vector>
+#if MAC
+#include "ghc/filesystem.hpp"
+namespace fs = ghc::filesystem;
+#else
 #include <filesystem>
+namespace fs = std::filesystem;
+#endif
+
+#include <vector>
 #include <functional>
 #include <clap/clap.h>
 #if WIN
@@ -27,7 +34,7 @@
 namespace Clap
 {
 
-  std::vector<std::filesystem::path> getValidCLAPSearchPaths();
+  std::vector<fs::path> getValidCLAPSearchPaths();
   class Plugin;
   class IHost;
 

--- a/src/detail/clap/mac_helpers.mm
+++ b/src/detail/clap/mac_helpers.mm
@@ -10,14 +10,17 @@
 */
 
 #include <vector>
-#include <filesystem>
+
+// No need to ifdef this - it is mac only
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
 
 #include <Foundation/Foundation.h>
 
 namespace Clap
 {
-    std::vector<std::filesystem::path> getMacCLAPSearchPaths() {
-       auto res = std::vector<std::filesystem::path>();
+    std::vector<fs::path> getMacCLAPSearchPaths() {
+       auto res = std::vector<fs::path>();
        auto *fileManager = [NSFileManager defaultManager];
        auto *userLibURLs = [fileManager URLsForDirectory:NSLibraryDirectory
                                                inDomains:NSUserDomainMask];
@@ -27,14 +30,14 @@ namespace Clap
        if (userLibURLs) {
           auto *u = [userLibURLs objectAtIndex:0];
           auto p =
-                  std::filesystem::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
+                  fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
           res.push_back(p);
        }
 
        if (sysLibURLs) {
           auto *u = [sysLibURLs objectAtIndex:0];
           auto p =
-                  std::filesystem::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
+                  fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
           res.push_back(p);
        }
        return res;

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -14,7 +14,8 @@
 #include "public.sdk/source/main/moduleinit.h"
 #include "osutil.h"
 #include <vector>
-#include <filesystem>
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
 #include <iostream>
 
 namespace os
@@ -123,7 +124,7 @@ namespace os
   std::string getParentFolderName()
   {
     NSString* identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
-    std::filesystem::path n = [identifier UTF8String];
+    fs::path n = [identifier UTF8String];
     if (n.has_parent_path())
     {
       auto p = n.parent_path();
@@ -143,7 +144,7 @@ namespace os
     
     // this is needed:
     NSString* identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
-    std::filesystem::path k = [identifier UTF8String];
+    fs::path k = [identifier UTF8String];
     return k.stem();
   }
 }

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -37,7 +37,9 @@ namespace Clap
 			clap_event_note_expression_t noteexpression;
 		} clap_multi_event_t;
 
-		// the bitly helpers
+#if 0
+		// the bitly helpers. These names conflict with macOS params.h but are
+      // unused, so for now comment out
 		static void setbit(uint64_t& val, int bit, bool value)
 		{
 			if (value) val |= ((uint64_t)1 << bit); else val &= ~((uint64_t)1 << bit);
@@ -48,6 +50,7 @@ namespace Clap
 			val &= ~(mask << pos);
 			if (value) val |= mask << pos;
 		}
+#endif
 
 		void setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params, 
 			Steinberg::Vst::BusList& numInputs, Steinberg::Vst::BusList& numOutputs,

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -79,14 +79,14 @@ bool findPlugin(Clap::Library& lib, const std::string& pluginfilename)
 	// Strategy 1: look for a clap with the same name as this binary
 	for (auto& i : paths)
 	{
-		if ( !std::filesystem::exists(i) )
+		if ( !fs::exists(i) )
 		 continue;
 		// try to find it the CLAP folder immediately
 		auto k1 = i / pluginfilename;
 		LOGDETAIL("scanning for binary: {}", k1.u8string().c_str());
 		std::cout << "scanning for " << k1 << std::endl;
 		
-		if (std::filesystem::exists(k1))
+		if (fs::exists(k1))
 		{
 			if (lib.load(k1.u8string().c_str()))
 			{
@@ -97,7 +97,7 @@ bool findPlugin(Clap::Library& lib, const std::string& pluginfilename)
 		// Strategy 2: try to locate "CLAP/vendorX/plugY.clap"  - derived from "VST3/vendorX/plugY.vst3"
 		auto k2 = i / parentfolder / pluginfilename;
 		LOGDETAIL("scanning for binary: {}", k2.u8string().c_str());
-		if (std::filesystem::exists(k2))
+		if (fs::exists(k2))
 		{
 			if (lib.load(k2.u8string().c_str()))
 			{
@@ -106,11 +106,11 @@ bool findPlugin(Clap::Library& lib, const std::string& pluginfilename)
 		}
 
 		// Strategy 3: enumerate folders in CLAP folder and try to locate the plugin in any sub folder (only one level)
-		for (const auto& subdir : std::filesystem::directory_iterator(i))
+		for (const auto& subdir : fs::directory_iterator(i))
 		{
 			auto k3 = i / subdir / pluginfilename;
 			LOGDETAIL("scanning for binary: {}", k3.u8string().c_str());
-			if (std::filesystem::exists(k3))
+			if (fs::exists(k3))
 			{
 				if (lib.load(k3.u8string().c_str()))
 				{


### PR DESCRIPTION
Use gulrak filesystem rather than std::filesystem by using ifdefs and fs:: namespace alias for std::filesystem or ghc::filesystem. Grab the gulrak filesystem from github using CPM. Set the OS version to 10.11 - which allows AU and VST3.

Closes #20

As a result, the VST3 no longer leaks filesystem symbols, so also Closes #72