### PR TITLE
Fix a small warning on param info access

### DIFF
--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -54,8 +54,8 @@ Vst3Parameter* Vst3Parameter::create(const clap_param_info_t* info, std::functio
 	std::string fullname;
 	Vst::UnitID unit = 0;
 
-	// if there is a module and a lambda
-	if (info->module && info->module[0] != 0 && getUnitId)
+	// if there is a module name and a lambda
+	if (info->module[0] != 0 && getUnitId)
 	{
 		unit = getUnitId(info->module);
 		fullname = info->name;


### PR DESCRIPTION
Vst3Parameeter::create used to do

if (info->module && info->module[0])

but clap_param_info_t defines the module a `char module[CLAP_PATH_SIZE] so it is always a realized pointer. This made macos throw the warning

address of array 'info->module' will always evaluate to 'true' [-Wpointer-bool-conversion]

correctly. So just fix it!