### PR TITLE
If OSX_DEPLOYMENT target >= 10.15, use std::filesystem

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,18 @@
+﻿---
+UseTab: Never
+---
+Language: Cpp
+IndentWidth: 2
+AlignAfterOpenBracket: Align
+BreakBeforeBraces: Allman
+ColumnLimit: 100
+SortIncludes: false
+---
+Language: ObjC
+IndentWidth: 2
+AlignAfterOpenBracket: Align
+BreakBeforeBraces: Allman
+ColumnLimit: 100
+SortIncludes: false
+
+...

--- a/src/detail/clap/fsutil.h
+++ b/src/detail/clap/fsutil.h
@@ -11,8 +11,13 @@
 #pragma once
 
 #if MAC
+#if MACOS_USE_STD_FILESYSTEM
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
 #include "ghc/filesystem.hpp"
 namespace fs = ghc::filesystem;
+#endif
 #else
 #include <filesystem>
 namespace fs = std::filesystem;

--- a/src/detail/clap/mac_helpers.mm
+++ b/src/detail/clap/mac_helpers.mm
@@ -13,8 +13,13 @@
 #include <dlfcn.h>
 
 // No need to ifdef this - it is mac only
-#include <ghc/filesystem.hpp>
+#if MACOS_USE_STD_FILESYSTEM
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include "ghc/filesystem.hpp"
 namespace fs = ghc::filesystem;
+#endif
 
 #include <Foundation/Foundation.h>
 

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -14,8 +14,13 @@
 #include "public.sdk/source/main/moduleinit.h"
 #include "osutil.h"
 #include <vector>
-#include <ghc/filesystem.hpp>
+#if MACOS_USE_STD_FILESYSTEM
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include "ghc/filesystem.hpp"
 namespace fs = ghc::filesystem;
+#endif
 #include <iostream>
 
 namespace os


### PR DESCRIPTION
The default OSX_DEPLOYMENT for this package is 10.11, but since we can also be included and used by a parent project which may make a different choice, if that parent project chooses an OSX_DEPLOYMENT of 10.15 or higher, don't download gulrak filesystem and use std::filesystem from the os libc

Closes #90