### PR TITLE
Defensive guard of CFTimerCreate

### DIFF
--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -80,7 +80,8 @@ namespace os
 	  	CFRunLoopTimerContext context = {};
 	  	context.info = this;
 	  	_timer = CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + (kIntervall * 0.001f), kIntervall * 0.001f, 0, 0, timerCallback, &context);
-	  	CFRunLoopAddTimer(CFRunLoopGetCurrent(), _timer, kCFRunLoopCommonModes);
+                if (_timer)
+	  	    CFRunLoopAddTimer(CFRunLoopGetCurrent(), _timer, kCFRunLoopCommonModes);
 	  }
 	  _plugs.push_back(plugobject);
 	}
@@ -90,9 +91,12 @@ namespace os
 	  _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
 	  if ( _plugs.empty() )
 	  {
-	    CFRunLoopTimerInvalidate(_timer);
-	    CFRelease(_timer);
-	    _timer = nullptr;
+            if (_timer)
+            {
+                CFRunLoopTimerInvalidate(_timer);
+                CFRelease(_timer);
+            }
+            _timer = nullptr;
 	  }
 	}
 

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -513,12 +513,6 @@ void ClapAsVst3::setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin
 
   fprintf(stderr, "\tAUDIO in: %d, out: %d\n", (int)numAudioInputs, (int)numAudioOutputs);
 
-  std::vector<clap_audio_port_info_t> inputs;
-  std::vector<clap_audio_port_info_t> outputs;
-
-  inputs.resize(numAudioInputs);
-  outputs.resize(numAudioOutputs);
-
   for (decltype(numAudioInputs) i = 0; i < numAudioInputs; ++i)
   {
     clap_audio_port_info_t info;


### PR DESCRIPTION
on macOS we do a cf timer create / destroy in attach/detatch but we don't guard for success. the vst3 validator has this fail so we will dump core on detach in some cases. Guard.