### PR TITLE
fixing the erase-remove idiom and notify the host only when appropriate

### DIFF
--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -680,8 +680,12 @@ namespace Clap
         auto ev = (clap_event_param_gesture*)event;
         auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
 
-        _automation->onEndEdit(param->getInfo().id);
-        _gesturedParameters.erase(std::remove(_gesturedParameters.begin(), _gesturedParameters.end(), param->getInfo().id));
+        auto n = std::remove(_gesturedParameters.begin(), _gesturedParameters.end(), param->getInfo().id);
+        if (n != _gesturedParameters.end())
+        {
+          _gesturedParameters.erase(n, _gesturedParameters.end());
+          _automation->onEndEdit(param->getInfo().id);
+        }
       }
       return true;
       break;


### PR DESCRIPTION
The usage of the erase-remove idiom was wrong and let to undefined behavior, if no parameter was in the list of gestured parameters.