### PR TITLE
Implement outbound CLAP_EVENT_NOTE_* from wrapped plugins

### DIFF
--- a/src/detail/vst3/categories.cpp
+++ b/src/detail/vst3/categories.cpp
@@ -57,6 +57,7 @@ static const struct _translate
   // CLAP main categories
   {   CLAP_PLUGIN_FEATURE_INSTRUMENT            , PlugType::kInstrument },
   {   CLAP_PLUGIN_FEATURE_AUDIO_EFFECT          , PlugType::kFx},
+  {   CLAP_PLUGIN_FEATURE_NOTE_EFFECT           , PlugType::kInstrumentSynth}, // it seems there is no type for a sequencer etc
   {   CLAP_PLUGIN_FEATURE_DRUM                  , PlugType::kInstrumentDrum},
   {   CLAP_PLUGIN_FEATURE_ANALYZER              , PlugType::kAnalyzer},
 

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -633,8 +633,6 @@ namespace Clap
 
       if (_vstdata && _vstdata->outputEvents)
         _vstdata->outputEvents->addEvent(oe);
-      else
-        fprintf(stderr, "No Output Events for CLAP_NOTE_ON\n");
     }
       return true;
     case CLAP_EVENT_NOTE_OFF:
@@ -655,8 +653,6 @@ namespace Clap
 
       if (_vstdata && _vstdata->outputEvents)
         _vstdata->outputEvents->addEvent(oe);
-      else
-        fprintf(stderr, "No Output Events for CLAP_NOTE_OFF\n");
     }
       return true;
     case CLAP_EVENT_NOTE_END:
@@ -733,7 +729,6 @@ namespace Clap
     case CLAP_EVENT_MIDI:
     case CLAP_EVENT_MIDI_SYSEX:
     case CLAP_EVENT_MIDI2:
-      fprintf(stderr, "Ignoring output event CLAP_EVENT_MIDI*\n");
       return true;
       break;
     default:

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -617,7 +617,47 @@ namespace Clap
     switch (event->type)
     {
     case CLAP_EVENT_NOTE_ON:
+    {
+      auto nevt = reinterpret_cast<const clap_event_note *>(event);
+
+      Steinberg::Vst::Event oe{};
+      oe.type = Steinberg::Vst::Event::kNoteOnEvent;
+      oe.noteOn.channel = nevt->channel;
+      oe.noteOn.pitch = nevt->key;
+      oe.noteOn.velocity = nevt->velocity;
+      oe.noteOn.length = 0;
+      oe.noteOn.tuning = 0.0f;
+      oe.noteOn.noteId = nevt->note_id;
+      oe.busIndex = 0; // FIXME - multi-out midi still needs work
+      oe.sampleOffset = nevt->header.time;
+
+      if (_vstdata && _vstdata->outputEvents)
+        _vstdata->outputEvents->addEvent(oe);
+      else
+        fprintf(stderr, "No Output Events for CLAP_NOTE_ON\n");
+    }
+      return true;
     case CLAP_EVENT_NOTE_OFF:
+    {
+      auto nevt = reinterpret_cast<const clap_event_note *>(event);
+
+      Steinberg::Vst::Event oe{};
+      oe.type = Steinberg::Vst::Event::kNoteOffEvent;
+      oe.noteOff.channel = nevt->channel;
+      oe.noteOff.pitch = nevt->key;
+      oe.noteOff.velocity = nevt->velocity;
+      oe.noteOn.length = 0;
+      oe.noteOff.tuning = 0.0f;
+      oe.noteOff.noteId = nevt->note_id;
+      oe.busIndex = 0; // FIXME - multi-out midi still needs work
+      oe.sampleOffset = nevt->header.time;
+
+
+      if (_vstdata && _vstdata->outputEvents)
+        _vstdata->outputEvents->addEvent(oe);
+      else
+        fprintf(stderr, "No Output Events for CLAP_NOTE_OFF\n");
+    }
       return true;
     case CLAP_EVENT_NOTE_END:
     case CLAP_EVENT_NOTE_CHOKE:
@@ -693,6 +733,7 @@ namespace Clap
     case CLAP_EVENT_MIDI:
     case CLAP_EVENT_MIDI_SYSEX:
     case CLAP_EVENT_MIDI2:
+      fprintf(stderr, "Ignoring output event CLAP_EVENT_MIDI*\n");
       return true;
       break;
     default:

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -389,6 +389,10 @@ void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t* info, uint32_t inde
     {
       addEventInput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
     }
+    else
+    {
+      addEventOutput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);
+    }
   }
 }
 


### PR DESCRIPTION
Push them as kNoteOn/Off events onto the result bus.