### PR TITLE
Turn on Wextra and Wpedantic on clang/gcc

### DIFF
--- a/cmake/enable_sdks.cmake
+++ b/cmake/enable_sdks.cmake
@@ -340,7 +340,7 @@ function(target_add_vst3_wrapper)
 				)
 
 		if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-			target_compile_options(${V3_TARGET}-clap-wrapper-vst3-lib PRIVATE -Wall)
+			target_compile_options(${V3_TARGET}-clap-wrapper-vst3-lib PRIVATE -Wall -Wextra -Wno-unused-parameter -Wpedantic)
 		endif()
 		if (APPLE)
 			target_link_libraries(${V3_TARGET}-clap-wrapper-vst3-lib PUBLIC macos_filesystem_support)

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -49,7 +49,7 @@ namespace Clap
     if ( numInputs > 0)
     {
       _input_ports = new clap_audio_buffer_t[numInputs];
-      for (int i = 0; i < numInputs; ++i)
+      for (auto i = 0U; i < numInputs; ++i)
       {
         clap_audio_buffer_t& bus = _input_ports[i];
         Vst::BusInfo info;
@@ -77,7 +77,7 @@ namespace Clap
     if (numOutputs > 0)
     {
       _output_ports = new clap_audio_buffer_t[numOutputs];
-      for (int i = 0; i < numOutputs; ++i)
+      for (auto i = 0U; i < numOutputs; ++i)
       {
         clap_audio_buffer_t& bus = _output_ports[i];
         Vst::BusInfo info;
@@ -361,7 +361,7 @@ namespace Clap
     {
       // setting the buffers
       auto inbusses = _audioinputs->size();
-      for (int i = 0; i < inbusses; ++i)
+      for (auto i = 0U; i < inbusses; ++i)
       {
         if (_vstdata->inputs[i].numChannels > 0)
           _input_ports[i].data32 = _vstdata->inputs[i].channelBuffers32;
@@ -370,7 +370,7 @@ namespace Clap
       }
 
       auto outbusses = _audiooutputs->size();
-      for (int i = 0; i < outbusses; ++i)
+      for (auto i = 0U; i < outbusses; ++i)
       {
         if (_vstdata->outputs[i].numChannels > 0)
           _output_ports[i].data32 = _vstdata->outputs[i].channelBuffers32;

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -13,10 +13,21 @@
 
 */
 #include <clap/clap.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wextra"
+#endif
+
 #include <pluginterfaces/vst/ivstevents.h>
 #include <pluginterfaces/vst/ivstaudioprocessor.h>
 #include <public.sdk/source/vst/vstparameters.h>
 #include <public.sdk/source/vst/vstbus.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 #include <vector>
 #include <memory>
 

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -398,11 +398,11 @@ void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t* info, uint32_t inde
 
 void ClapAsVst3::updateAudioBusses()
 {
-  for ( int i = 0 ; i < audioInputs.size() ; ++i)
+  for ( auto i = 0U; i < audioInputs.size() ; ++i)
   {
     _processAdapter->activateAudioBus(Vst::kInput, i,audioInputs[i]->isActive());
   }
-  for (int i = 0; i < audioOutputs.size(); ++i)
+  for (auto i = 0U; i < audioOutputs.size(); ++i)
   {
     _processAdapter->activateAudioBus(Vst::kOutput, i, audioOutputs[i]->isActive());
   }
@@ -667,7 +667,7 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
     vstflags |= Vst::RestartFlags::kMidiCCAssignmentChanged;
   }
 
-  vstflags |= ((flags & CLAP_PARAM_RESCAN_VALUES) ? Vst::RestartFlags::kParamValuesChanged : 0u);
+  vstflags |= ((flags & CLAP_PARAM_RESCAN_VALUES) ? (uint32_t)Vst::RestartFlags::kParamValuesChanged : 0u);
   vstflags |= ((flags & CLAP_PARAM_RESCAN_INFO) ? Vst::RestartFlags::kParamValuesChanged | Vst::RestartFlags::kParamTitlesChanged : 0u);
   if (vstflags != 0)
   {

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -14,10 +14,21 @@
 */
 
 #include "clap_proxy.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wextra"
+#endif
+
 #include <pluginterfaces/vst/ivstmidicontrollers.h>
 #include <pluginterfaces/vst/ivstnoteexpression.h>
 #include <public.sdk/source/vst/vstsinglecomponenteffect.h>
 #include <public.sdk/source/vst/vstnoteexpressiontypes.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 #include "detail/vst3/plugview.h"
 #include "detail/os/osutil.h"
 #include "detail/clap/automation.h"

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -268,7 +268,7 @@ IPluginFactory* GetPluginFactoryEntryPoint() {
 				char x[sizeof(g)*2+8];
 				char* o = x;
 				constexpr char hexchar[] = "0123456789ABCDEF";
-				for (int i = 0 ; i < sizeof(g) ; i++)
+				for (auto i = 0U ; i < sizeof(g) ; i++)
 				{
 					auto n = v[i];
 					*o++ = hexchar[(n >> 4) & 0xF];


### PR DESCRIPTION
Ignore unused-parameter; it is useful to document intent. Keep the rest
If we merge #107 we will be able to turn on Werror also, at least on mac.