### PR TITLE
Add an AUv2 factory option for subtype etc...

### DIFF
--- a/cmake/enable_sdks.cmake
+++ b/cmake/enable_sdks.cmake
@@ -473,14 +473,6 @@ if (APPLE)
 				message(FATAL_ERROR "clap-wrapper: auv2-target must be a target")
 			endif()
 
-			if (NOT DEFINED AUV2_MANUFACTURER_NAME)
-				message(FATAL_ERROR "clap-wrapper: For now please specify AUV2 manufacturer name")
-			endif()
-
-			if (NOT DEFINED AUV2_MANUFACTURER_CODE)
-				message(FATAL_ERROR "clap-wrapper: For now please specify AUV2 manufacturer code (4 chars)")
-			endif()
-
 			if (NOT DEFINED AUV2_BUNDLE_VERSION)
 				message(WARNING "clap-wrapper: bundle version not defined. Chosing 1")
 				set(AUV2_BUNDLE_VERSION 1)
@@ -531,7 +523,15 @@ if (APPLE)
 				endif()
 
 				if (NOT DEFINED AUV2_SUBTYPE_CODE)
-					message(FATAL_ERROR "clap-wrapper: For now please specify AUV2 subtype code (4 chars)")
+					message(FATAL_ERROR "clap-wrapper: For nontarget build specify AUV2 subtype code (4 chars)")
+				endif()
+
+				if (NOT DEFINED AUV2_MANUFACTURER_NAME)
+					message(FATAL_ERROR "clap-wrapper: For nontarget build specify AUV2 manufacturer name")
+				endif()
+
+				if (NOT DEFINED AUV2_MANUFACTURER_CODE)
+					message(FATAL_ERROR "clap-wrapper: For nontarget build specify AUV2 manufacturer code (4 chars)")
 				endif()
 
 				if (NOT DEFINED AUV2_INSTRUMENT_TYPE)

--- a/include/clapwrapper/auv2.h
+++ b/include/clapwrapper/auv2.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "clap/private/macros.h"
+#include <cstdint>
+
+static const CLAP_CONSTEXPR char CLAP_PLUGIN_FACTORY_INFO_AUV2[] =
+    "clap.plugin-factory-info-as-auv2.draft0";
+
+typedef struct clap_plugin_info_as_auv2
+{
+    char au_type[5]; // the au_type. If empty (best choice) use the features[0] to aumu aufx aumi
+    char au_subt[5]; // the subtype. If empty (worst choice) we try a bad 32 bit hash of the id
+} clap_plugin_info_as_auv2_t;
+
+typedef struct clap_plugin_factory_as_auv2
+{
+    // optional values for the Steinberg::PFactoryInfo structure
+    const char *manufacturer_code; // your 'manu' field
+    const char *manufacturer_name; // your manufacturer display name
+
+    // populate information about this particular auv2. Return false if we cannot.
+    bool(CLAP_ABI *get_auv2_info)(const clap_plugin_factory_as_auv2 *factory, uint32_t index,
+                                  clap_plugin_info_as_auv2_t *info);
+} clap_plugin_factory_as_auv2_t;

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -239,6 +239,8 @@ namespace Clap
     {
       _parentHost->setupParameters(_plugin, _ext._params);
     }
+
+    _parentHost->setupWrapperSpecifics(_plugin);
     return true;
   }
 

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -196,11 +196,14 @@ namespace Clap
                    static_cast<const clap_plugin_factory *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_ID));
            _pluginFactoryVst3Info =
                   static_cast<const clap_plugin_factory_as_vst3*>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_VST3));
+           _pluginFactoryAUv2Info =
+               static_cast<const clap_plugin_factory_as_auv2*>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_AUV2));
 
            // detect plugins that do not check the CLAP_PLUGIN_FACTORY_ID
            if ((void*)_pluginFactory == (void*)_pluginFactoryVst3Info)
            {
              _pluginFactoryVst3Info = nullptr;
+             _pluginFactoryAUv2Info = nullptr;
            }
 
            auto count = _pluginFactory->get_plugin_count(_pluginFactory);

--- a/src/detail/clap/fsutil.h
+++ b/src/detail/clap/fsutil.h
@@ -31,6 +31,7 @@ namespace fs = std::filesystem;
 #endif
 
 #include "clapwrapper/vst3.h"
+#include "clapwrapper/auv2.h"
 
 #if MAC
 #include <CoreFoundation/CoreFoundation.h>
@@ -53,6 +54,7 @@ namespace Clap
     const clap_plugin_entry_t* _pluginEntry = nullptr;
     const clap_plugin_factory_t* _pluginFactory = nullptr;
     const clap_plugin_factory_as_vst3* _pluginFactoryVst3Info = nullptr;
+    const clap_plugin_factory_as_auv2* _pluginFactoryAUv2Info = nullptr;
     std::vector<const clap_plugin_descriptor_t*> plugins;
     const clap_plugin_info_as_vst3_t* get_vst3_info(uint32_t index);
 


### PR DESCRIPTION
The subtype etc can be determined bu either cmake arguments, a hash of the id, or explicit sets of optiosn through a factor akin to the vst3 factory. This commit implements the latter.

Once merged, conduit will use this to explicitly set its vst3 and auv2 options.