### PR TITLE
Enable consistent clang format for the project

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ BreakConstructorInitializers: BeforeComma
 BreakBeforeBraces: Allman
 ColumnLimit: 105 
 SortIncludes: false
-NamespaceIndentation: All
+NamespaceIndentation: Inner
 ReflowComments: false
 AllowShortFunctionsOnASingleLine: None
 ---
@@ -30,7 +30,7 @@ BreakConstructorInitializers: BeforeComma
 BreakBeforeBraces: Allman
 ColumnLimit: 105
 SortIncludes: false
-NamespaceIndentation: All
+NamespaceIndentation: Inner
 ReflowComments: false
 AllowShortFunctionsOnASingleLine: None
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -10,6 +10,7 @@ ColumnLimit: 250
 SortIncludes: false
 NamespaceIndentation: All
 ReflowComments: false
+AllowShortFunctionsOnASingleLine: None
 ---
 Language: ObjC
 BasedOnStyle: Google
@@ -20,4 +21,5 @@ ColumnLimit: 250
 SortIncludes: false
 NamespaceIndentation: All
 ReflowComments: false
+AllowShortFunctionsOnASingleLine: None
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,10 @@
 UseTab: Never
 ---
 Language: Cpp
+AlignAfterOpenBracket: BAS_Align
+ConstructorInitializerIndentWidth: 2 
+SpaceBeforeParens: ControlStatements
+ColumnLimit: 105
 BasedOnStyle: Google
 IndentWidth: 2
 AlignAfterOpenBracket: Align
@@ -16,6 +20,9 @@ AllowShortFunctionsOnASingleLine: None
 ---
 Language: ObjC
 BasedOnStyle: Google
+AlignAfterOpenBracket: BAS_Align
+ConstructorInitializerIndentWidth: 2 
+SpaceBeforeParens: ControlStatements
 IndentWidth: 2
 AlignAfterOpenBracket: Align
 ConstructorInitializerAllOnOneLineOrOnePerLine: true

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,19 @@
+﻿---
+UseTab: Never
+---
+Language: Cpp
+IndentWidth: 2
+AlignAfterOpenBracket: Align
+BreakBeforeBraces: Allman
+ColumnLimit: 120
+SortIncludes: false
+NamespaceIndentation: All
+---
+Language: ObjC
+IndentWidth: 2
+AlignAfterOpenBracket: Align
+BreakBeforeBraces: Allman
+ColumnLimit: 120
+SortIncludes: false
+NamespaceIndentation: All
+...

--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ BreakConstructorInitializers: BeforeComma
 BreakBeforeBraces: Allman
 ColumnLimit: 105 
 SortIncludes: false
-NamespaceIndentation: Inner
+NamespaceIndentation: None
 ReflowComments: false
 AllowShortFunctionsOnASingleLine: None
 ---
@@ -30,7 +30,7 @@ BreakConstructorInitializers: BeforeComma
 BreakBeforeBraces: Allman
 ColumnLimit: 105
 SortIncludes: false
-NamespaceIndentation: Inner
+NamespaceIndentation: None
 ReflowComments: false
 AllowShortFunctionsOnASingleLine: None
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -2,18 +2,22 @@
 UseTab: Never
 ---
 Language: Cpp
+BasedOnStyle: Google
 IndentWidth: 2
 AlignAfterOpenBracket: Align
 BreakBeforeBraces: Allman
-ColumnLimit: 120
+ColumnLimit: 250 
 SortIncludes: false
 NamespaceIndentation: All
+ReflowComments: false
 ---
 Language: ObjC
+BasedOnStyle: Google
 IndentWidth: 2
 AlignAfterOpenBracket: Align
 BreakBeforeBraces: Allman
-ColumnLimit: 120
+ColumnLimit: 250
 SortIncludes: false
 NamespaceIndentation: All
+ReflowComments: false
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -5,8 +5,10 @@ Language: Cpp
 BasedOnStyle: Google
 IndentWidth: 2
 AlignAfterOpenBracket: Align
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+BreakConstructorInitializers: BeforeComma
 BreakBeforeBraces: Allman
-ColumnLimit: 250 
+ColumnLimit: 105 
 SortIncludes: false
 NamespaceIndentation: All
 ReflowComments: false
@@ -16,8 +18,10 @@ Language: ObjC
 BasedOnStyle: Google
 IndentWidth: 2
 AlignAfterOpenBracket: Align
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+BreakConstructorInitializers: BeforeComma
 BreakBeforeBraces: Allman
-ColumnLimit: 250
+ColumnLimit: 105
 SortIncludes: false
 NamespaceIndentation: All
 ReflowComments: false

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -1,0 +1,21 @@
+name: Clap Wrapper Format and Code Checks
+on: [pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-code-checks:
+    name: code-checks
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Run Code Checks
+        run: |
+          cmake -Bbuild -DCLAP_WRAPPER_CODE_CHECKS_ONLY=TRUE
+          cmake --build build --target clap-wrapper-code-checks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,11 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 # defines functions relative to this, so needs a cache
 # variable with the source dir
 set(CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE STRING "Clap Wrapper Source Location")
-include(cmake/enable_sdks.cmake)
+if (DEFINED CLAP_WRAPPER_CODE_CHECKS_ONLY)
+	message(STATUS "clap-wrapper: code checks only; skipping enable sdks")
+else()
+	include(cmake/enable_sdks.cmake)
+endif()
 
 # automatically build the wrapper only if this is the top level project
 set(skipbuild FALSE)
@@ -63,6 +67,9 @@ if (NOT PROJECT_IS_TOP_LEVEL)
 	if(DEFINED CLAP_WRAPPER_DONT_ADD_TARGETS)
 		set(skipbuild TRUE)
 	endif()
+endif()
+if (DEFINED CLAP_WRAPPER_CODE_CHECKS_ONLY)
+	set(skipbuild ${CLAP_WRAPPER_CODE_CHECKS_ONLY})
 endif()
 
 if (${skipbuild})
@@ -106,3 +113,23 @@ else()
 		endif()
 	endif()
 endif()
+
+
+add_custom_target(clap-wrapper-code-checks)
+
+# Clang Format checks
+find_program(CLANG_FORMAT_EXE NAMES clang-format-12 clang-format)
+set(CLANG_FORMAT_DIRS src)
+set(CLANG_FORMAT_EXTS cpp h)
+foreach(dir ${CLANG_FORMAT_DIRS})
+	foreach(ext ${CLANG_FORMAT_EXTS})
+		list(APPEND CLANG_FORMAT_GLOBS "':(glob)${dir}/**/*.${ext}'")
+	endforeach()
+endforeach()
+add_custom_command(TARGET clap-wrapper-code-checks
+		POST_BUILD
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		COMMAND ${CMAKE_COMMAND} -E echo About to check clang-format using ${CLANG_FORMAT_EXE}
+		COMMAND git ls-files -- ${CLANG_FORMAT_GLOBS} | xargs ${CLANG_FORMAT_EXE} --dry-run --Werror
+		)
+# }}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ endif()
 add_custom_target(clap-wrapper-code-checks)
 
 # Clang Format checks
-find_program(CLANG_FORMAT_EXE NAMES clang-format-12 clang-format)
+find_program(CLANG_FORMAT_EXE NAMES clang-format)
 set(CLANG_FORMAT_DIRS src)
 set(CLANG_FORMAT_EXTS cpp h)
 foreach(dir ${CLANG_FORMAT_DIRS})

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -12,108 +12,107 @@ namespace Clap
 {
 namespace HostExt
 {
-  static Plugin* self(const clap_host_t* host)
-  {
-    return static_cast<Plugin*>(host->host_data);
-  }
+static Plugin* self(const clap_host_t* host)
+{
+  return static_cast<Plugin*>(host->host_data);
+}
 
-  void host_log(const clap_host_t* host, clap_log_severity severity, const char* msg)
-  {
-    self(host)->log(severity, msg);
-  }
+void host_log(const clap_host_t* host, clap_log_severity severity, const char* msg)
+{
+  self(host)->log(severity, msg);
+}
 
-  clap_host_log_t log = {host_log};
+clap_host_log_t log = {host_log};
 
-  void rescan(const clap_host_t* host, clap_param_rescan_flags flags)
-  {
-    self(host)->param_rescan(flags);
-  }
+void rescan(const clap_host_t* host, clap_param_rescan_flags flags)
+{
+  self(host)->param_rescan(flags);
+}
 
-  // Clears references to a parameter.
-  // [main-thread]
-  void clear(const clap_host_t* host, clap_id param_id, clap_param_clear_flags flags)
-  {
-  }
+// Clears references to a parameter.
+// [main-thread]
+void clear(const clap_host_t* host, clap_id param_id, clap_param_clear_flags flags)
+{
+}
 
-  // Request a parameter flush.
-  //
-  // If the plugin is processing, this will result in no action. The process call
-  // will run normally. If plugin isn't processing, the host will make a subsequent
-  // call to clap_plugin_params->flush(). As a result, this function is always
-  // safe to call from a non-audio thread (typically the UI thread on a gesture)
-  // whether processing is active or not.
-  //
-  // This must not be called on the [audio-thread].
-  // [thread-safe,!audio-thread]
-  void request_flush(const clap_host_t* host)
-  {
-    self(host)->param_request_flush();
-  }
-  clap_host_params_t params = {rescan, clear, request_flush};
+// Request a parameter flush.
+//
+// If the plugin is processing, this will result in no action. The process call
+// will run normally. If plugin isn't processing, the host will make a subsequent
+// call to clap_plugin_params->flush(). As a result, this function is always
+// safe to call from a non-audio thread (typically the UI thread on a gesture)
+// whether processing is active or not.
+//
+// This must not be called on the [audio-thread].
+// [thread-safe,!audio-thread]
+void request_flush(const clap_host_t* host)
+{
+  self(host)->param_request_flush();
+}
+clap_host_params_t params = {rescan, clear, request_flush};
 
-  bool is_main_thread(const clap_host_t* host)
-  {
-    return self(host)->is_main_thread();
-  }
+bool is_main_thread(const clap_host_t* host)
+{
+  return self(host)->is_main_thread();
+}
 
-  // Returns true if "this" thread is one of the audio threads.
-  // [thread-safe]
-  bool is_audio_thread(const clap_host_t* host)
-  {
-    return self(host)->is_audio_thread();
-  }
+// Returns true if "this" thread is one of the audio threads.
+// [thread-safe]
+bool is_audio_thread(const clap_host_t* host)
+{
+  return self(host)->is_audio_thread();
+}
 
-  clap_host_thread_check_t threadcheck = {is_main_thread, is_audio_thread};
+clap_host_thread_check_t threadcheck = {is_main_thread, is_audio_thread};
 
-  static void resize_hints_changed(const clap_host_t* host)
-  {
-    self(host)->resize_hints_changed();
-  }
-  static bool request_resize(const clap_host_t* host, uint32_t width, uint32_t height)
-  {
-    return self(host)->request_resize(width, height);
-  }
-  static bool request_show(const clap_host_t* host)
-  {
-    return self(host)->request_show();
-  }
-  static bool request_hide(const clap_host_t* host)
-  {
-    return self(host)->request_hide();
-  }
-  static void closed(const clap_host_t* host, bool was_destroyed)
-  {
-    self(host)->closed(was_destroyed);
-  }
+static void resize_hints_changed(const clap_host_t* host)
+{
+  self(host)->resize_hints_changed();
+}
+static bool request_resize(const clap_host_t* host, uint32_t width, uint32_t height)
+{
+  return self(host)->request_resize(width, height);
+}
+static bool request_show(const clap_host_t* host)
+{
+  return self(host)->request_show();
+}
+static bool request_hide(const clap_host_t* host)
+{
+  return self(host)->request_hide();
+}
+static void closed(const clap_host_t* host, bool was_destroyed)
+{
+  self(host)->closed(was_destroyed);
+}
 
-  const clap_host_gui hostgui = {resize_hints_changed, request_resize, request_show, request_hide,
-                                 closed};
+const clap_host_gui hostgui = {resize_hints_changed, request_resize, request_show, request_hide, closed};
 
-  const clap_host_timer_support hosttimer = {
-      /* register_timer */ [](const clap_host_t* host, uint32_t period_ms, clap_id* timer_id) -> bool
-      { return self(host)->register_timer(period_ms, timer_id); },
-      /* unregister_timer */
-      [](const clap_host_t* host, clap_id timer_id) -> bool
-      { return self(host)->unregister_timer(timer_id); }};
+const clap_host_timer_support hosttimer = {
+    /* register_timer */ [](const clap_host_t* host, uint32_t period_ms, clap_id* timer_id) -> bool
+    { return self(host)->register_timer(period_ms, timer_id); },
+    /* unregister_timer */
+    [](const clap_host_t* host, clap_id timer_id) -> bool
+    { return self(host)->unregister_timer(timer_id); }};
 
 #if LIN
-  const clap_host_posix_fd_support hostposixfd = {
-      [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
-      { return self(host)->register_fd(fd, flags); },
-      [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
-      { return self(host)->modify_fd(fd, flags); },
-      [](const clap_host_t* host, int fd) -> bool { return self(host)->unregister_fd(fd); }};
+const clap_host_posix_fd_support hostposixfd = {
+    [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
+    { return self(host)->register_fd(fd, flags); },
+    [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
+    { return self(host)->modify_fd(fd, flags); },
+    [](const clap_host_t* host, int fd) -> bool { return self(host)->unregister_fd(fd); }};
 #endif
 
-  const clap_host_latency latency = {[](const clap_host_t* host) -> void
-                                     { self(host)->latency_changed(); }};
+const clap_host_latency latency = {[](const clap_host_t* host) -> void
+                                   { self(host)->latency_changed(); }};
 
-  static void tail_changed(const clap_host_t* host)
-  {
-    self(host)->tail_changed();
-  }
+static void tail_changed(const clap_host_t* host)
+{
+  self(host)->tail_changed();
+}
 
-  const clap_host_tail tail = {tail_changed};
+const clap_host_tail tail = {tail_changed};
 
 }  // namespace HostExt
 

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -12,20 +12,17 @@ namespace Clap
 {
   namespace HostExt
   {
-    static Plugin *self(const clap_host_t *host) { return static_cast<Plugin *>(host->host_data); }
+    static Plugin* self(const clap_host_t* host) { return static_cast<Plugin*>(host->host_data); }
 
-    void host_log(const clap_host_t *host, clap_log_severity severity, const char *msg)
-    {
-      self(host)->log(severity, msg);
-    }
+    void host_log(const clap_host_t* host, clap_log_severity severity, const char* msg) { self(host)->log(severity, msg); }
 
     clap_host_log_t log = {host_log};
 
-    void rescan(const clap_host_t *host, clap_param_rescan_flags flags) { self(host)->param_rescan(flags); }
+    void rescan(const clap_host_t* host, clap_param_rescan_flags flags) { self(host)->param_rescan(flags); }
 
     // Clears references to a parameter.
     // [main-thread]
-    void clear(const clap_host_t *host, clap_id param_id, clap_param_clear_flags flags) {}
+    void clear(const clap_host_t* host, clap_id param_id, clap_param_clear_flags flags) {}
 
     // Request a parameter flush.
     //
@@ -37,58 +34,49 @@ namespace Clap
     //
     // This must not be called on the [audio-thread].
     // [thread-safe,!audio-thread]
-    void request_flush(const clap_host_t *host) { self(host)->param_request_flush(); }
+    void request_flush(const clap_host_t* host) { self(host)->param_request_flush(); }
     clap_host_params_t params = {rescan, clear, request_flush};
 
-    bool is_main_thread(const clap_host_t *host) { return self(host)->is_main_thread(); }
+    bool is_main_thread(const clap_host_t* host) { return self(host)->is_main_thread(); }
 
     // Returns true if "this" thread is one of the audio threads.
     // [thread-safe]
-    bool is_audio_thread(const clap_host_t *host) { return self(host)->is_audio_thread(); }
+    bool is_audio_thread(const clap_host_t* host) { return self(host)->is_audio_thread(); }
 
     clap_host_thread_check_t threadcheck = {is_main_thread, is_audio_thread};
 
-    static void resize_hints_changed(const clap_host_t *host) { self(host)->resize_hints_changed(); }
-    static bool request_resize(const clap_host_t *host, uint32_t width, uint32_t height)
-    {
-      return self(host)->request_resize(width, height);
-    }
-    static bool request_show(const clap_host_t *host) { return self(host)->request_show(); }
-    static bool request_hide(const clap_host_t *host) { return self(host)->request_hide(); }
-    static void closed(const clap_host_t *host, bool was_destroyed) { self(host)->closed(was_destroyed); }
+    static void resize_hints_changed(const clap_host_t* host) { self(host)->resize_hints_changed(); }
+    static bool request_resize(const clap_host_t* host, uint32_t width, uint32_t height) { return self(host)->request_resize(width, height); }
+    static bool request_show(const clap_host_t* host) { return self(host)->request_show(); }
+    static bool request_hide(const clap_host_t* host) { return self(host)->request_hide(); }
+    static void closed(const clap_host_t* host, bool was_destroyed) { self(host)->closed(was_destroyed); }
 
     const clap_host_gui hostgui = {resize_hints_changed, request_resize, request_show, request_hide, closed};
 
     const clap_host_timer_support hosttimer = {
-        /* register_timer */ [](const clap_host_t *host, uint32_t period_ms, clap_id *timer_id) -> bool
-        { return self(host)->register_timer(period_ms, timer_id); },
-        /* unregister_timer */
-        [](const clap_host_t *host, clap_id timer_id) -> bool { return self(host)->unregister_timer(timer_id); }};
+        /* register_timer */ [](const clap_host_t* host, uint32_t period_ms, clap_id* timer_id) -> bool { return self(host)->register_timer(period_ms, timer_id); },
+        /* unregister_timer */ [](const clap_host_t* host, clap_id timer_id) -> bool { return self(host)->unregister_timer(timer_id); }};
 
 #if LIN
-    const clap_host_posix_fd_support hostposixfd = {
-        [](const clap_host_t *host, int fd, clap_posix_fd_flags_t flags) -> bool
-        { return self(host)->register_fd(fd, flags); },
-        [](const clap_host_t *host, int fd, clap_posix_fd_flags_t flags) -> bool
-        { return self(host)->modify_fd(fd, flags); },
-        [](const clap_host_t *host, int fd) -> bool { return self(host)->unregister_fd(fd); }};
+    const clap_host_posix_fd_support hostposixfd = {[](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool { return self(host)->register_fd(fd, flags); },
+                                                    [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool { return self(host)->modify_fd(fd, flags); },
+                                                    [](const clap_host_t* host, int fd) -> bool { return self(host)->unregister_fd(fd); }};
 #endif
 
-    const clap_host_latency latency = {[](const clap_host_t *host) -> void { self(host)->latency_changed(); }};
+    const clap_host_latency latency = {[](const clap_host_t* host) -> void { self(host)->latency_changed(); }};
 
-    static void tail_changed(const clap_host_t *host) { self(host)->tail_changed(); }
+    static void tail_changed(const clap_host_t* host) { self(host)->tail_changed(); }
 
     const clap_host_tail tail = {tail_changed};
 
-  } // namespace HostExt
+  }  // namespace HostExt
 
-  std::shared_ptr<Plugin> Plugin::createInstance(Clap::Library &library, size_t index, IHost *host)
+  std::shared_ptr<Plugin> Plugin::createInstance(Clap::Library& library, size_t index, IHost* host)
   {
     if (library.plugins.size() > index)
     {
       auto plug = std::shared_ptr<Plugin>(new Plugin(host));
-      auto instance = library._pluginFactory->create_plugin(library._pluginFactory, plug->getClapHostInterface(),
-                                                            library.plugins[index]->id);
+      auto instance = library._pluginFactory->create_plugin(library._pluginFactory, plug->getClapHostInterface(), library.plugins[index]->id);
       plug->connectClap(instance);
 
       return plug;
@@ -96,27 +84,18 @@ namespace Clap
     return nullptr;
   }
 
-  Plugin::Plugin(IHost *host)
-      : _host{CLAP_VERSION,
-              this,
-              "Clap-As-VST3-Wrapper",
-              "defiant nerd",
-              "https://www.defiantnerd.com",
-              "0.0.1",
-              Plugin::clapExtension,
-              Plugin::clapRequestRestart,
-              Plugin::clapRequestProcess,
-              Plugin::clapRequestCallback},
-        _parentHost(host)
+  Plugin::Plugin(IHost* host)
+      : _host{CLAP_VERSION, this, "Clap-As-VST3-Wrapper", "defiant nerd", "https://www.defiantnerd.com", "0.0.1", Plugin::clapExtension, Plugin::clapRequestRestart, Plugin::clapRequestProcess, Plugin::clapRequestCallback}, _parentHost(host)
   {
   }
 
-  template <typename T> void getExtension(const clap_plugin_t *plugin, T &ref, const char *name)
+  template <typename T>
+  void getExtension(const clap_plugin_t* plugin, T& ref, const char* name)
   {
     ref = static_cast<T>(plugin->get_extension(plugin, name));
   }
 
-  void Plugin::connectClap(const clap_plugin_t *clap)
+  void Plugin::connectClap(const clap_plugin_t* clap)
   {
     _plugin = clap;
 
@@ -145,7 +124,7 @@ namespace Clap
 
     if (_ext._gui)
     {
-      const char *api;
+      const char* api;
 #if WIN
       api = CLAP_WINDOW_API_WIN32;
 #endif
@@ -209,7 +188,7 @@ namespace Clap
     _audioSetup.maxFrames = maxFrames;
   }
 
-  bool Plugin::load(const clap_istream_t *stream)
+  bool Plugin::load(const clap_istream_t* stream)
   {
     if (_ext._state)
     {
@@ -218,7 +197,7 @@ namespace Clap
     return false;
   }
 
-  bool Plugin::save(const clap_ostream_t *stream)
+  bool Plugin::save(const clap_ostream_t* stream)
   {
     if (_ext._state)
     {
@@ -227,10 +206,7 @@ namespace Clap
     return false;
   }
 
-  bool Plugin::activate()
-  {
-    return _plugin->activate(_plugin, _audioSetup.sampleRate, _audioSetup.minFrames, _audioSetup.maxFrames);
-  }
+  bool Plugin::activate() { return _plugin->activate(_plugin, _audioSetup.sampleRate, _audioSetup.minFrames, _audioSetup.maxFrames); }
 
   void Plugin::deactivate() { _plugin->deactivate(_plugin); }
 
@@ -246,13 +222,13 @@ namespace Clap
     _plugin->stop_processing(_plugin);
   }
 
-  // void Plugin::process(const clap_process_t* data)
+  //void Plugin::process(const clap_process_t* data)
   //{
-  //   auto thisFn = AlwaysAudioThread();
-  //   _plugin->process(_plugin, data);
-  // }
+  //  auto thisFn = AlwaysAudioThread();
+  //  _plugin->process(_plugin, data);
+  //}
 
-  const clap_plugin_gui_t *Plugin::getUI()
+  const clap_plugin_gui_t* Plugin::getUI()
   {
     if (_ext._gui)
     {
@@ -268,39 +244,39 @@ namespace Clap
 
   void Plugin::tail_changed() { _parentHost->tail_changed(); }
 
-  void Plugin::log(clap_log_severity severity, const char *msg)
+  void Plugin::log(clap_log_severity severity, const char* msg)
   {
     std::string n;
     switch (severity)
     {
-    case CLAP_LOG_DEBUG:
-      n.append("PLUGIN: DEBUG: ");
-      break;
-    case CLAP_LOG_INFO:
-      n.append("PLUGIN: INFO: ");
-      break;
-    case CLAP_LOG_WARNING:
-      n.append("PLUGIN: WARNING: ");
-      break;
-    case CLAP_LOG_ERROR:
-      n.append("PLUGIN: ERROR: ");
-      break;
-    case CLAP_LOG_FATAL:
-      n.append("PLUGIN: FATAL: ");
-      break;
-    case CLAP_LOG_PLUGIN_MISBEHAVING:
-      n.append("PLUGIN: MISBEHAVING: ");
-      break;
-    case CLAP_LOG_HOST_MISBEHAVING:
-      n.append("PLUGIN: HOST MISBEHAVING: ");
+      case CLAP_LOG_DEBUG:
+        n.append("PLUGIN: DEBUG: ");
+        break;
+      case CLAP_LOG_INFO:
+        n.append("PLUGIN: INFO: ");
+        break;
+      case CLAP_LOG_WARNING:
+        n.append("PLUGIN: WARNING: ");
+        break;
+      case CLAP_LOG_ERROR:
+        n.append("PLUGIN: ERROR: ");
+        break;
+      case CLAP_LOG_FATAL:
+        n.append("PLUGIN: FATAL: ");
+        break;
+      case CLAP_LOG_PLUGIN_MISBEHAVING:
+        n.append("PLUGIN: MISBEHAVING: ");
+        break;
+      case CLAP_LOG_HOST_MISBEHAVING:
+        n.append("PLUGIN: HOST MISBEHAVING: ");
 #if WIN32
-      OutputDebugStringA(msg);
-      _CrtDbgBreak();
+        OutputDebugStringA(msg);
+        _CrtDbgBreak();
 #endif
 #if MAC
-      fprintf(stderr, "%s\n", msg);
+        fprintf(stderr, "%s\n", msg);
 #endif
-      break;
+        break;
     }
     n.append(msg);
 #if WIN32
@@ -332,24 +308,17 @@ namespace Clap
 
   // Query an extension.
   // [thread-safe]
-  const void *Plugin::clapExtension(const clap_host *host, const char *extension)
+  const void* Plugin::clapExtension(const clap_host* host, const char* extension)
   {
-    if (!strcmp(extension, CLAP_EXT_LOG))
-      return &HostExt::log;
-    if (!strcmp(extension, CLAP_EXT_PARAMS))
-      return &HostExt::params;
-    if (!strcmp(extension, CLAP_EXT_THREAD_CHECK))
-      return &HostExt::threadcheck;
-    if (!strcmp(extension, CLAP_EXT_GUI))
-      return &HostExt::hostgui;
-    if (!strcmp(extension, CLAP_EXT_TIMER_SUPPORT))
-      return &HostExt::hosttimer;
+    if (!strcmp(extension, CLAP_EXT_LOG)) return &HostExt::log;
+    if (!strcmp(extension, CLAP_EXT_PARAMS)) return &HostExt::params;
+    if (!strcmp(extension, CLAP_EXT_THREAD_CHECK)) return &HostExt::threadcheck;
+    if (!strcmp(extension, CLAP_EXT_GUI)) return &HostExt::hostgui;
+    if (!strcmp(extension, CLAP_EXT_TIMER_SUPPORT)) return &HostExt::hosttimer;
 #if LIN
-    if (!strcmp(extension, CLAP_EXT_POSIX_FD_SUPPORT))
-      return &HostExt::hostposixfd;
+    if (!strcmp(extension, CLAP_EXT_POSIX_FD_SUPPORT)) return &HostExt::hostposixfd;
 #endif
-    if (!strcmp(extension, CLAP_EXT_LATENCY))
-      return &HostExt::latency;
+    if (!strcmp(extension, CLAP_EXT_LATENCY)) return &HostExt::latency;
     if (!strcmp(extension, CLAP_EXT_TAIL))
     {
       return &HostExt::tail;
@@ -364,25 +333,25 @@ namespace Clap
 
   // Request the host to schedule a call to plugin->on_main_thread(plugin) on the main thread.
   // [thread-safe]
-  void Plugin::clapRequestCallback(const clap_host *host)
+  void Plugin::clapRequestCallback(const clap_host* host)
   {
-    auto self = static_cast<Plugin *>(host->host_data);
+    auto self = static_cast<Plugin*>(host->host_data);
     self->_parentHost->request_callback();
   }
 
   // Request the host to deactivate and then reactivate the plugin.
   // The operation may be delayed by the host.
   // [thread-safe]
-  void Plugin::clapRequestRestart(const clap_host *host)
+  void Plugin::clapRequestRestart(const clap_host* host)
   {
-    auto self = static_cast<Plugin *>(host->host_data);
+    auto self = static_cast<Plugin*>(host->host_data);
     self->_parentHost->restartPlugin();
   }
 
   // Request the host to activate and start processing the plugin.
   // This is useful if you have external IO and need to wake up the plugin from "sleep".
   // [thread-safe]
-  void Plugin::clapRequestProcess(const clap_host *host)
+  void Plugin::clapRequestProcess(const clap_host* host)
   {
     // right now, I don't know how to communicate this to the host
     // in VST3 you can't force processing...
@@ -392,10 +361,7 @@ namespace Clap
   // The host may adjust the period if it is under a certain threshold.
   // 30 Hz should be allowed.
   // [main-thread]
-  bool Plugin::register_timer(uint32_t period_ms, clap_id *timer_id)
-  {
-    return _parentHost->register_timer(period_ms, timer_id);
-  }
+  bool Plugin::register_timer(uint32_t period_ms, clap_id* timer_id) { return _parentHost->register_timer(period_ms, timer_id); }
   bool Plugin::unregister_timer(clap_id timer_id) { return _parentHost->unregister_timer(timer_id); }
 
 #if LIN
@@ -403,4 +369,4 @@ namespace Clap
   bool Plugin::modify_fd(int fd, clap_posix_fd_flags_t flags) { return _parentHost->modify_fd(fd, flags); }
   bool Plugin::unregister_fd(int fd) { return _parentHost->unregister_fd(fd); }
 #endif
-} // namespace Clap
+}  // namespace Clap

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -10,468 +10,468 @@
 
 namespace Clap
 {
-  namespace HostExt
+namespace HostExt
+{
+  static Plugin* self(const clap_host_t* host)
   {
-    static Plugin* self(const clap_host_t* host)
-    {
-      return static_cast<Plugin*>(host->host_data);
-    }
+    return static_cast<Plugin*>(host->host_data);
+  }
 
-    void host_log(const clap_host_t* host, clap_log_severity severity, const char* msg)
-    {
-      self(host)->log(severity, msg);
-    }
+  void host_log(const clap_host_t* host, clap_log_severity severity, const char* msg)
+  {
+    self(host)->log(severity, msg);
+  }
 
-    clap_host_log_t log = {host_log};
+  clap_host_log_t log = {host_log};
 
-    void rescan(const clap_host_t* host, clap_param_rescan_flags flags)
-    {
-      self(host)->param_rescan(flags);
-    }
+  void rescan(const clap_host_t* host, clap_param_rescan_flags flags)
+  {
+    self(host)->param_rescan(flags);
+  }
 
-    // Clears references to a parameter.
-    // [main-thread]
-    void clear(const clap_host_t* host, clap_id param_id, clap_param_clear_flags flags)
-    {
-    }
+  // Clears references to a parameter.
+  // [main-thread]
+  void clear(const clap_host_t* host, clap_id param_id, clap_param_clear_flags flags)
+  {
+  }
 
-    // Request a parameter flush.
-    //
-    // If the plugin is processing, this will result in no action. The process call
-    // will run normally. If plugin isn't processing, the host will make a subsequent
-    // call to clap_plugin_params->flush(). As a result, this function is always
-    // safe to call from a non-audio thread (typically the UI thread on a gesture)
-    // whether processing is active or not.
-    //
-    // This must not be called on the [audio-thread].
-    // [thread-safe,!audio-thread]
-    void request_flush(const clap_host_t* host)
-    {
-      self(host)->param_request_flush();
-    }
-    clap_host_params_t params = {rescan, clear, request_flush};
+  // Request a parameter flush.
+  //
+  // If the plugin is processing, this will result in no action. The process call
+  // will run normally. If plugin isn't processing, the host will make a subsequent
+  // call to clap_plugin_params->flush(). As a result, this function is always
+  // safe to call from a non-audio thread (typically the UI thread on a gesture)
+  // whether processing is active or not.
+  //
+  // This must not be called on the [audio-thread].
+  // [thread-safe,!audio-thread]
+  void request_flush(const clap_host_t* host)
+  {
+    self(host)->param_request_flush();
+  }
+  clap_host_params_t params = {rescan, clear, request_flush};
 
-    bool is_main_thread(const clap_host_t* host)
-    {
-      return self(host)->is_main_thread();
-    }
+  bool is_main_thread(const clap_host_t* host)
+  {
+    return self(host)->is_main_thread();
+  }
 
-    // Returns true if "this" thread is one of the audio threads.
-    // [thread-safe]
-    bool is_audio_thread(const clap_host_t* host)
-    {
-      return self(host)->is_audio_thread();
-    }
+  // Returns true if "this" thread is one of the audio threads.
+  // [thread-safe]
+  bool is_audio_thread(const clap_host_t* host)
+  {
+    return self(host)->is_audio_thread();
+  }
 
-    clap_host_thread_check_t threadcheck = {is_main_thread, is_audio_thread};
+  clap_host_thread_check_t threadcheck = {is_main_thread, is_audio_thread};
 
-    static void resize_hints_changed(const clap_host_t* host)
-    {
-      self(host)->resize_hints_changed();
-    }
-    static bool request_resize(const clap_host_t* host, uint32_t width, uint32_t height)
-    {
-      return self(host)->request_resize(width, height);
-    }
-    static bool request_show(const clap_host_t* host)
-    {
-      return self(host)->request_show();
-    }
-    static bool request_hide(const clap_host_t* host)
-    {
-      return self(host)->request_hide();
-    }
-    static void closed(const clap_host_t* host, bool was_destroyed)
-    {
-      self(host)->closed(was_destroyed);
-    }
+  static void resize_hints_changed(const clap_host_t* host)
+  {
+    self(host)->resize_hints_changed();
+  }
+  static bool request_resize(const clap_host_t* host, uint32_t width, uint32_t height)
+  {
+    return self(host)->request_resize(width, height);
+  }
+  static bool request_show(const clap_host_t* host)
+  {
+    return self(host)->request_show();
+  }
+  static bool request_hide(const clap_host_t* host)
+  {
+    return self(host)->request_hide();
+  }
+  static void closed(const clap_host_t* host, bool was_destroyed)
+  {
+    self(host)->closed(was_destroyed);
+  }
 
-    const clap_host_gui hostgui = {resize_hints_changed, request_resize, request_show, request_hide,
-                                   closed};
+  const clap_host_gui hostgui = {resize_hints_changed, request_resize, request_show, request_hide,
+                                 closed};
 
-    const clap_host_timer_support hosttimer = {
-        /* register_timer */ [](const clap_host_t* host, uint32_t period_ms, clap_id* timer_id) -> bool
-        { return self(host)->register_timer(period_ms, timer_id); },
-        /* unregister_timer */
-        [](const clap_host_t* host, clap_id timer_id) -> bool
-        { return self(host)->unregister_timer(timer_id); }};
+  const clap_host_timer_support hosttimer = {
+      /* register_timer */ [](const clap_host_t* host, uint32_t period_ms, clap_id* timer_id) -> bool
+      { return self(host)->register_timer(period_ms, timer_id); },
+      /* unregister_timer */
+      [](const clap_host_t* host, clap_id timer_id) -> bool
+      { return self(host)->unregister_timer(timer_id); }};
 
 #if LIN
-    const clap_host_posix_fd_support hostposixfd = {
-        [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
-        { return self(host)->register_fd(fd, flags); },
-        [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
-        { return self(host)->modify_fd(fd, flags); },
-        [](const clap_host_t* host, int fd) -> bool { return self(host)->unregister_fd(fd); }};
+  const clap_host_posix_fd_support hostposixfd = {
+      [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
+      { return self(host)->register_fd(fd, flags); },
+      [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
+      { return self(host)->modify_fd(fd, flags); },
+      [](const clap_host_t* host, int fd) -> bool { return self(host)->unregister_fd(fd); }};
 #endif
 
-    const clap_host_latency latency = {[](const clap_host_t* host) -> void
-                                       { self(host)->latency_changed(); }};
+  const clap_host_latency latency = {[](const clap_host_t* host) -> void
+                                     { self(host)->latency_changed(); }};
 
-    static void tail_changed(const clap_host_t* host)
-    {
-      self(host)->tail_changed();
-    }
-
-    const clap_host_tail tail = {tail_changed};
-
-  }  // namespace HostExt
-
-  std::shared_ptr<Plugin> Plugin::createInstance(Clap::Library& library, size_t index, IHost* host)
+  static void tail_changed(const clap_host_t* host)
   {
-    if (library.plugins.size() > index)
-    {
-      auto plug = std::shared_ptr<Plugin>(new Plugin(host));
-      auto instance = library._pluginFactory->create_plugin(
-          library._pluginFactory, plug->getClapHostInterface(), library.plugins[index]->id);
-      plug->connectClap(instance);
-
-      return plug;
-    }
-    return nullptr;
+    self(host)->tail_changed();
   }
 
-  Plugin::Plugin(IHost* host)
-    : _host{CLAP_VERSION,
-            this,
-            "Clap-As-VST3-Wrapper",
-            "defiant nerd",
-            "https://www.defiantnerd.com",
-            "0.0.1",
-            Plugin::clapExtension,
-            Plugin::clapRequestRestart,
-            Plugin::clapRequestProcess,
-            Plugin::clapRequestCallback}
-    , _parentHost(host)
+  const clap_host_tail tail = {tail_changed};
+
+}  // namespace HostExt
+
+std::shared_ptr<Plugin> Plugin::createInstance(Clap::Library& library, size_t index, IHost* host)
+{
+  if (library.plugins.size() > index)
   {
+    auto plug = std::shared_ptr<Plugin>(new Plugin(host));
+    auto instance = library._pluginFactory->create_plugin(
+        library._pluginFactory, plug->getClapHostInterface(), library.plugins[index]->id);
+    plug->connectClap(instance);
+
+    return plug;
+  }
+  return nullptr;
+}
+
+Plugin::Plugin(IHost* host)
+  : _host{CLAP_VERSION,
+          this,
+          "Clap-As-VST3-Wrapper",
+          "defiant nerd",
+          "https://www.defiantnerd.com",
+          "0.0.1",
+          Plugin::clapExtension,
+          Plugin::clapRequestRestart,
+          Plugin::clapRequestProcess,
+          Plugin::clapRequestCallback}
+  , _parentHost(host)
+{
+}
+
+template <typename T>
+void getExtension(const clap_plugin_t* plugin, T& ref, const char* name)
+{
+  ref = static_cast<T>(plugin->get_extension(plugin, name));
+}
+
+void Plugin::connectClap(const clap_plugin_t* clap)
+{
+  _plugin = clap;
+
+  // initialize the plugin
+  if (!_plugin->init(_plugin))
+  {
+    _plugin->destroy(_plugin);
+    _plugin = nullptr;
+    return;
   }
 
-  template <typename T>
-  void getExtension(const clap_plugin_t* plugin, T& ref, const char* name)
-  {
-    ref = static_cast<T>(plugin->get_extension(plugin, name));
-  }
-
-  void Plugin::connectClap(const clap_plugin_t* clap)
-  {
-    _plugin = clap;
-
-    // initialize the plugin
-    if (!_plugin->init(_plugin))
-    {
-      _plugin->destroy(_plugin);
-      _plugin = nullptr;
-      return;
-    }
-
-    // if successful, query the extensions the wrapper might want to use
-    getExtension(_plugin, _ext._state, CLAP_EXT_STATE);
-    getExtension(_plugin, _ext._params, CLAP_EXT_PARAMS);
-    getExtension(_plugin, _ext._audioports, CLAP_EXT_AUDIO_PORTS);
-    getExtension(_plugin, _ext._noteports, CLAP_EXT_NOTE_PORTS);
-    getExtension(_plugin, _ext._midimap, CLAP_EXT_MIDI_MAPPINGS);
-    getExtension(_plugin, _ext._latency, CLAP_EXT_LATENCY);
-    getExtension(_plugin, _ext._render, CLAP_EXT_RENDER);
-    getExtension(_plugin, _ext._tail, CLAP_EXT_TAIL);
-    getExtension(_plugin, _ext._gui, CLAP_EXT_GUI);
-    getExtension(_plugin, _ext._timer, CLAP_EXT_TIMER_SUPPORT);
+  // if successful, query the extensions the wrapper might want to use
+  getExtension(_plugin, _ext._state, CLAP_EXT_STATE);
+  getExtension(_plugin, _ext._params, CLAP_EXT_PARAMS);
+  getExtension(_plugin, _ext._audioports, CLAP_EXT_AUDIO_PORTS);
+  getExtension(_plugin, _ext._noteports, CLAP_EXT_NOTE_PORTS);
+  getExtension(_plugin, _ext._midimap, CLAP_EXT_MIDI_MAPPINGS);
+  getExtension(_plugin, _ext._latency, CLAP_EXT_LATENCY);
+  getExtension(_plugin, _ext._render, CLAP_EXT_RENDER);
+  getExtension(_plugin, _ext._tail, CLAP_EXT_TAIL);
+  getExtension(_plugin, _ext._gui, CLAP_EXT_GUI);
+  getExtension(_plugin, _ext._timer, CLAP_EXT_TIMER_SUPPORT);
 #if LIN
-    getExtension(_plugin, _ext._posixfd, CLAP_EXT_POSIX_FD_SUPPORT);
+  getExtension(_plugin, _ext._posixfd, CLAP_EXT_POSIX_FD_SUPPORT);
 #endif
 
-    if (_ext._gui)
-    {
-      const char* api;
+  if (_ext._gui)
+  {
+    const char* api;
 #if WIN
-      api = CLAP_WINDOW_API_WIN32;
+    api = CLAP_WINDOW_API_WIN32;
 #endif
 #if MAC
-      api = CLAP_WINDOW_API_COCOA;
+    api = CLAP_WINDOW_API_COCOA;
 #endif
 #if LIN
-      api = CLAP_WINDOW_API_X11;
+    api = CLAP_WINDOW_API_X11;
 #endif
 
-      if (!_ext._gui->is_api_supported(_plugin, api, false))
-      {
-        // disable GUI if not win32
-        _ext._gui = nullptr;
-      }
+    if (!_ext._gui->is_api_supported(_plugin, api, false))
+    {
+      // disable GUI if not win32
+      _ext._gui = nullptr;
     }
   }
+}
 
-  Plugin::~Plugin()
-  {
-    if (_plugin)
-    {
-      _plugin->destroy(_plugin);
-      _plugin = nullptr;
-    }
-  }
-
-  void Plugin::schnick()
-  {
-  }
-
-  bool Plugin::initialize()
-  {
-    fprintf(stderr, "Plugin Initialize\n");
-    if (_ext._audioports)
-    {
-      _parentHost->setupAudioBusses(_plugin, _ext._audioports);
-    }
-    if (_ext._noteports)
-    {
-      _parentHost->setupMIDIBusses(_plugin, _ext._noteports);
-    }
-    if (_ext._params)
-    {
-      _parentHost->setupParameters(_plugin, _ext._params);
-    }
-
-    _parentHost->setupWrapperSpecifics(_plugin);
-    return true;
-  }
-
-  void Plugin::terminate()
+Plugin::~Plugin()
+{
+  if (_plugin)
   {
     _plugin->destroy(_plugin);
     _plugin = nullptr;
   }
+}
 
-  void Plugin::setSampleRate(double sampleRate)
+void Plugin::schnick()
+{
+}
+
+bool Plugin::initialize()
+{
+  fprintf(stderr, "Plugin Initialize\n");
+  if (_ext._audioports)
   {
-    _audioSetup.sampleRate = sampleRate;
+    _parentHost->setupAudioBusses(_plugin, _ext._audioports);
+  }
+  if (_ext._noteports)
+  {
+    _parentHost->setupMIDIBusses(_plugin, _ext._noteports);
+  }
+  if (_ext._params)
+  {
+    _parentHost->setupParameters(_plugin, _ext._params);
   }
 
-  void Plugin::setBlockSizes(uint32_t minFrames, uint32_t maxFrames)
-  {
-    _audioSetup.minFrames = minFrames;
-    _audioSetup.maxFrames = maxFrames;
-  }
+  _parentHost->setupWrapperSpecifics(_plugin);
+  return true;
+}
 
-  bool Plugin::load(const clap_istream_t* stream)
+void Plugin::terminate()
+{
+  _plugin->destroy(_plugin);
+  _plugin = nullptr;
+}
+
+void Plugin::setSampleRate(double sampleRate)
+{
+  _audioSetup.sampleRate = sampleRate;
+}
+
+void Plugin::setBlockSizes(uint32_t minFrames, uint32_t maxFrames)
+{
+  _audioSetup.minFrames = minFrames;
+  _audioSetup.maxFrames = maxFrames;
+}
+
+bool Plugin::load(const clap_istream_t* stream)
+{
+  if (_ext._state)
   {
-    if (_ext._state)
+    return _ext._state->load(_plugin, stream);
+  }
+  return false;
+}
+
+bool Plugin::save(const clap_ostream_t* stream)
+{
+  if (_ext._state)
+  {
+    return _ext._state->save(_plugin, stream);
+  }
+  return false;
+}
+
+bool Plugin::activate()
+{
+  return _plugin->activate(_plugin, _audioSetup.sampleRate, _audioSetup.minFrames,
+                           _audioSetup.maxFrames);
+}
+
+void Plugin::deactivate()
+{
+  _plugin->deactivate(_plugin);
+}
+
+bool Plugin::start_processing()
+{
+  auto thisFn = AlwaysAudioThread();
+  return _plugin->start_processing(_plugin);
+}
+
+void Plugin::stop_processing()
+{
+  auto thisFn = AlwaysAudioThread();
+  _plugin->stop_processing(_plugin);
+}
+
+//void Plugin::process(const clap_process_t* data)
+//{
+//  auto thisFn = AlwaysAudioThread();
+//  _plugin->process(_plugin, data);
+//}
+
+const clap_plugin_gui_t* Plugin::getUI()
+{
+  if (_ext._gui)
+  {
+    if (_ext._gui->is_api_supported(_plugin, CLAP_WINDOW_API_WIN32, false))
     {
-      return _ext._state->load(_plugin, stream);
+      // _ext._g
     }
-    return false;
   }
+  return nullptr;
+}
 
-  bool Plugin::save(const clap_ostream_t* stream)
+void Plugin::latency_changed()
+{
+  _parentHost->latency_changed();
+}
+
+void Plugin::tail_changed()
+{
+  _parentHost->tail_changed();
+}
+
+void Plugin::log(clap_log_severity severity, const char* msg)
+{
+  std::string n;
+  switch (severity)
   {
-    if (_ext._state)
-    {
-      return _ext._state->save(_plugin, stream);
-    }
-    return false;
-  }
-
-  bool Plugin::activate()
-  {
-    return _plugin->activate(_plugin, _audioSetup.sampleRate, _audioSetup.minFrames,
-                             _audioSetup.maxFrames);
-  }
-
-  void Plugin::deactivate()
-  {
-    _plugin->deactivate(_plugin);
-  }
-
-  bool Plugin::start_processing()
-  {
-    auto thisFn = AlwaysAudioThread();
-    return _plugin->start_processing(_plugin);
-  }
-
-  void Plugin::stop_processing()
-  {
-    auto thisFn = AlwaysAudioThread();
-    _plugin->stop_processing(_plugin);
-  }
-
-  //void Plugin::process(const clap_process_t* data)
-  //{
-  //  auto thisFn = AlwaysAudioThread();
-  //  _plugin->process(_plugin, data);
-  //}
-
-  const clap_plugin_gui_t* Plugin::getUI()
-  {
-    if (_ext._gui)
-    {
-      if (_ext._gui->is_api_supported(_plugin, CLAP_WINDOW_API_WIN32, false))
-      {
-        // _ext._g
-      }
-    }
-    return nullptr;
-  }
-
-  void Plugin::latency_changed()
-  {
-    _parentHost->latency_changed();
-  }
-
-  void Plugin::tail_changed()
-  {
-    _parentHost->tail_changed();
-  }
-
-  void Plugin::log(clap_log_severity severity, const char* msg)
-  {
-    std::string n;
-    switch (severity)
-    {
-      case CLAP_LOG_DEBUG:
-        n.append("PLUGIN: DEBUG: ");
-        break;
-      case CLAP_LOG_INFO:
-        n.append("PLUGIN: INFO: ");
-        break;
-      case CLAP_LOG_WARNING:
-        n.append("PLUGIN: WARNING: ");
-        break;
-      case CLAP_LOG_ERROR:
-        n.append("PLUGIN: ERROR: ");
-        break;
-      case CLAP_LOG_FATAL:
-        n.append("PLUGIN: FATAL: ");
-        break;
-      case CLAP_LOG_PLUGIN_MISBEHAVING:
-        n.append("PLUGIN: MISBEHAVING: ");
-        break;
-      case CLAP_LOG_HOST_MISBEHAVING:
-        n.append("PLUGIN: HOST MISBEHAVING: ");
+    case CLAP_LOG_DEBUG:
+      n.append("PLUGIN: DEBUG: ");
+      break;
+    case CLAP_LOG_INFO:
+      n.append("PLUGIN: INFO: ");
+      break;
+    case CLAP_LOG_WARNING:
+      n.append("PLUGIN: WARNING: ");
+      break;
+    case CLAP_LOG_ERROR:
+      n.append("PLUGIN: ERROR: ");
+      break;
+    case CLAP_LOG_FATAL:
+      n.append("PLUGIN: FATAL: ");
+      break;
+    case CLAP_LOG_PLUGIN_MISBEHAVING:
+      n.append("PLUGIN: MISBEHAVING: ");
+      break;
+    case CLAP_LOG_HOST_MISBEHAVING:
+      n.append("PLUGIN: HOST MISBEHAVING: ");
 #if WIN32
-        OutputDebugStringA(msg);
-        _CrtDbgBreak();
+      OutputDebugStringA(msg);
+      _CrtDbgBreak();
 #endif
 #if MAC
-        fprintf(stderr, "%s\n", msg);
+      fprintf(stderr, "%s\n", msg);
 #endif
-        break;
-    }
-    n.append(msg);
+      break;
+  }
+  n.append(msg);
 #if WIN32
-    OutputDebugStringA(n.c_str());
-    OutputDebugStringA("\n");
+  OutputDebugStringA(n.c_str());
+  OutputDebugStringA("\n");
 #endif
 #if MAC
-    fprintf(stderr, "%s\n", n.c_str());
+  fprintf(stderr, "%s\n", n.c_str());
 #endif
-  }
+}
 
-  bool Plugin::is_main_thread() const
-  {
-    return _main_thread_id == std::this_thread::get_id();
-  }
+bool Plugin::is_main_thread() const
+{
+  return _main_thread_id == std::this_thread::get_id();
+}
 
-  bool Plugin::is_audio_thread() const
+bool Plugin::is_audio_thread() const
+{
+  if (this->_audio_thread_override > 0)
   {
-    if (this->_audio_thread_override > 0)
-    {
-      return true;
-    }
-    return !is_main_thread();
+    return true;
   }
+  return !is_main_thread();
+}
 
-  CLAP_NODISCARD Raise Plugin::AlwaysAudioThread()
-  {
-    return Raise(this->_audio_thread_override);
-  }
+CLAP_NODISCARD Raise Plugin::AlwaysAudioThread()
+{
+  return Raise(this->_audio_thread_override);
+}
 
-  void Plugin::param_rescan(clap_param_rescan_flags flags)
-  {
-    _parentHost->param_rescan(flags);
-  }
+void Plugin::param_rescan(clap_param_rescan_flags flags)
+{
+  _parentHost->param_rescan(flags);
+}
 
-  void Plugin::param_clear(clap_id param, clap_param_clear_flags flags)
-  {
-    _parentHost->param_clear(param, flags);
-  }
-  void Plugin::param_request_flush()
-  {
-    _parentHost->param_request_flush();
-  }
+void Plugin::param_clear(clap_id param, clap_param_clear_flags flags)
+{
+  _parentHost->param_clear(param, flags);
+}
+void Plugin::param_request_flush()
+{
+  _parentHost->param_request_flush();
+}
 
-  // Query an extension.
-  // [thread-safe]
-  const void* Plugin::clapExtension(const clap_host* host, const char* extension)
-  {
-    if (!strcmp(extension, CLAP_EXT_LOG)) return &HostExt::log;
-    if (!strcmp(extension, CLAP_EXT_PARAMS)) return &HostExt::params;
-    if (!strcmp(extension, CLAP_EXT_THREAD_CHECK)) return &HostExt::threadcheck;
-    if (!strcmp(extension, CLAP_EXT_GUI)) return &HostExt::hostgui;
-    if (!strcmp(extension, CLAP_EXT_TIMER_SUPPORT)) return &HostExt::hosttimer;
+// Query an extension.
+// [thread-safe]
+const void* Plugin::clapExtension(const clap_host* host, const char* extension)
+{
+  if (!strcmp(extension, CLAP_EXT_LOG)) return &HostExt::log;
+  if (!strcmp(extension, CLAP_EXT_PARAMS)) return &HostExt::params;
+  if (!strcmp(extension, CLAP_EXT_THREAD_CHECK)) return &HostExt::threadcheck;
+  if (!strcmp(extension, CLAP_EXT_GUI)) return &HostExt::hostgui;
+  if (!strcmp(extension, CLAP_EXT_TIMER_SUPPORT)) return &HostExt::hosttimer;
 #if LIN
-    if (!strcmp(extension, CLAP_EXT_POSIX_FD_SUPPORT)) return &HostExt::hostposixfd;
+  if (!strcmp(extension, CLAP_EXT_POSIX_FD_SUPPORT)) return &HostExt::hostposixfd;
 #endif
-    if (!strcmp(extension, CLAP_EXT_LATENCY)) return &HostExt::latency;
-    if (!strcmp(extension, CLAP_EXT_TAIL))
-    {
-      return &HostExt::tail;
-    }
-    if (!strcmp(extension, CLAP_EXT_RENDER))
-    {
-      // TODO: implement CLAP_EXT_RENDER
-    }
-
-    return nullptr;
+  if (!strcmp(extension, CLAP_EXT_LATENCY)) return &HostExt::latency;
+  if (!strcmp(extension, CLAP_EXT_TAIL))
+  {
+    return &HostExt::tail;
+  }
+  if (!strcmp(extension, CLAP_EXT_RENDER))
+  {
+    // TODO: implement CLAP_EXT_RENDER
   }
 
-  // Request the host to schedule a call to plugin->on_main_thread(plugin) on the main thread.
-  // [thread-safe]
-  void Plugin::clapRequestCallback(const clap_host* host)
-  {
-    auto self = static_cast<Plugin*>(host->host_data);
-    self->_parentHost->request_callback();
-  }
+  return nullptr;
+}
 
-  // Request the host to deactivate and then reactivate the plugin.
-  // The operation may be delayed by the host.
-  // [thread-safe]
-  void Plugin::clapRequestRestart(const clap_host* host)
-  {
-    auto self = static_cast<Plugin*>(host->host_data);
-    self->_parentHost->restartPlugin();
-  }
+// Request the host to schedule a call to plugin->on_main_thread(plugin) on the main thread.
+// [thread-safe]
+void Plugin::clapRequestCallback(const clap_host* host)
+{
+  auto self = static_cast<Plugin*>(host->host_data);
+  self->_parentHost->request_callback();
+}
 
-  // Request the host to activate and start processing the plugin.
-  // This is useful if you have external IO and need to wake up the plugin from "sleep".
-  // [thread-safe]
-  void Plugin::clapRequestProcess(const clap_host* host)
-  {
-    // right now, I don't know how to communicate this to the host
-    // in VST3 you can't force processing...
-  }
+// Request the host to deactivate and then reactivate the plugin.
+// The operation may be delayed by the host.
+// [thread-safe]
+void Plugin::clapRequestRestart(const clap_host* host)
+{
+  auto self = static_cast<Plugin*>(host->host_data);
+  self->_parentHost->restartPlugin();
+}
 
-  // Registers a periodic timer.
-  // The host may adjust the period if it is under a certain threshold.
-  // 30 Hz should be allowed.
-  // [main-thread]
-  bool Plugin::register_timer(uint32_t period_ms, clap_id* timer_id)
-  {
-    return _parentHost->register_timer(period_ms, timer_id);
-  }
-  bool Plugin::unregister_timer(clap_id timer_id)
-  {
-    return _parentHost->unregister_timer(timer_id);
-  }
+// Request the host to activate and start processing the plugin.
+// This is useful if you have external IO and need to wake up the plugin from "sleep".
+// [thread-safe]
+void Plugin::clapRequestProcess(const clap_host* host)
+{
+  // right now, I don't know how to communicate this to the host
+  // in VST3 you can't force processing...
+}
+
+// Registers a periodic timer.
+// The host may adjust the period if it is under a certain threshold.
+// 30 Hz should be allowed.
+// [main-thread]
+bool Plugin::register_timer(uint32_t period_ms, clap_id* timer_id)
+{
+  return _parentHost->register_timer(period_ms, timer_id);
+}
+bool Plugin::unregister_timer(clap_id timer_id)
+{
+  return _parentHost->unregister_timer(timer_id);
+}
 
 #if LIN
-  bool Plugin::register_fd(int fd, clap_posix_fd_flags_t flags)
-  {
-    return _parentHost->register_fd(fd, flags);
-  }
-  bool Plugin::modify_fd(int fd, clap_posix_fd_flags_t flags)
-  {
-    return _parentHost->modify_fd(fd, flags);
-  }
-  bool Plugin::unregister_fd(int fd)
-  {
-    return _parentHost->unregister_fd(fd);
-  }
+bool Plugin::register_fd(int fd, clap_posix_fd_flags_t flags)
+{
+  return _parentHost->register_fd(fd, flags);
+}
+bool Plugin::modify_fd(int fd, clap_posix_fd_flags_t flags)
+{
+  return _parentHost->modify_fd(fd, flags);
+}
+bool Plugin::unregister_fd(int fd)
+{
+  return _parentHost->unregister_fd(fd);
+}
 #endif
 }  // namespace Clap

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -12,17 +12,28 @@ namespace Clap
 {
   namespace HostExt
   {
-    static Plugin* self(const clap_host_t* host) { return static_cast<Plugin*>(host->host_data); }
+    static Plugin* self(const clap_host_t* host)
+    {
+      return static_cast<Plugin*>(host->host_data);
+    }
 
-    void host_log(const clap_host_t* host, clap_log_severity severity, const char* msg) { self(host)->log(severity, msg); }
+    void host_log(const clap_host_t* host, clap_log_severity severity, const char* msg)
+    {
+      self(host)->log(severity, msg);
+    }
 
     clap_host_log_t log = {host_log};
 
-    void rescan(const clap_host_t* host, clap_param_rescan_flags flags) { self(host)->param_rescan(flags); }
+    void rescan(const clap_host_t* host, clap_param_rescan_flags flags)
+    {
+      self(host)->param_rescan(flags);
+    }
 
     // Clears references to a parameter.
     // [main-thread]
-    void clear(const clap_host_t* host, clap_id param_id, clap_param_clear_flags flags) {}
+    void clear(const clap_host_t* host, clap_id param_id, clap_param_clear_flags flags)
+    {
+    }
 
     // Request a parameter flush.
     //
@@ -34,22 +45,46 @@ namespace Clap
     //
     // This must not be called on the [audio-thread].
     // [thread-safe,!audio-thread]
-    void request_flush(const clap_host_t* host) { self(host)->param_request_flush(); }
+    void request_flush(const clap_host_t* host)
+    {
+      self(host)->param_request_flush();
+    }
     clap_host_params_t params = {rescan, clear, request_flush};
 
-    bool is_main_thread(const clap_host_t* host) { return self(host)->is_main_thread(); }
+    bool is_main_thread(const clap_host_t* host)
+    {
+      return self(host)->is_main_thread();
+    }
 
     // Returns true if "this" thread is one of the audio threads.
     // [thread-safe]
-    bool is_audio_thread(const clap_host_t* host) { return self(host)->is_audio_thread(); }
+    bool is_audio_thread(const clap_host_t* host)
+    {
+      return self(host)->is_audio_thread();
+    }
 
     clap_host_thread_check_t threadcheck = {is_main_thread, is_audio_thread};
 
-    static void resize_hints_changed(const clap_host_t* host) { self(host)->resize_hints_changed(); }
-    static bool request_resize(const clap_host_t* host, uint32_t width, uint32_t height) { return self(host)->request_resize(width, height); }
-    static bool request_show(const clap_host_t* host) { return self(host)->request_show(); }
-    static bool request_hide(const clap_host_t* host) { return self(host)->request_hide(); }
-    static void closed(const clap_host_t* host, bool was_destroyed) { self(host)->closed(was_destroyed); }
+    static void resize_hints_changed(const clap_host_t* host)
+    {
+      self(host)->resize_hints_changed();
+    }
+    static bool request_resize(const clap_host_t* host, uint32_t width, uint32_t height)
+    {
+      return self(host)->request_resize(width, height);
+    }
+    static bool request_show(const clap_host_t* host)
+    {
+      return self(host)->request_show();
+    }
+    static bool request_hide(const clap_host_t* host)
+    {
+      return self(host)->request_hide();
+    }
+    static void closed(const clap_host_t* host, bool was_destroyed)
+    {
+      self(host)->closed(was_destroyed);
+    }
 
     const clap_host_gui hostgui = {resize_hints_changed, request_resize, request_show, request_hide, closed};
 
@@ -65,7 +100,10 @@ namespace Clap
 
     const clap_host_latency latency = {[](const clap_host_t* host) -> void { self(host)->latency_changed(); }};
 
-    static void tail_changed(const clap_host_t* host) { self(host)->tail_changed(); }
+    static void tail_changed(const clap_host_t* host)
+    {
+      self(host)->tail_changed();
+    }
 
     const clap_host_tail tail = {tail_changed};
 
@@ -152,7 +190,9 @@ namespace Clap
     }
   }
 
-  void Plugin::schnick() {}
+  void Plugin::schnick()
+  {
+  }
 
   bool Plugin::initialize()
   {
@@ -180,7 +220,10 @@ namespace Clap
     _plugin = nullptr;
   }
 
-  void Plugin::setSampleRate(double sampleRate) { _audioSetup.sampleRate = sampleRate; }
+  void Plugin::setSampleRate(double sampleRate)
+  {
+    _audioSetup.sampleRate = sampleRate;
+  }
 
   void Plugin::setBlockSizes(uint32_t minFrames, uint32_t maxFrames)
   {
@@ -206,9 +249,15 @@ namespace Clap
     return false;
   }
 
-  bool Plugin::activate() { return _plugin->activate(_plugin, _audioSetup.sampleRate, _audioSetup.minFrames, _audioSetup.maxFrames); }
+  bool Plugin::activate()
+  {
+    return _plugin->activate(_plugin, _audioSetup.sampleRate, _audioSetup.minFrames, _audioSetup.maxFrames);
+  }
 
-  void Plugin::deactivate() { _plugin->deactivate(_plugin); }
+  void Plugin::deactivate()
+  {
+    _plugin->deactivate(_plugin);
+  }
 
   bool Plugin::start_processing()
   {
@@ -240,9 +289,15 @@ namespace Clap
     return nullptr;
   }
 
-  void Plugin::latency_changed() { _parentHost->latency_changed(); }
+  void Plugin::latency_changed()
+  {
+    _parentHost->latency_changed();
+  }
 
-  void Plugin::tail_changed() { _parentHost->tail_changed(); }
+  void Plugin::tail_changed()
+  {
+    _parentHost->tail_changed();
+  }
 
   void Plugin::log(clap_log_severity severity, const char* msg)
   {
@@ -288,7 +343,10 @@ namespace Clap
 #endif
   }
 
-  bool Plugin::is_main_thread() const { return _main_thread_id == std::this_thread::get_id(); }
+  bool Plugin::is_main_thread() const
+  {
+    return _main_thread_id == std::this_thread::get_id();
+  }
 
   bool Plugin::is_audio_thread() const
   {
@@ -299,12 +357,24 @@ namespace Clap
     return !is_main_thread();
   }
 
-  CLAP_NODISCARD Raise Plugin::AlwaysAudioThread() { return Raise(this->_audio_thread_override); }
+  CLAP_NODISCARD Raise Plugin::AlwaysAudioThread()
+  {
+    return Raise(this->_audio_thread_override);
+  }
 
-  void Plugin::param_rescan(clap_param_rescan_flags flags) { _parentHost->param_rescan(flags); }
+  void Plugin::param_rescan(clap_param_rescan_flags flags)
+  {
+    _parentHost->param_rescan(flags);
+  }
 
-  void Plugin::param_clear(clap_id param, clap_param_clear_flags flags) { _parentHost->param_clear(param, flags); }
-  void Plugin::param_request_flush() { _parentHost->param_request_flush(); }
+  void Plugin::param_clear(clap_id param, clap_param_clear_flags flags)
+  {
+    _parentHost->param_clear(param, flags);
+  }
+  void Plugin::param_request_flush()
+  {
+    _parentHost->param_request_flush();
+  }
 
   // Query an extension.
   // [thread-safe]
@@ -361,12 +431,27 @@ namespace Clap
   // The host may adjust the period if it is under a certain threshold.
   // 30 Hz should be allowed.
   // [main-thread]
-  bool Plugin::register_timer(uint32_t period_ms, clap_id* timer_id) { return _parentHost->register_timer(period_ms, timer_id); }
-  bool Plugin::unregister_timer(clap_id timer_id) { return _parentHost->unregister_timer(timer_id); }
+  bool Plugin::register_timer(uint32_t period_ms, clap_id* timer_id)
+  {
+    return _parentHost->register_timer(period_ms, timer_id);
+  }
+  bool Plugin::unregister_timer(clap_id timer_id)
+  {
+    return _parentHost->unregister_timer(timer_id);
+  }
 
 #if LIN
-  bool Plugin::register_fd(int fd, clap_posix_fd_flags_t flags) { return _parentHost->register_fd(fd, flags); }
-  bool Plugin::modify_fd(int fd, clap_posix_fd_flags_t flags) { return _parentHost->modify_fd(fd, flags); }
-  bool Plugin::unregister_fd(int fd) { return _parentHost->unregister_fd(fd); }
+  bool Plugin::register_fd(int fd, clap_posix_fd_flags_t flags)
+  {
+    return _parentHost->register_fd(fd, flags);
+  }
+  bool Plugin::modify_fd(int fd, clap_posix_fd_flags_t flags)
+  {
+    return _parentHost->modify_fd(fd, flags);
+  }
+  bool Plugin::unregister_fd(int fd)
+  {
+    return _parentHost->unregister_fd(fd);
+  }
 #endif
 }  // namespace Clap

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -12,32 +12,20 @@ namespace Clap
 {
   namespace HostExt
   {
-    static Plugin* self(const clap_host_t* host)
-    {
-      return static_cast<Plugin*>(host->host_data);
-    }
+    static Plugin *self(const clap_host_t *host) { return static_cast<Plugin *>(host->host_data); }
 
-    void host_log(const clap_host_t* host, clap_log_severity severity, const char* msg)
+    void host_log(const clap_host_t *host, clap_log_severity severity, const char *msg)
     {
       self(host)->log(severity, msg);
     }
 
-    clap_host_log_t log =
-    {
-      host_log
-    };
+    clap_host_log_t log = {host_log};
 
-    void rescan(const clap_host_t* host, clap_param_rescan_flags flags)
-    {
-      self(host)->param_rescan(flags);
-    }
+    void rescan(const clap_host_t *host, clap_param_rescan_flags flags) { self(host)->param_rescan(flags); }
 
     // Clears references to a parameter.
     // [main-thread]
-    void clear(const clap_host_t* host, clap_id param_id, clap_param_clear_flags flags)
-    {
-
-    }
+    void clear(const clap_host_t *host, clap_id param_id, clap_param_clear_flags flags) {}
 
     // Request a parameter flush.
     //
@@ -49,86 +37,58 @@ namespace Clap
     //
     // This must not be called on the [audio-thread].
     // [thread-safe,!audio-thread]
-    void request_flush(const clap_host_t* host)
-    {
-      self(host)->param_request_flush();
-    }
-    clap_host_params_t params =
-    {
-      rescan, clear, request_flush
-    };
+    void request_flush(const clap_host_t *host) { self(host)->param_request_flush(); }
+    clap_host_params_t params = {rescan, clear, request_flush};
 
-    bool is_main_thread(const clap_host_t* host)
-    {
-      return self(host)->is_main_thread();
-    }
+    bool is_main_thread(const clap_host_t *host) { return self(host)->is_main_thread(); }
 
     // Returns true if "this" thread is one of the audio threads.
     // [thread-safe]
-    bool is_audio_thread(const clap_host_t* host)
-    {
-      return self(host)->is_audio_thread();
-    }
+    bool is_audio_thread(const clap_host_t *host) { return self(host)->is_audio_thread(); }
 
-    clap_host_thread_check_t threadcheck =
-    {
-      is_main_thread, is_audio_thread
-    };
+    clap_host_thread_check_t threadcheck = {is_main_thread, is_audio_thread};
 
-    static void resize_hints_changed(const clap_host_t* host)
+    static void resize_hints_changed(const clap_host_t *host) { self(host)->resize_hints_changed(); }
+    static bool request_resize(const clap_host_t *host, uint32_t width, uint32_t height)
     {
-      self(host)->resize_hints_changed();
-    }
-    static bool request_resize(const clap_host_t* host, uint32_t width, uint32_t height)
-    {      
       return self(host)->request_resize(width, height);
     }
-    static bool request_show(const clap_host_t* host)
-    {
-      return self(host)->request_show();
-    }
-    static bool request_hide(const clap_host_t* host)
-    {
-      return self(host)->request_hide();
-    }
-    static void closed(const clap_host_t* host, bool was_destroyed)
-    {
-      self(host)->closed(was_destroyed);
-    }
+    static bool request_show(const clap_host_t *host) { return self(host)->request_show(); }
+    static bool request_hide(const clap_host_t *host) { return self(host)->request_hide(); }
+    static void closed(const clap_host_t *host, bool was_destroyed) { self(host)->closed(was_destroyed); }
 
-    const clap_host_gui hostgui = {
-    resize_hints_changed,request_resize,request_show,request_hide,closed };
+    const clap_host_gui hostgui = {resize_hints_changed, request_resize, request_show, request_hide, closed};
 
-    const clap_host_timer_support hosttimer = { 
-      /* register_timer */    [](const clap_host_t* host, uint32_t period_ms, clap_id* timer_id) -> bool { return  self(host)->register_timer(period_ms, timer_id); }, 
-      /* unregister_timer */  [](const clap_host_t* host, clap_id timer_id) -> bool { return  self(host)->unregister_timer(timer_id); }
-    };
+    const clap_host_timer_support hosttimer = {
+        /* register_timer */ [](const clap_host_t *host, uint32_t period_ms, clap_id *timer_id) -> bool
+        { return self(host)->register_timer(period_ms, timer_id); },
+        /* unregister_timer */
+        [](const clap_host_t *host, clap_id timer_id) -> bool { return self(host)->unregister_timer(timer_id); }};
 
 #if LIN
     const clap_host_posix_fd_support hostposixfd = {
-        [](const clap_host_t *host, int fd, clap_posix_fd_flags_t  flags) -> bool { return self(host)->register_fd(fd, flags);},
-        [](const clap_host_t *host, int fd, clap_posix_fd_flags_t  flags) -> bool { return self(host)->modify_fd(fd, flags);},
-        [](const clap_host_t *host, int fd) -> bool { return self(host)->unregister_fd(fd);}
-    };
+        [](const clap_host_t *host, int fd, clap_posix_fd_flags_t flags) -> bool
+        { return self(host)->register_fd(fd, flags); },
+        [](const clap_host_t *host, int fd, clap_posix_fd_flags_t flags) -> bool
+        { return self(host)->modify_fd(fd, flags); },
+        [](const clap_host_t *host, int fd) -> bool { return self(host)->unregister_fd(fd); }};
 #endif
 
-    const clap_host_latency latency = { [](const clap_host_t* host) -> void { self(host)->latency_changed(); } };
+    const clap_host_latency latency = {[](const clap_host_t *host) -> void { self(host)->latency_changed(); }};
 
-    static void tail_changed(const clap_host_t* host)
-    {
-      self(host)->tail_changed();
-    }
+    static void tail_changed(const clap_host_t *host) { self(host)->tail_changed(); }
 
-    const clap_host_tail tail = { tail_changed };
+    const clap_host_tail tail = {tail_changed};
 
-  }
+  } // namespace HostExt
 
-  std::shared_ptr<Plugin> Plugin::createInstance(Clap::Library& library, size_t index, IHost* host)
+  std::shared_ptr<Plugin> Plugin::createInstance(Clap::Library &library, size_t index, IHost *host)
   {
     if (library.plugins.size() > index)
     {
       auto plug = std::shared_ptr<Plugin>(new Plugin(host));
-      auto instance = library._pluginFactory->create_plugin(library._pluginFactory, plug->getClapHostInterface(), library.plugins[index]->id);
+      auto instance = library._pluginFactory->create_plugin(library._pluginFactory, plug->getClapHostInterface(),
+                                                            library.plugins[index]->id);
       plug->connectClap(instance);
 
       return plug;
@@ -136,31 +96,27 @@ namespace Clap
     return nullptr;
   }
 
-  Plugin::Plugin(IHost* host)
-    : _host{
-          CLAP_VERSION,
-          this,
-          "Clap-As-VST3-Wrapper",
-          "defiant nerd",
-          "https://www.defiantnerd.com",
-          "0.0.1",
-          Plugin::clapExtension,
-          Plugin::clapRequestRestart,
-          Plugin::clapRequestProcess,
-          Plugin::clapRequestCallback
-  }
-    , _parentHost(host)
+  Plugin::Plugin(IHost *host)
+      : _host{CLAP_VERSION,
+              this,
+              "Clap-As-VST3-Wrapper",
+              "defiant nerd",
+              "https://www.defiantnerd.com",
+              "0.0.1",
+              Plugin::clapExtension,
+              Plugin::clapRequestRestart,
+              Plugin::clapRequestProcess,
+              Plugin::clapRequestCallback},
+        _parentHost(host)
   {
-
   }
 
-  template<typename T>
-  void getExtension(const clap_plugin_t* plugin, T& ref, const char* name)
+  template <typename T> void getExtension(const clap_plugin_t *plugin, T &ref, const char *name)
   {
     ref = static_cast<T>(plugin->get_extension(plugin, name));
   }
 
-  void Plugin::connectClap(const clap_plugin_t* clap)
+  void Plugin::connectClap(const clap_plugin_t *clap)
   {
     _plugin = clap;
 
@@ -189,15 +145,15 @@ namespace Clap
 
     if (_ext._gui)
     {
-       const char* api;
+      const char *api;
 #if WIN
-       api = CLAP_WINDOW_API_WIN32;
+      api = CLAP_WINDOW_API_WIN32;
 #endif
 #if MAC
-        api = CLAP_WINDOW_API_COCOA;
+      api = CLAP_WINDOW_API_COCOA;
 #endif
 #if LIN
-        api = CLAP_WINDOW_API_X11;
+      api = CLAP_WINDOW_API_X11;
 #endif
 
       if (!_ext._gui->is_api_supported(_plugin, api, false))
@@ -215,14 +171,9 @@ namespace Clap
       _plugin->destroy(_plugin);
       _plugin = nullptr;
     }
-
   }
 
-  void Plugin::schnick()
-  {
-
-  }
-
+  void Plugin::schnick() {}
 
   bool Plugin::initialize()
   {
@@ -250,10 +201,7 @@ namespace Clap
     _plugin = nullptr;
   }
 
-  void Plugin::setSampleRate(double sampleRate)
-  {
-    _audioSetup.sampleRate = sampleRate;
-  }
+  void Plugin::setSampleRate(double sampleRate) { _audioSetup.sampleRate = sampleRate; }
 
   void Plugin::setBlockSizes(uint32_t minFrames, uint32_t maxFrames)
   {
@@ -261,7 +209,7 @@ namespace Clap
     _audioSetup.maxFrames = maxFrames;
   }
 
-  bool Plugin::load(const clap_istream_t* stream)
+  bool Plugin::load(const clap_istream_t *stream)
   {
     if (_ext._state)
     {
@@ -270,7 +218,7 @@ namespace Clap
     return false;
   }
 
-  bool Plugin::save(const clap_ostream_t* stream)
+  bool Plugin::save(const clap_ostream_t *stream)
   {
     if (_ext._state)
     {
@@ -284,10 +232,7 @@ namespace Clap
     return _plugin->activate(_plugin, _audioSetup.sampleRate, _audioSetup.minFrames, _audioSetup.maxFrames);
   }
 
-  void Plugin::deactivate()
-  {
-    _plugin->deactivate(_plugin);
-  }
+  void Plugin::deactivate() { _plugin->deactivate(_plugin); }
 
   bool Plugin::start_processing()
   {
@@ -301,13 +246,13 @@ namespace Clap
     _plugin->stop_processing(_plugin);
   }
 
-  //void Plugin::process(const clap_process_t* data)
+  // void Plugin::process(const clap_process_t* data)
   //{
-  //  auto thisFn = AlwaysAudioThread();
-  //  _plugin->process(_plugin, data);
-  //}
+  //   auto thisFn = AlwaysAudioThread();
+  //   _plugin->process(_plugin, data);
+  // }
 
-  const clap_plugin_gui_t* Plugin::getUI()
+  const clap_plugin_gui_t *Plugin::getUI()
   {
     if (_ext._gui)
     {
@@ -319,17 +264,11 @@ namespace Clap
     return nullptr;
   }
 
-  void Plugin::latency_changed()
-  {
-    _parentHost->latency_changed();
-  }
+  void Plugin::latency_changed() { _parentHost->latency_changed(); }
 
-  void Plugin::tail_changed()
-  {
-    _parentHost->tail_changed();
-  }
+  void Plugin::tail_changed() { _parentHost->tail_changed(); }
 
-  void Plugin::log(clap_log_severity severity, const char* msg)
+  void Plugin::log(clap_log_severity severity, const char *msg)
   {
     std::string n;
     switch (severity)
@@ -359,7 +298,7 @@ namespace Clap
       _CrtDbgBreak();
 #endif
 #if MAC
-        fprintf(stderr,"%s\n",msg);
+      fprintf(stderr, "%s\n", msg);
 #endif
       break;
     }
@@ -369,14 +308,11 @@ namespace Clap
     OutputDebugStringA("\n");
 #endif
 #if MAC
-    fprintf(stderr,"%s\n",n.c_str());
+    fprintf(stderr, "%s\n", n.c_str());
 #endif
   }
 
-  bool Plugin::is_main_thread() const
-  {
-    return _main_thread_id == std::this_thread::get_id();
-  }
+  bool Plugin::is_main_thread() const { return _main_thread_id == std::this_thread::get_id(); }
 
   bool Plugin::is_audio_thread() const
   {
@@ -387,33 +323,20 @@ namespace Clap
     return !is_main_thread();
   }
 
-  CLAP_NODISCARD Raise Plugin::AlwaysAudioThread()
-  {
-      return Raise(this->_audio_thread_override); 
-  }
+  CLAP_NODISCARD Raise Plugin::AlwaysAudioThread() { return Raise(this->_audio_thread_override); }
 
+  void Plugin::param_rescan(clap_param_rescan_flags flags) { _parentHost->param_rescan(flags); }
 
-  void Plugin::param_rescan(clap_param_rescan_flags flags)
-  {
-    _parentHost->param_rescan(flags);
-  }
-
-  void Plugin::param_clear(clap_id param, clap_param_clear_flags flags)
-  {
-    _parentHost->param_clear(param, flags);
-  }
-  void Plugin::param_request_flush()
-  {
-    _parentHost->param_request_flush();
-  }
+  void Plugin::param_clear(clap_id param, clap_param_clear_flags flags) { _parentHost->param_clear(param, flags); }
+  void Plugin::param_request_flush() { _parentHost->param_request_flush(); }
 
   // Query an extension.
   // [thread-safe]
-  const void* Plugin::clapExtension(const clap_host* host, const char* extension)
+  const void *Plugin::clapExtension(const clap_host *host, const char *extension)
   {
     if (!strcmp(extension, CLAP_EXT_LOG))
       return &HostExt::log;
-    if (!strcmp(extension, CLAP_EXT_PARAMS)) 
+    if (!strcmp(extension, CLAP_EXT_PARAMS))
       return &HostExt::params;
     if (!strcmp(extension, CLAP_EXT_THREAD_CHECK))
       return &HostExt::threadcheck;
@@ -441,52 +364,43 @@ namespace Clap
 
   // Request the host to schedule a call to plugin->on_main_thread(plugin) on the main thread.
   // [thread-safe]
-  void Plugin::clapRequestCallback(const clap_host* host)
+  void Plugin::clapRequestCallback(const clap_host *host)
   {
-    auto self = static_cast<Plugin*>(host->host_data);
+    auto self = static_cast<Plugin *>(host->host_data);
     self->_parentHost->request_callback();
   }
 
   // Request the host to deactivate and then reactivate the plugin.
   // The operation may be delayed by the host.
   // [thread-safe]
-  void Plugin::clapRequestRestart(const clap_host* host)
+  void Plugin::clapRequestRestart(const clap_host *host)
   {
-    auto self = static_cast<Plugin*>(host->host_data);
+    auto self = static_cast<Plugin *>(host->host_data);
     self->_parentHost->restartPlugin();
   }
 
   // Request the host to activate and start processing the plugin.
   // This is useful if you have external IO and need to wake up the plugin from "sleep".
   // [thread-safe]
-  void Plugin::clapRequestProcess(const clap_host* host)
+  void Plugin::clapRequestProcess(const clap_host *host)
   {
     // right now, I don't know how to communicate this to the host
     // in VST3 you can't force processing...
   }
 
   // Registers a periodic timer.
-// The host may adjust the period if it is under a certain threshold.
-// 30 Hz should be allowed.
-// [main-thread]
-  bool Plugin::register_timer(uint32_t period_ms, clap_id* timer_id)
+  // The host may adjust the period if it is under a certain threshold.
+  // 30 Hz should be allowed.
+  // [main-thread]
+  bool Plugin::register_timer(uint32_t period_ms, clap_id *timer_id)
   {
     return _parentHost->register_timer(period_ms, timer_id);
   }
-  bool Plugin::unregister_timer(clap_id timer_id)
-  {
-    return _parentHost->unregister_timer(timer_id);
-  }
+  bool Plugin::unregister_timer(clap_id timer_id) { return _parentHost->unregister_timer(timer_id); }
 
 #if LIN
-  bool Plugin::register_fd(int fd, clap_posix_fd_flags_t flags)
-  {
-    return _parentHost->register_fd(fd, flags);
-  }
-  bool Plugin::modify_fd(int fd, clap_posix_fd_flags_t flags)
-  {
-    return _parentHost->modify_fd(fd, flags);
-  }
+  bool Plugin::register_fd(int fd, clap_posix_fd_flags_t flags) { return _parentHost->register_fd(fd, flags); }
+  bool Plugin::modify_fd(int fd, clap_posix_fd_flags_t flags) { return _parentHost->modify_fd(fd, flags); }
   bool Plugin::unregister_fd(int fd) { return _parentHost->unregister_fd(fd); }
 #endif
-  }
+} // namespace Clap

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -141,8 +141,8 @@ namespace Clap
               Plugin::clapExtension,
               Plugin::clapRequestRestart,
               Plugin::clapRequestProcess,
-              Plugin::clapRequestCallback},
-        _parentHost(host)
+              Plugin::clapRequestCallback}
+      , _parentHost(host)
   {
   }
 

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -86,19 +86,27 @@ namespace Clap
       self(host)->closed(was_destroyed);
     }
 
-    const clap_host_gui hostgui = {resize_hints_changed, request_resize, request_show, request_hide, closed};
+    const clap_host_gui hostgui = {resize_hints_changed, request_resize, request_show, request_hide,
+                                   closed};
 
     const clap_host_timer_support hosttimer = {
-        /* register_timer */ [](const clap_host_t* host, uint32_t period_ms, clap_id* timer_id) -> bool { return self(host)->register_timer(period_ms, timer_id); },
-        /* unregister_timer */ [](const clap_host_t* host, clap_id timer_id) -> bool { return self(host)->unregister_timer(timer_id); }};
+        /* register_timer */ [](const clap_host_t* host, uint32_t period_ms, clap_id* timer_id) -> bool
+        { return self(host)->register_timer(period_ms, timer_id); },
+        /* unregister_timer */
+        [](const clap_host_t* host, clap_id timer_id) -> bool
+        { return self(host)->unregister_timer(timer_id); }};
 
 #if LIN
-    const clap_host_posix_fd_support hostposixfd = {[](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool { return self(host)->register_fd(fd, flags); },
-                                                    [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool { return self(host)->modify_fd(fd, flags); },
-                                                    [](const clap_host_t* host, int fd) -> bool { return self(host)->unregister_fd(fd); }};
+    const clap_host_posix_fd_support hostposixfd = {
+        [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
+        { return self(host)->register_fd(fd, flags); },
+        [](const clap_host_t* host, int fd, clap_posix_fd_flags_t flags) -> bool
+        { return self(host)->modify_fd(fd, flags); },
+        [](const clap_host_t* host, int fd) -> bool { return self(host)->unregister_fd(fd); }};
 #endif
 
-    const clap_host_latency latency = {[](const clap_host_t* host) -> void { self(host)->latency_changed(); }};
+    const clap_host_latency latency = {[](const clap_host_t* host) -> void
+                                       { self(host)->latency_changed(); }};
 
     static void tail_changed(const clap_host_t* host)
     {
@@ -114,7 +122,8 @@ namespace Clap
     if (library.plugins.size() > index)
     {
       auto plug = std::shared_ptr<Plugin>(new Plugin(host));
-      auto instance = library._pluginFactory->create_plugin(library._pluginFactory, plug->getClapHostInterface(), library.plugins[index]->id);
+      auto instance = library._pluginFactory->create_plugin(
+          library._pluginFactory, plug->getClapHostInterface(), library.plugins[index]->id);
       plug->connectClap(instance);
 
       return plug;
@@ -123,7 +132,17 @@ namespace Clap
   }
 
   Plugin::Plugin(IHost* host)
-      : _host{CLAP_VERSION, this, "Clap-As-VST3-Wrapper", "defiant nerd", "https://www.defiantnerd.com", "0.0.1", Plugin::clapExtension, Plugin::clapRequestRestart, Plugin::clapRequestProcess, Plugin::clapRequestCallback}, _parentHost(host)
+      : _host{CLAP_VERSION,
+              this,
+              "Clap-As-VST3-Wrapper",
+              "defiant nerd",
+              "https://www.defiantnerd.com",
+              "0.0.1",
+              Plugin::clapExtension,
+              Plugin::clapRequestRestart,
+              Plugin::clapRequestProcess,
+              Plugin::clapRequestCallback},
+        _parentHost(host)
   {
   }
 
@@ -251,7 +270,8 @@ namespace Clap
 
   bool Plugin::activate()
   {
-    return _plugin->activate(_plugin, _audioSetup.sampleRate, _audioSetup.minFrames, _audioSetup.maxFrames);
+    return _plugin->activate(_plugin, _audioSetup.sampleRate, _audioSetup.minFrames,
+                             _audioSetup.maxFrames);
   }
 
   void Plugin::deactivate()

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -132,17 +132,17 @@ namespace Clap
   }
 
   Plugin::Plugin(IHost* host)
-      : _host{CLAP_VERSION,
-              this,
-              "Clap-As-VST3-Wrapper",
-              "defiant nerd",
-              "https://www.defiantnerd.com",
-              "0.0.1",
-              Plugin::clapExtension,
-              Plugin::clapRequestRestart,
-              Plugin::clapRequestProcess,
-              Plugin::clapRequestCallback}
-      , _parentHost(host)
+    : _host{CLAP_VERSION,
+            this,
+            "Clap-As-VST3-Wrapper",
+            "defiant nerd",
+            "https://www.defiantnerd.com",
+            "0.0.1",
+            Plugin::clapExtension,
+            Plugin::clapRequestRestart,
+            Plugin::clapRequestProcess,
+            Plugin::clapRequestCallback}
+    , _parentHost(host)
   {
   }
 

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -39,13 +39,18 @@ namespace Clap
     virtual void restartPlugin() = 0;
     virtual void request_callback() = 0;
 
-    virtual void setupWrapperSpecifics(const clap_plugin_t* plugin) = 0;                                           // called when a wrapper could scan for wrapper specific plugins
+    virtual void setupWrapperSpecifics(
+        const clap_plugin_t *plugin) = 0; // called when a wrapper could scan for wrapper specific plugins
 
-    virtual void setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin_audio_ports_t* audioports) = 0;   // called from initialize() to allow the setup of audio ports
-    virtual void setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports) = 0;      // called from initialize() to allow the setup of MIDI ports
-    virtual void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) = 0;
+    virtual void setupAudioBusses(
+        const clap_plugin_t *plugin,
+        const clap_plugin_audio_ports_t *audioports) = 0; // called from initialize() to allow the setup of audio ports
+    virtual void setupMIDIBusses(
+        const clap_plugin_t *plugin,
+        const clap_plugin_note_ports_t *noteports) = 0; // called from initialize() to allow the setup of MIDI ports
+    virtual void setupParameters(const clap_plugin_t *plugin, const clap_plugin_params_t *params) = 0;
 
-    virtual void param_rescan(clap_param_rescan_flags flags) = 0;                                                  // ext_host_params
+    virtual void param_rescan(clap_param_rescan_flags flags) = 0; // ext_host_params
     virtual void param_clear(clap_id param, clap_param_clear_flags flags) = 0;
     virtual void param_request_flush() = 0;
 
@@ -54,7 +59,7 @@ namespace Clap
     virtual bool gui_request_show() = 0;
     virtual bool gui_request_hide() = 0;
 
-    virtual bool register_timer(uint32_t period_ms, clap_id* timer_id) = 0;
+    virtual bool register_timer(uint32_t period_ms, clap_id *timer_id) = 0;
     virtual bool unregister_timer(clap_id timer_id) = 0;
 
 #if LIN
@@ -66,11 +71,10 @@ namespace Clap
     virtual void latency_changed() = 0;
 
     virtual void tail_changed() = 0;
-
   };
 
   struct ClapPluginExtensions;
-  
+
   struct AudioSetup
   {
     double sampleRate = 44100.;
@@ -80,36 +84,29 @@ namespace Clap
 
   struct ClapPluginExtensions
   {
-    const clap_plugin_state_t* _state = nullptr;
-    const clap_plugin_params_t* _params = nullptr;
-    const clap_plugin_audio_ports_t* _audioports = nullptr;
-    const clap_plugin_gui_t* _gui = nullptr;
-    const clap_plugin_note_ports_t* _noteports = nullptr;
-    const clap_plugin_midi_mappings_t* _midimap = nullptr;
-    const clap_plugin_latency_t* _latency = nullptr;
-    const clap_plugin_render_t* _render = nullptr;
-    const clap_plugin_tail_t* _tail = nullptr;
-    const clap_plugin_timer_support_t* _timer = nullptr;
+    const clap_plugin_state_t *_state = nullptr;
+    const clap_plugin_params_t *_params = nullptr;
+    const clap_plugin_audio_ports_t *_audioports = nullptr;
+    const clap_plugin_gui_t *_gui = nullptr;
+    const clap_plugin_note_ports_t *_noteports = nullptr;
+    const clap_plugin_midi_mappings_t *_midimap = nullptr;
+    const clap_plugin_latency_t *_latency = nullptr;
+    const clap_plugin_render_t *_render = nullptr;
+    const clap_plugin_tail_t *_tail = nullptr;
+    const clap_plugin_timer_support_t *_timer = nullptr;
 #if LIN
-    const clap_plugin_posix_fd_support* _posixfd = nullptr;
+    const clap_plugin_posix_fd_support *_posixfd = nullptr;
 #endif
-
   };
 
   class Raise
   {
   public:
-    Raise(std::atomic<uint32_t>& counter)
-      : ctx(counter)
-    {
-      ++ctx;
-    }
-    ~Raise()
-    {
-      ctx--;
-    }
+    Raise(std::atomic<uint32_t> &counter) : ctx(counter) { ++ctx; }
+    ~Raise() { ctx--; }
+
   private:
-    std::atomic<uint32_t>& ctx;
+    std::atomic<uint32_t> &ctx;
   };
 
   /// <summary>
@@ -119,17 +116,19 @@ namespace Clap
   class Plugin
   {
   public:
-    static std::shared_ptr<Plugin> createInstance(Clap::Library& library, size_t index, IHost* host);
+    static std::shared_ptr<Plugin> createInstance(Clap::Library &library, size_t index, IHost *host);
+
   protected:
     // only the Clap::Library is allowed to create instances
-    Plugin(IHost* host);
-    const clap_host_t* getClapHostInterface() { return &_host; }
-    void connectClap(const clap_plugin_t* clap);
+    Plugin(IHost *host);
+    const clap_host_t *getClapHostInterface() { return &_host; }
+    void connectClap(const clap_plugin_t *clap);
+
   public:
-    Plugin(const Plugin&) = delete;
-    Plugin(Plugin&&) = delete;
-    Plugin& operator=(const Plugin&) = delete;
-    Plugin& operator=(Plugin&&) = delete;
+    Plugin(const Plugin &) = delete;
+    Plugin(Plugin &&) = delete;
+    Plugin &operator=(const Plugin &) = delete;
+    Plugin &operator=(Plugin &&) = delete;
     ~Plugin();
 
     void schnick();
@@ -138,18 +137,18 @@ namespace Clap
     void setSampleRate(double sampleRate);
     void setBlockSizes(uint32_t minFrames, uint32_t maxFrames);
 
-    bool load(const clap_istream_t* stream);
-    bool save(const clap_ostream_t* stream);
+    bool load(const clap_istream_t *stream);
+    bool save(const clap_ostream_t *stream);
     bool activate();
     void deactivate();
     bool start_processing();
     void stop_processing();
     // void process(const clap_process_t* data);
-    const clap_plugin_gui_t* getUI();
+    const clap_plugin_gui_t *getUI();
 
     ClapPluginExtensions _ext;
-    const clap_plugin_t* _plugin = nullptr;
-    void log(clap_log_severity severity, const char* msg);
+    const clap_plugin_t *_plugin = nullptr;
+    void log(clap_log_severity severity, const char *msg);
 
     // threadcheck
     bool is_main_thread() const;
@@ -167,9 +166,7 @@ namespace Clap
     void tail_changed();
 
     // hostgui
-    void resize_hints_changed()
-    {
-    }
+    void resize_hints_changed() {}
     bool request_resize(uint32_t width, uint32_t height)
     {
       if (_parentHost->gui_can_resize())
@@ -179,20 +176,12 @@ namespace Clap
       }
       return false;
     }
-    bool request_show()
-    {
-      return _parentHost->gui_request_show();
-    }
-    bool request_hide()
-    {
-      return false;
-    }
-    void closed(bool was_destroyed)
-    {    
-    }
+    bool request_show() { return _parentHost->gui_request_show(); }
+    bool request_hide() { return false; }
+    void closed(bool was_destroyed) {}
 
     // clap_timer support
-    bool register_timer(uint32_t period_ms, clap_id* timer_id);
+    bool register_timer(uint32_t period_ms, clap_id *timer_id);
     bool unregister_timer(clap_id timer_id);
 
 #if LIN
@@ -202,21 +191,20 @@ namespace Clap
 
 #endif
     CLAP_NODISCARD Raise AlwaysAudioThread();
+
   private:
-    
-    static const void* clapExtension(const clap_host* host, const char* extension);
-    static void clapRequestCallback(const clap_host* host);
-    static void clapRequestRestart(const clap_host* host);
-    static void clapRequestProcess(const clap_host* host);
+    static const void *clapExtension(const clap_host *host, const char *extension);
+    static void clapRequestCallback(const clap_host *host);
+    static void clapRequestRestart(const clap_host *host);
+    static void clapRequestProcess(const clap_host *host);
 
-    //static bool clapIsMainThread(const clap_host* host);
-    //static bool clapIsAudioThread(const clap_host* host);
+    // static bool clapIsMainThread(const clap_host* host);
+    // static bool clapIsAudioThread(const clap_host* host);
 
-
-    clap_host_t _host;                        // the host_t structure for the proxy
-    IHost* _parentHost = nullptr;
+    clap_host_t _host; // the host_t structure for the proxy
+    IHost *_parentHost = nullptr;
     const std::thread::id _main_thread_id = std::this_thread::get_id();
     std::atomic<uint32_t> _audio_thread_override = 0;
     AudioSetup _audioSetup;
   };
-}
+} // namespace Clap

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -28,205 +28,204 @@
 
 namespace Clap
 {
-  class Plugin;
-  class Raise;
+class Plugin;
+class Raise;
 
-  // the IHost interface is being implemented by the actual wrapper class
-  class IHost
-  {
-   public:
-    virtual void mark_dirty() = 0;
-    virtual void restartPlugin() = 0;
-    virtual void request_callback() = 0;
+// the IHost interface is being implemented by the actual wrapper class
+class IHost
+{
+ public:
+  virtual void mark_dirty() = 0;
+  virtual void restartPlugin() = 0;
+  virtual void request_callback() = 0;
 
-    virtual void setupWrapperSpecifics(
-        const clap_plugin_t*
-            plugin) = 0;  // called when a wrapper could scan for wrapper specific plugins
+  virtual void setupWrapperSpecifics(
+      const clap_plugin_t* plugin) = 0;  // called when a wrapper could scan for wrapper specific plugins
 
-    virtual void setupAudioBusses(
-        const clap_plugin_t* plugin,
-        const clap_plugin_audio_ports_t*
-            audioports) = 0;  // called from initialize() to allow the setup of audio ports
-    virtual void setupMIDIBusses(
-        const clap_plugin_t* plugin,
-        const clap_plugin_note_ports_t*
-            noteports) = 0;  // called from initialize() to allow the setup of MIDI ports
-    virtual void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) = 0;
+  virtual void setupAudioBusses(
+      const clap_plugin_t* plugin,
+      const clap_plugin_audio_ports_t*
+          audioports) = 0;  // called from initialize() to allow the setup of audio ports
+  virtual void setupMIDIBusses(
+      const clap_plugin_t* plugin,
+      const clap_plugin_note_ports_t*
+          noteports) = 0;  // called from initialize() to allow the setup of MIDI ports
+  virtual void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) = 0;
 
-    virtual void param_rescan(clap_param_rescan_flags flags) = 0;  // ext_host_params
-    virtual void param_clear(clap_id param, clap_param_clear_flags flags) = 0;
-    virtual void param_request_flush() = 0;
+  virtual void param_rescan(clap_param_rescan_flags flags) = 0;  // ext_host_params
+  virtual void param_clear(clap_id param, clap_param_clear_flags flags) = 0;
+  virtual void param_request_flush() = 0;
 
-    virtual bool gui_can_resize() = 0;
-    virtual bool gui_request_resize(uint32_t width, uint32_t height) = 0;
-    virtual bool gui_request_show() = 0;
-    virtual bool gui_request_hide() = 0;
+  virtual bool gui_can_resize() = 0;
+  virtual bool gui_request_resize(uint32_t width, uint32_t height) = 0;
+  virtual bool gui_request_show() = 0;
+  virtual bool gui_request_hide() = 0;
 
-    virtual bool register_timer(uint32_t period_ms, clap_id* timer_id) = 0;
-    virtual bool unregister_timer(clap_id timer_id) = 0;
-
-#if LIN
-    virtual bool register_fd(int fd, clap_posix_fd_flags_t flags) = 0;
-    virtual bool modify_fd(int fd, clap_posix_fd_flags_t flags) = 0;
-    virtual bool unregister_fd(int fd) = 0;
-#endif
-
-    virtual void latency_changed() = 0;
-
-    virtual void tail_changed() = 0;
-  };
-
-  struct ClapPluginExtensions;
-
-  struct AudioSetup
-  {
-    double sampleRate = 44100.;
-    uint32_t minFrames = 0;
-    uint32_t maxFrames = 0;
-  };
-
-  struct ClapPluginExtensions
-  {
-    const clap_plugin_state_t* _state = nullptr;
-    const clap_plugin_params_t* _params = nullptr;
-    const clap_plugin_audio_ports_t* _audioports = nullptr;
-    const clap_plugin_gui_t* _gui = nullptr;
-    const clap_plugin_note_ports_t* _noteports = nullptr;
-    const clap_plugin_midi_mappings_t* _midimap = nullptr;
-    const clap_plugin_latency_t* _latency = nullptr;
-    const clap_plugin_render_t* _render = nullptr;
-    const clap_plugin_tail_t* _tail = nullptr;
-    const clap_plugin_timer_support_t* _timer = nullptr;
-#if LIN
-    const clap_plugin_posix_fd_support* _posixfd = nullptr;
-#endif
-  };
-
-  class Raise
-  {
-   public:
-    Raise(std::atomic<uint32_t>& counter) : ctx(counter)
-    {
-      ++ctx;
-    }
-    ~Raise()
-    {
-      ctx--;
-    }
-
-   private:
-    std::atomic<uint32_t>& ctx;
-  };
-
-  /// <summary>
-  /// Plugin is the `host` for the CLAP plugin instance
-  /// and the interface for the VST3 plugin wrapper
-  /// </summary>
-  class Plugin
-  {
-   public:
-    static std::shared_ptr<Plugin> createInstance(Clap::Library& library, size_t index, IHost* host);
-
-   protected:
-    // only the Clap::Library is allowed to create instances
-    Plugin(IHost* host);
-    const clap_host_t* getClapHostInterface()
-    {
-      return &_host;
-    }
-    void connectClap(const clap_plugin_t* clap);
-
-   public:
-    Plugin(const Plugin&) = delete;
-    Plugin(Plugin&&) = delete;
-    Plugin& operator=(const Plugin&) = delete;
-    Plugin& operator=(Plugin&&) = delete;
-    ~Plugin();
-
-    void schnick();
-    bool initialize();
-    void terminate();
-    void setSampleRate(double sampleRate);
-    void setBlockSizes(uint32_t minFrames, uint32_t maxFrames);
-
-    bool load(const clap_istream_t* stream);
-    bool save(const clap_ostream_t* stream);
-    bool activate();
-    void deactivate();
-    bool start_processing();
-    void stop_processing();
-    // void process(const clap_process_t* data);
-    const clap_plugin_gui_t* getUI();
-
-    ClapPluginExtensions _ext;
-    const clap_plugin_t* _plugin = nullptr;
-    void log(clap_log_severity severity, const char* msg);
-
-    // threadcheck
-    bool is_main_thread() const;
-    bool is_audio_thread() const;
-
-    // param
-    void param_rescan(clap_param_rescan_flags flags);
-    void param_clear(clap_id param, clap_param_clear_flags flags);
-    void param_request_flush();
-
-    // latency
-    void latency_changed();
-
-    // tail
-    void tail_changed();
-
-    // hostgui
-    void resize_hints_changed()
-    {
-    }
-    bool request_resize(uint32_t width, uint32_t height)
-    {
-      if (_parentHost->gui_can_resize())
-      {
-        _parentHost->gui_request_resize(width, height);
-        return true;
-      }
-      return false;
-    }
-    bool request_show()
-    {
-      return _parentHost->gui_request_show();
-    }
-    bool request_hide()
-    {
-      return false;
-    }
-    void closed(bool was_destroyed)
-    {
-    }
-
-    // clap_timer support
-    bool register_timer(uint32_t period_ms, clap_id* timer_id);
-    bool unregister_timer(clap_id timer_id);
+  virtual bool register_timer(uint32_t period_ms, clap_id* timer_id) = 0;
+  virtual bool unregister_timer(clap_id timer_id) = 0;
 
 #if LIN
-    bool register_fd(int fd, clap_posix_fd_flags_t flags);
-    bool modify_fd(int fd, clap_posix_fd_flags_t flags);
-    bool unregister_fd(int fd);
+  virtual bool register_fd(int fd, clap_posix_fd_flags_t flags) = 0;
+  virtual bool modify_fd(int fd, clap_posix_fd_flags_t flags) = 0;
+  virtual bool unregister_fd(int fd) = 0;
+#endif
+
+  virtual void latency_changed() = 0;
+
+  virtual void tail_changed() = 0;
+};
+
+struct ClapPluginExtensions;
+
+struct AudioSetup
+{
+  double sampleRate = 44100.;
+  uint32_t minFrames = 0;
+  uint32_t maxFrames = 0;
+};
+
+struct ClapPluginExtensions
+{
+  const clap_plugin_state_t* _state = nullptr;
+  const clap_plugin_params_t* _params = nullptr;
+  const clap_plugin_audio_ports_t* _audioports = nullptr;
+  const clap_plugin_gui_t* _gui = nullptr;
+  const clap_plugin_note_ports_t* _noteports = nullptr;
+  const clap_plugin_midi_mappings_t* _midimap = nullptr;
+  const clap_plugin_latency_t* _latency = nullptr;
+  const clap_plugin_render_t* _render = nullptr;
+  const clap_plugin_tail_t* _tail = nullptr;
+  const clap_plugin_timer_support_t* _timer = nullptr;
+#if LIN
+  const clap_plugin_posix_fd_support* _posixfd = nullptr;
+#endif
+};
+
+class Raise
+{
+ public:
+  Raise(std::atomic<uint32_t>& counter) : ctx(counter)
+  {
+    ++ctx;
+  }
+  ~Raise()
+  {
+    ctx--;
+  }
+
+ private:
+  std::atomic<uint32_t>& ctx;
+};
+
+/// <summary>
+/// Plugin is the `host` for the CLAP plugin instance
+/// and the interface for the VST3 plugin wrapper
+/// </summary>
+class Plugin
+{
+ public:
+  static std::shared_ptr<Plugin> createInstance(Clap::Library& library, size_t index, IHost* host);
+
+ protected:
+  // only the Clap::Library is allowed to create instances
+  Plugin(IHost* host);
+  const clap_host_t* getClapHostInterface()
+  {
+    return &_host;
+  }
+  void connectClap(const clap_plugin_t* clap);
+
+ public:
+  Plugin(const Plugin&) = delete;
+  Plugin(Plugin&&) = delete;
+  Plugin& operator=(const Plugin&) = delete;
+  Plugin& operator=(Plugin&&) = delete;
+  ~Plugin();
+
+  void schnick();
+  bool initialize();
+  void terminate();
+  void setSampleRate(double sampleRate);
+  void setBlockSizes(uint32_t minFrames, uint32_t maxFrames);
+
+  bool load(const clap_istream_t* stream);
+  bool save(const clap_ostream_t* stream);
+  bool activate();
+  void deactivate();
+  bool start_processing();
+  void stop_processing();
+  // void process(const clap_process_t* data);
+  const clap_plugin_gui_t* getUI();
+
+  ClapPluginExtensions _ext;
+  const clap_plugin_t* _plugin = nullptr;
+  void log(clap_log_severity severity, const char* msg);
+
+  // threadcheck
+  bool is_main_thread() const;
+  bool is_audio_thread() const;
+
+  // param
+  void param_rescan(clap_param_rescan_flags flags);
+  void param_clear(clap_id param, clap_param_clear_flags flags);
+  void param_request_flush();
+
+  // latency
+  void latency_changed();
+
+  // tail
+  void tail_changed();
+
+  // hostgui
+  void resize_hints_changed()
+  {
+  }
+  bool request_resize(uint32_t width, uint32_t height)
+  {
+    if (_parentHost->gui_can_resize())
+    {
+      _parentHost->gui_request_resize(width, height);
+      return true;
+    }
+    return false;
+  }
+  bool request_show()
+  {
+    return _parentHost->gui_request_show();
+  }
+  bool request_hide()
+  {
+    return false;
+  }
+  void closed(bool was_destroyed)
+  {
+  }
+
+  // clap_timer support
+  bool register_timer(uint32_t period_ms, clap_id* timer_id);
+  bool unregister_timer(clap_id timer_id);
+
+#if LIN
+  bool register_fd(int fd, clap_posix_fd_flags_t flags);
+  bool modify_fd(int fd, clap_posix_fd_flags_t flags);
+  bool unregister_fd(int fd);
 
 #endif
-    CLAP_NODISCARD Raise AlwaysAudioThread();
+  CLAP_NODISCARD Raise AlwaysAudioThread();
 
-   private:
-    static const void* clapExtension(const clap_host* host, const char* extension);
-    static void clapRequestCallback(const clap_host* host);
-    static void clapRequestRestart(const clap_host* host);
-    static void clapRequestProcess(const clap_host* host);
+ private:
+  static const void* clapExtension(const clap_host* host, const char* extension);
+  static void clapRequestCallback(const clap_host* host);
+  static void clapRequestRestart(const clap_host* host);
+  static void clapRequestProcess(const clap_host* host);
 
-    //static bool clapIsMainThread(const clap_host* host);
-    //static bool clapIsAudioThread(const clap_host* host);
+  //static bool clapIsMainThread(const clap_host* host);
+  //static bool clapIsAudioThread(const clap_host* host);
 
-    clap_host_t _host;  // the host_t structure for the proxy
-    IHost* _parentHost = nullptr;
-    const std::thread::id _main_thread_id = std::this_thread::get_id();
-    std::atomic<uint32_t> _audio_thread_override = 0;
-    AudioSetup _audioSetup;
-  };
+  clap_host_t _host;  // the host_t structure for the proxy
+  IHost* _parentHost = nullptr;
+  const std::thread::id _main_thread_id = std::this_thread::get_id();
+  std::atomic<uint32_t> _audio_thread_override = 0;
+  AudioSetup _audioSetup;
+};
 }  // namespace Clap

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -34,23 +34,18 @@ namespace Clap
   // the IHost interface is being implemented by the actual wrapper class
   class IHost
   {
-  public:
+   public:
     virtual void mark_dirty() = 0;
     virtual void restartPlugin() = 0;
     virtual void request_callback() = 0;
 
-    virtual void setupWrapperSpecifics(
-        const clap_plugin_t *plugin) = 0; // called when a wrapper could scan for wrapper specific plugins
+    virtual void setupWrapperSpecifics(const clap_plugin_t* plugin) = 0;  // called when a wrapper could scan for wrapper specific plugins
 
-    virtual void setupAudioBusses(
-        const clap_plugin_t *plugin,
-        const clap_plugin_audio_ports_t *audioports) = 0; // called from initialize() to allow the setup of audio ports
-    virtual void setupMIDIBusses(
-        const clap_plugin_t *plugin,
-        const clap_plugin_note_ports_t *noteports) = 0; // called from initialize() to allow the setup of MIDI ports
-    virtual void setupParameters(const clap_plugin_t *plugin, const clap_plugin_params_t *params) = 0;
+    virtual void setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin_audio_ports_t* audioports) = 0;  // called from initialize() to allow the setup of audio ports
+    virtual void setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports) = 0;     // called from initialize() to allow the setup of MIDI ports
+    virtual void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) = 0;
 
-    virtual void param_rescan(clap_param_rescan_flags flags) = 0; // ext_host_params
+    virtual void param_rescan(clap_param_rescan_flags flags) = 0;  // ext_host_params
     virtual void param_clear(clap_id param, clap_param_clear_flags flags) = 0;
     virtual void param_request_flush() = 0;
 
@@ -59,7 +54,7 @@ namespace Clap
     virtual bool gui_request_show() = 0;
     virtual bool gui_request_hide() = 0;
 
-    virtual bool register_timer(uint32_t period_ms, clap_id *timer_id) = 0;
+    virtual bool register_timer(uint32_t period_ms, clap_id* timer_id) = 0;
     virtual bool unregister_timer(clap_id timer_id) = 0;
 
 #if LIN
@@ -84,29 +79,29 @@ namespace Clap
 
   struct ClapPluginExtensions
   {
-    const clap_plugin_state_t *_state = nullptr;
-    const clap_plugin_params_t *_params = nullptr;
-    const clap_plugin_audio_ports_t *_audioports = nullptr;
-    const clap_plugin_gui_t *_gui = nullptr;
-    const clap_plugin_note_ports_t *_noteports = nullptr;
-    const clap_plugin_midi_mappings_t *_midimap = nullptr;
-    const clap_plugin_latency_t *_latency = nullptr;
-    const clap_plugin_render_t *_render = nullptr;
-    const clap_plugin_tail_t *_tail = nullptr;
-    const clap_plugin_timer_support_t *_timer = nullptr;
+    const clap_plugin_state_t* _state = nullptr;
+    const clap_plugin_params_t* _params = nullptr;
+    const clap_plugin_audio_ports_t* _audioports = nullptr;
+    const clap_plugin_gui_t* _gui = nullptr;
+    const clap_plugin_note_ports_t* _noteports = nullptr;
+    const clap_plugin_midi_mappings_t* _midimap = nullptr;
+    const clap_plugin_latency_t* _latency = nullptr;
+    const clap_plugin_render_t* _render = nullptr;
+    const clap_plugin_tail_t* _tail = nullptr;
+    const clap_plugin_timer_support_t* _timer = nullptr;
 #if LIN
-    const clap_plugin_posix_fd_support *_posixfd = nullptr;
+    const clap_plugin_posix_fd_support* _posixfd = nullptr;
 #endif
   };
 
   class Raise
   {
-  public:
-    Raise(std::atomic<uint32_t> &counter) : ctx(counter) { ++ctx; }
+   public:
+    Raise(std::atomic<uint32_t>& counter) : ctx(counter) { ++ctx; }
     ~Raise() { ctx--; }
 
-  private:
-    std::atomic<uint32_t> &ctx;
+   private:
+    std::atomic<uint32_t>& ctx;
   };
 
   /// <summary>
@@ -115,20 +110,20 @@ namespace Clap
   /// </summary>
   class Plugin
   {
-  public:
-    static std::shared_ptr<Plugin> createInstance(Clap::Library &library, size_t index, IHost *host);
+   public:
+    static std::shared_ptr<Plugin> createInstance(Clap::Library& library, size_t index, IHost* host);
 
-  protected:
+   protected:
     // only the Clap::Library is allowed to create instances
-    Plugin(IHost *host);
-    const clap_host_t *getClapHostInterface() { return &_host; }
-    void connectClap(const clap_plugin_t *clap);
+    Plugin(IHost* host);
+    const clap_host_t* getClapHostInterface() { return &_host; }
+    void connectClap(const clap_plugin_t* clap);
 
-  public:
-    Plugin(const Plugin &) = delete;
-    Plugin(Plugin &&) = delete;
-    Plugin &operator=(const Plugin &) = delete;
-    Plugin &operator=(Plugin &&) = delete;
+   public:
+    Plugin(const Plugin&) = delete;
+    Plugin(Plugin&&) = delete;
+    Plugin& operator=(const Plugin&) = delete;
+    Plugin& operator=(Plugin&&) = delete;
     ~Plugin();
 
     void schnick();
@@ -137,18 +132,18 @@ namespace Clap
     void setSampleRate(double sampleRate);
     void setBlockSizes(uint32_t minFrames, uint32_t maxFrames);
 
-    bool load(const clap_istream_t *stream);
-    bool save(const clap_ostream_t *stream);
+    bool load(const clap_istream_t* stream);
+    bool save(const clap_ostream_t* stream);
     bool activate();
     void deactivate();
     bool start_processing();
     void stop_processing();
     // void process(const clap_process_t* data);
-    const clap_plugin_gui_t *getUI();
+    const clap_plugin_gui_t* getUI();
 
     ClapPluginExtensions _ext;
-    const clap_plugin_t *_plugin = nullptr;
-    void log(clap_log_severity severity, const char *msg);
+    const clap_plugin_t* _plugin = nullptr;
+    void log(clap_log_severity severity, const char* msg);
 
     // threadcheck
     bool is_main_thread() const;
@@ -181,7 +176,7 @@ namespace Clap
     void closed(bool was_destroyed) {}
 
     // clap_timer support
-    bool register_timer(uint32_t period_ms, clap_id *timer_id);
+    bool register_timer(uint32_t period_ms, clap_id* timer_id);
     bool unregister_timer(clap_id timer_id);
 
 #if LIN
@@ -192,19 +187,19 @@ namespace Clap
 #endif
     CLAP_NODISCARD Raise AlwaysAudioThread();
 
-  private:
-    static const void *clapExtension(const clap_host *host, const char *extension);
-    static void clapRequestCallback(const clap_host *host);
-    static void clapRequestRestart(const clap_host *host);
-    static void clapRequestProcess(const clap_host *host);
+   private:
+    static const void* clapExtension(const clap_host* host, const char* extension);
+    static void clapRequestCallback(const clap_host* host);
+    static void clapRequestRestart(const clap_host* host);
+    static void clapRequestProcess(const clap_host* host);
 
-    // static bool clapIsMainThread(const clap_host* host);
-    // static bool clapIsAudioThread(const clap_host* host);
+    //static bool clapIsMainThread(const clap_host* host);
+    //static bool clapIsAudioThread(const clap_host* host);
 
-    clap_host_t _host; // the host_t structure for the proxy
-    IHost *_parentHost = nullptr;
+    clap_host_t _host;  // the host_t structure for the proxy
+    IHost* _parentHost = nullptr;
     const std::thread::id _main_thread_id = std::this_thread::get_id();
     std::atomic<uint32_t> _audio_thread_override = 0;
     AudioSetup _audioSetup;
   };
-} // namespace Clap
+}  // namespace Clap

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -39,10 +39,18 @@ namespace Clap
     virtual void restartPlugin() = 0;
     virtual void request_callback() = 0;
 
-    virtual void setupWrapperSpecifics(const clap_plugin_t* plugin) = 0;  // called when a wrapper could scan for wrapper specific plugins
+    virtual void setupWrapperSpecifics(
+        const clap_plugin_t*
+            plugin) = 0;  // called when a wrapper could scan for wrapper specific plugins
 
-    virtual void setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin_audio_ports_t* audioports) = 0;  // called from initialize() to allow the setup of audio ports
-    virtual void setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports) = 0;     // called from initialize() to allow the setup of MIDI ports
+    virtual void setupAudioBusses(
+        const clap_plugin_t* plugin,
+        const clap_plugin_audio_ports_t*
+            audioports) = 0;  // called from initialize() to allow the setup of audio ports
+    virtual void setupMIDIBusses(
+        const clap_plugin_t* plugin,
+        const clap_plugin_note_ports_t*
+            noteports) = 0;  // called from initialize() to allow the setup of MIDI ports
     virtual void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) = 0;
 
     virtual void param_rescan(clap_param_rescan_flags flags) = 0;  // ext_host_params

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -97,8 +97,14 @@ namespace Clap
   class Raise
   {
    public:
-    Raise(std::atomic<uint32_t>& counter) : ctx(counter) { ++ctx; }
-    ~Raise() { ctx--; }
+    Raise(std::atomic<uint32_t>& counter) : ctx(counter)
+    {
+      ++ctx;
+    }
+    ~Raise()
+    {
+      ctx--;
+    }
 
    private:
     std::atomic<uint32_t>& ctx;
@@ -116,7 +122,10 @@ namespace Clap
    protected:
     // only the Clap::Library is allowed to create instances
     Plugin(IHost* host);
-    const clap_host_t* getClapHostInterface() { return &_host; }
+    const clap_host_t* getClapHostInterface()
+    {
+      return &_host;
+    }
     void connectClap(const clap_plugin_t* clap);
 
    public:
@@ -161,7 +170,9 @@ namespace Clap
     void tail_changed();
 
     // hostgui
-    void resize_hints_changed() {}
+    void resize_hints_changed()
+    {
+    }
     bool request_resize(uint32_t width, uint32_t height)
     {
       if (_parentHost->gui_can_resize())
@@ -171,9 +182,17 @@ namespace Clap
       }
       return false;
     }
-    bool request_show() { return _parentHost->gui_request_show(); }
-    bool request_hide() { return false; }
-    void closed(bool was_destroyed) {}
+    bool request_show()
+    {
+      return _parentHost->gui_request_show();
+    }
+    bool request_hide()
+    {
+      return false;
+    }
+    void closed(bool was_destroyed)
+    {
+    }
 
     // clap_timer support
     bool register_timer(uint32_t period_ms, clap_id* timer_id);

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -15,68 +15,68 @@
 namespace free_audio::auv2_wrapper
 {
 
-  // -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 
-  class ClapWrapper_AUV2_Effect : public ausdk::AUEffectBase
+class ClapWrapper_AUV2_Effect : public ausdk::AUEffectBase
+{
+  using Base = ausdk::AUEffectBase;
+  ClapBridge bridge;
+
+ public:
+  explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx,
+                                   AudioComponentInstance ci)
+    : Base{ci, true}, bridge(clapname, clapid, clapidx)
   {
-    using Base = ausdk::AUEffectBase;
-    ClapBridge bridge;
+    std::cout << "[clap-wrapper] auv2: creating effect" << std::endl;
+    std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
 
-   public:
-    explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx,
-                                     AudioComponentInstance ci)
-      : Base{ci, true}, bridge(clapname, clapid, clapidx)
-    {
-      std::cout << "[clap-wrapper] auv2: creating effect" << std::endl;
-      std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
+    bridge.initialize();
+  }
+};
 
-      bridge.initialize();
-    }
-  };
+class ClapWrapper_AUV2_NoteEffect : public ausdk::AUMIDIEffectBase
+{
+  using Base = ausdk::AUMIDIEffectBase;
+  ClapBridge bridge;
 
-  class ClapWrapper_AUV2_NoteEffect : public ausdk::AUMIDIEffectBase
+ public:
+  explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid,
+                                       int clapidx, AudioComponentInstance ci)
+    : Base{ci, true}, bridge(clapname, clapid, clapidx)
   {
-    using Base = ausdk::AUMIDIEffectBase;
-    ClapBridge bridge;
+    std::cout << "[clap-wrapper] auv2: creating note effect" << std::endl;
+    std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
 
-   public:
-    explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid,
-                                         int clapidx, AudioComponentInstance ci)
-      : Base{ci, true}, bridge(clapname, clapid, clapidx)
-    {
-      std::cout << "[clap-wrapper] auv2: creating note effect" << std::endl;
-      std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
+    bridge.initialize();
+  }
+};
 
-      bridge.initialize();
-    }
-  };
+// -------------------------------------------------------------------------------------------------
 
-  // -------------------------------------------------------------------------------------------------
+class ClapWrapper_AUV2_Instrument : public ausdk::MusicDeviceBase
+{
+  using Base = ausdk::MusicDeviceBase;
+  ClapBridge bridge;
 
-  class ClapWrapper_AUV2_Instrument : public ausdk::MusicDeviceBase
+ public:
+  explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid,
+                                       int clapidx, AudioComponentInstance ci)
+    : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
   {
-    using Base = ausdk::MusicDeviceBase;
-    ClapBridge bridge;
+    std::cout << "[clap-wrapper] auv2: creating instrument" << std::endl;
+    std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
 
-   public:
-    explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid,
-                                         int clapidx, AudioComponentInstance ci)
-      : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
-    {
-      std::cout << "[clap-wrapper] auv2: creating instrument" << std::endl;
-      std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
+    bridge.initialize();
+  }
 
-      bridge.initialize();
-    }
+  bool StreamFormatWritable(AudioUnitScope, AudioUnitElement) override
+  {
+    return true;
+  }
 
-    bool StreamFormatWritable(AudioUnitScope, AudioUnitElement) override
-    {
-      return true;
-    }
-
-    bool CanScheduleParameters() const override
-    {
-      return false;
-    }
-  };
+  bool CanScheduleParameters() const override
+  {
+    return false;
+  }
+};
 }  // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -63,8 +63,14 @@ namespace free_audio::auv2_wrapper
       bridge.initialize();
     }
 
-    bool StreamFormatWritable(AudioUnitScope, AudioUnitElement) override { return true; }
+    bool StreamFormatWritable(AudioUnitScope, AudioUnitElement) override
+    {
+      return true;
+    }
 
-    bool CanScheduleParameters() const override { return false; }
+    bool CanScheduleParameters() const override
+    {
+      return false;
+    }
   };
 }  // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -23,7 +23,9 @@ namespace free_audio::auv2_wrapper
     ClapBridge bridge;
 
    public:
-    explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx, AudioComponentInstance ci) : Base{ci, true}, bridge(clapname, clapid, clapidx)
+    explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx,
+                                     AudioComponentInstance ci)
+        : Base{ci, true}, bridge(clapname, clapid, clapidx)
     {
       std::cout << "[clap-wrapper] auv2: creating effect" << std::endl;
       std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
@@ -38,7 +40,9 @@ namespace free_audio::auv2_wrapper
     ClapBridge bridge;
 
    public:
-    explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid, int clapidx, AudioComponentInstance ci) : Base{ci, true}, bridge(clapname, clapid, clapidx)
+    explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid,
+                                         int clapidx, AudioComponentInstance ci)
+        : Base{ci, true}, bridge(clapname, clapid, clapidx)
     {
       std::cout << "[clap-wrapper] auv2: creating note effect" << std::endl;
       std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
@@ -55,7 +59,9 @@ namespace free_audio::auv2_wrapper
     ClapBridge bridge;
 
    public:
-    explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid, int clapidx, AudioComponentInstance ci) : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
+    explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid,
+                                         int clapidx, AudioComponentInstance ci)
+        : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
     {
       std::cout << "[clap-wrapper] auv2: creating instrument" << std::endl;
       std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -15,65 +15,62 @@
 namespace free_audio::auv2_wrapper
 {
 
-    // -------------------------------------------------------------------------------------------------
+  // -------------------------------------------------------------------------------------------------
 
-    class ClapWrapper_AUV2_Effect : public ausdk::AUEffectBase
+  class ClapWrapper_AUV2_Effect : public ausdk::AUEffectBase
+  {
+    using Base = ausdk::AUEffectBase;
+    ClapBridge bridge;
+
+  public:
+    explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx,
+                                     AudioComponentInstance ci)
+        : Base{ci, true}, bridge(clapname, clapid, clapidx)
     {
-        using Base = ausdk::AUEffectBase;
-        ClapBridge bridge;
-      public:
-        explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid,
-                                         int clapidx, AudioComponentInstance ci)
-            : Base{ci, true}, bridge(clapname, clapid, clapidx)
-        {
-            std::cout << "[clap-wrapper] auv2: creating effect" << std::endl;
-            std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx
-                      << std::endl;
+      std::cout << "[clap-wrapper] auv2: creating effect" << std::endl;
+      std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
 
-            bridge.initialize();
-        }
-    };
+      bridge.initialize();
+    }
+  };
 
-    class ClapWrapper_AUV2_NoteEffect : public ausdk::AUMIDIEffectBase
+  class ClapWrapper_AUV2_NoteEffect : public ausdk::AUMIDIEffectBase
+  {
+    using Base = ausdk::AUMIDIEffectBase;
+    ClapBridge bridge;
+
+  public:
+    explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid, int clapidx,
+                                         AudioComponentInstance ci)
+        : Base{ci, true}, bridge(clapname, clapid, clapidx)
     {
-        using Base = ausdk::AUMIDIEffectBase;
-        ClapBridge bridge;
+      std::cout << "[clap-wrapper] auv2: creating note effect" << std::endl;
+      std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
 
-      public:
-        explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid,
-                                             int clapidx, AudioComponentInstance ci)
-            : Base{ci, true}, bridge(clapname, clapid, clapidx)
-        {
-            std::cout << "[clap-wrapper] auv2: creating note effect" << std::endl;
-            std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx
-                      << std::endl;
+      bridge.initialize();
+    }
+  };
 
+  // -------------------------------------------------------------------------------------------------
 
-            bridge.initialize();
-        }
-    };
+  class ClapWrapper_AUV2_Instrument : public ausdk::MusicDeviceBase
+  {
+    using Base = ausdk::MusicDeviceBase;
+    ClapBridge bridge;
 
-    // -------------------------------------------------------------------------------------------------
-
-    class ClapWrapper_AUV2_Instrument : public ausdk::MusicDeviceBase
+  public:
+    explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid, int clapidx,
+                                         AudioComponentInstance ci)
+        : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
     {
-        using Base = ausdk::MusicDeviceBase;
-        ClapBridge bridge;
+      std::cout << "[clap-wrapper] auv2: creating instrument" << std::endl;
+      std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
 
-      public:
-        explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid,
-                                             int clapidx, AudioComponentInstance ci)
-            : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
-        {
-            std::cout << "[clap-wrapper] auv2: creating instrument" << std::endl;
-            std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx
-                      << std::endl;
+      bridge.initialize();
+    }
 
-            bridge.initialize();
-        }
+    bool StreamFormatWritable(AudioUnitScope, AudioUnitElement) override { return true; }
 
-        bool StreamFormatWritable(AudioUnitScope, AudioUnitElement) override { return true; }
-
-        bool CanScheduleParameters() const override { return false; }
-    };
-} // namespace free_audio: auv2_wrapper
+    bool CanScheduleParameters() const override { return false; }
+  };
+} // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -22,10 +22,8 @@ namespace free_audio::auv2_wrapper
     using Base = ausdk::AUEffectBase;
     ClapBridge bridge;
 
-  public:
-    explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx,
-                                     AudioComponentInstance ci)
-        : Base{ci, true}, bridge(clapname, clapid, clapidx)
+   public:
+    explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx, AudioComponentInstance ci) : Base{ci, true}, bridge(clapname, clapid, clapidx)
     {
       std::cout << "[clap-wrapper] auv2: creating effect" << std::endl;
       std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
@@ -39,10 +37,8 @@ namespace free_audio::auv2_wrapper
     using Base = ausdk::AUMIDIEffectBase;
     ClapBridge bridge;
 
-  public:
-    explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid, int clapidx,
-                                         AudioComponentInstance ci)
-        : Base{ci, true}, bridge(clapname, clapid, clapidx)
+   public:
+    explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid, int clapidx, AudioComponentInstance ci) : Base{ci, true}, bridge(clapname, clapid, clapidx)
     {
       std::cout << "[clap-wrapper] auv2: creating note effect" << std::endl;
       std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
@@ -58,10 +54,8 @@ namespace free_audio::auv2_wrapper
     using Base = ausdk::MusicDeviceBase;
     ClapBridge bridge;
 
-  public:
-    explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid, int clapidx,
-                                         AudioComponentInstance ci)
-        : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
+   public:
+    explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid, int clapidx, AudioComponentInstance ci) : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
     {
       std::cout << "[clap-wrapper] auv2: creating instrument" << std::endl;
       std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
@@ -73,4 +67,4 @@ namespace free_audio::auv2_wrapper
 
     bool CanScheduleParameters() const override { return false; }
   };
-} // namespace free_audio::auv2_wrapper
+}  // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -25,7 +25,7 @@ namespace free_audio::auv2_wrapper
    public:
     explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx,
                                      AudioComponentInstance ci)
-        : Base{ci, true}, bridge(clapname, clapid, clapidx)
+      : Base{ci, true}, bridge(clapname, clapid, clapidx)
     {
       std::cout << "[clap-wrapper] auv2: creating effect" << std::endl;
       std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
@@ -42,7 +42,7 @@ namespace free_audio::auv2_wrapper
    public:
     explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid,
                                          int clapidx, AudioComponentInstance ci)
-        : Base{ci, true}, bridge(clapname, clapid, clapidx)
+      : Base{ci, true}, bridge(clapname, clapid, clapidx)
     {
       std::cout << "[clap-wrapper] auv2: creating note effect" << std::endl;
       std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
@@ -61,7 +61,7 @@ namespace free_audio::auv2_wrapper
    public:
     explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid,
                                          int clapidx, AudioComponentInstance ci)
-        : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
+      : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
     {
       std::cout << "[clap-wrapper] auv2: creating instrument" << std::endl;
       std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;

--- a/src/detail/auv2/auv2_shared.h
+++ b/src/detail/auv2/auv2_shared.h
@@ -17,7 +17,7 @@ namespace free_audio::auv2_wrapper
     const clap_plugin_descriptor_t *_desc{nullptr};
 
     ClapBridge(const std::string &clapname, const std::string &clapid, int idx)
-        : _clapname(clapname), _clapid(clapid), _idx(idx)
+      : _clapname(clapname), _clapid(clapid), _idx(idx)
     {
       std::cout << "[clap-wraper] auv2: creating clap bridge nm=" << clapname << " id=" << clapid
                 << " idx=" << idx << std::endl;

--- a/src/detail/auv2/auv2_shared.h
+++ b/src/detail/auv2/auv2_shared.h
@@ -4,66 +4,79 @@
 #include "detail/clap/fsutil.h"
 #include <iostream>
 
-namespace free_audio::auv2_wrapper {
-struct ClapBridge {
-  std::string _clapname;
-  std::string _clapid;
-  int _idx;
+namespace free_audio::auv2_wrapper
+{
+  struct ClapBridge
+  {
+    std::string _clapname;
+    std::string _clapid;
+    int _idx;
 
-  Clap::Library _library;
+    Clap::Library _library;
 
-  const clap_plugin_descriptor_t *_desc{nullptr};
+    const clap_plugin_descriptor_t *_desc{nullptr};
 
-  ClapBridge(const std::string &clapname, const std::string &clapid, int idx)
-      : _clapname(clapname), _clapid(clapid), _idx(idx) {
-    std::cout << "[clap-wraper] auv2: creating clap bridge nm=" << clapname
-              << " id=" << clapid << " idx=" << idx << std::endl;
-  }
-
-  void initialize() {
-    if (!_library.hasEntryPoint()) {
-      if (_clapname.empty()) {
-        std::cout << "[ERROR] _clapname (" << _clapname
-                  << ") empty and no internal entry point" << std::endl;
-      }
-      bool loaded{false};
-      auto csp = Clap::getValidCLAPSearchPaths();
-      for (auto &cs : csp) {
-        if (fs::is_directory(cs / (_clapname + ".clap")))
-          if (_library.load(_clapname.c_str())) {
-            std::cout << "[clap-wrapper] auv2 loaded clap from "
-                      << cs.u8string() << std::endl;
-            loaded = true;
-            break;
-          }
-      }
-      if (!loaded) {
-        std::cout << "[ERROR] cannot load clap" << std::endl;
-        return;
-      }
+    ClapBridge(const std::string &clapname, const std::string &clapid, int idx)
+        : _clapname(clapname), _clapid(clapid), _idx(idx)
+    {
+      std::cout << "[clap-wraper] auv2: creating clap bridge nm=" << clapname << " id=" << clapid << " idx=" << idx
+                << std::endl;
     }
 
-    if (_clapid.empty()) {
-      if (_idx < 0 || _idx >= _library.plugins.size()) {
-        std::cout << "[ERROR] cannot load by index" << std::endl;
-        return;
-      }
-      _desc = _library.plugins[_idx];
-    } else {
-      for (auto *d : _library.plugins) {
-        if (strcmp(d->id, _clapid.c_str()) == 0) {
-          _desc = d;
+    void initialize()
+    {
+      if (!_library.hasEntryPoint())
+      {
+        if (_clapname.empty())
+        {
+          std::cout << "[ERROR] _clapname (" << _clapname << ") empty and no internal entry point" << std::endl;
+        }
+        bool loaded{false};
+        auto csp = Clap::getValidCLAPSearchPaths();
+        for (auto &cs : csp)
+        {
+          if (fs::is_directory(cs / (_clapname + ".clap")))
+            if (_library.load(_clapname.c_str()))
+            {
+              std::cout << "[clap-wrapper] auv2 loaded clap from " << cs.u8string() << std::endl;
+              loaded = true;
+              break;
+            }
+        }
+        if (!loaded)
+        {
+          std::cout << "[ERROR] cannot load clap" << std::endl;
+          return;
         }
       }
-    }
 
-    if (!_desc) {
-      std::cout << "[ERROR] cannot determine plugin description" << std::endl;
-      return;
-    }
+      if (_clapid.empty())
+      {
+        if (_idx < 0 || _idx >= _library.plugins.size())
+        {
+          std::cout << "[ERROR] cannot load by index" << std::endl;
+          return;
+        }
+        _desc = _library.plugins[_idx];
+      }
+      else
+      {
+        for (auto *d : _library.plugins)
+        {
+          if (strcmp(d->id, _clapid.c_str()) == 0)
+          {
+            _desc = d;
+          }
+        }
+      }
 
-    std::cout << "[clap-wrapper] auv2: Initialized '" << _desc->id << "' / '"
-              << _desc->name << "'" << std::endl;
-  }
-};
+      if (!_desc)
+      {
+        std::cout << "[ERROR] cannot determine plugin description" << std::endl;
+        return;
+      }
+
+      std::cout << "[clap-wrapper] auv2: Initialized '" << _desc->id << "' / '" << _desc->name << "'" << std::endl;
+    }
+  };
 } // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/auv2_shared.h
+++ b/src/detail/auv2/auv2_shared.h
@@ -16,11 +16,9 @@ namespace free_audio::auv2_wrapper
 
     const clap_plugin_descriptor_t *_desc{nullptr};
 
-    ClapBridge(const std::string &clapname, const std::string &clapid, int idx)
-        : _clapname(clapname), _clapid(clapid), _idx(idx)
+    ClapBridge(const std::string &clapname, const std::string &clapid, int idx) : _clapname(clapname), _clapid(clapid), _idx(idx)
     {
-      std::cout << "[clap-wraper] auv2: creating clap bridge nm=" << clapname << " id=" << clapid << " idx=" << idx
-                << std::endl;
+      std::cout << "[clap-wraper] auv2: creating clap bridge nm=" << clapname << " id=" << clapid << " idx=" << idx << std::endl;
     }
 
     void initialize()
@@ -79,4 +77,4 @@ namespace free_audio::auv2_wrapper
       std::cout << "[clap-wrapper] auv2: Initialized '" << _desc->id << "' / '" << _desc->name << "'" << std::endl;
     }
   };
-} // namespace free_audio::auv2_wrapper
+}  // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/auv2_shared.h
+++ b/src/detail/auv2/auv2_shared.h
@@ -6,79 +6,79 @@
 
 namespace free_audio::auv2_wrapper
 {
-  struct ClapBridge
+struct ClapBridge
+{
+  std::string _clapname;
+  std::string _clapid;
+  int _idx;
+
+  Clap::Library _library;
+
+  const clap_plugin_descriptor_t *_desc{nullptr};
+
+  ClapBridge(const std::string &clapname, const std::string &clapid, int idx)
+    : _clapname(clapname), _clapid(clapid), _idx(idx)
   {
-    std::string _clapname;
-    std::string _clapid;
-    int _idx;
+    std::cout << "[clap-wraper] auv2: creating clap bridge nm=" << clapname << " id=" << clapid
+              << " idx=" << idx << std::endl;
+  }
 
-    Clap::Library _library;
-
-    const clap_plugin_descriptor_t *_desc{nullptr};
-
-    ClapBridge(const std::string &clapname, const std::string &clapid, int idx)
-      : _clapname(clapname), _clapid(clapid), _idx(idx)
+  void initialize()
+  {
+    if (!_library.hasEntryPoint())
     {
-      std::cout << "[clap-wraper] auv2: creating clap bridge nm=" << clapname << " id=" << clapid
-                << " idx=" << idx << std::endl;
-    }
-
-    void initialize()
-    {
-      if (!_library.hasEntryPoint())
+      if (_clapname.empty())
       {
-        if (_clapname.empty())
-        {
-          std::cout << "[ERROR] _clapname (" << _clapname << ") empty and no internal entry point"
-                    << std::endl;
-        }
-        bool loaded{false};
-        auto csp = Clap::getValidCLAPSearchPaths();
-        for (auto &cs : csp)
-        {
-          if (fs::is_directory(cs / (_clapname + ".clap")))
-            if (_library.load(_clapname.c_str()))
-            {
-              std::cout << "[clap-wrapper] auv2 loaded clap from " << cs.u8string() << std::endl;
-              loaded = true;
-              break;
-            }
-        }
-        if (!loaded)
-        {
-          std::cout << "[ERROR] cannot load clap" << std::endl;
-          return;
-        }
+        std::cout << "[ERROR] _clapname (" << _clapname << ") empty and no internal entry point"
+                  << std::endl;
       }
-
-      if (_clapid.empty())
+      bool loaded{false};
+      auto csp = Clap::getValidCLAPSearchPaths();
+      for (auto &cs : csp)
       {
-        if (_idx < 0 || _idx >= _library.plugins.size())
-        {
-          std::cout << "[ERROR] cannot load by index" << std::endl;
-          return;
-        }
-        _desc = _library.plugins[_idx];
-      }
-      else
-      {
-        for (auto *d : _library.plugins)
-        {
-          if (strcmp(d->id, _clapid.c_str()) == 0)
+        if (fs::is_directory(cs / (_clapname + ".clap")))
+          if (_library.load(_clapname.c_str()))
           {
-            _desc = d;
+            std::cout << "[clap-wrapper] auv2 loaded clap from " << cs.u8string() << std::endl;
+            loaded = true;
+            break;
           }
-        }
       }
-
-      if (!_desc)
+      if (!loaded)
       {
-        std::cout << "[ERROR] cannot determine plugin description" << std::endl;
+        std::cout << "[ERROR] cannot load clap" << std::endl;
         return;
       }
-
-      std::cout << "[clap-wrapper] auv2: Initialized '" << _desc->id << "' / '" << _desc->name << "'"
-                << std::endl;
     }
-  };
+
+    if (_clapid.empty())
+    {
+      if (_idx < 0 || _idx >= _library.plugins.size())
+      {
+        std::cout << "[ERROR] cannot load by index" << std::endl;
+        return;
+      }
+      _desc = _library.plugins[_idx];
+    }
+    else
+    {
+      for (auto *d : _library.plugins)
+      {
+        if (strcmp(d->id, _clapid.c_str()) == 0)
+        {
+          _desc = d;
+        }
+      }
+    }
+
+    if (!_desc)
+    {
+      std::cout << "[ERROR] cannot determine plugin description" << std::endl;
+      return;
+    }
+
+    std::cout << "[clap-wrapper] auv2: Initialized '" << _desc->id << "' / '" << _desc->name << "'"
+              << std::endl;
+  }
+};
 }  // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/auv2_shared.h
+++ b/src/detail/auv2/auv2_shared.h
@@ -16,9 +16,11 @@ namespace free_audio::auv2_wrapper
 
     const clap_plugin_descriptor_t *_desc{nullptr};
 
-    ClapBridge(const std::string &clapname, const std::string &clapid, int idx) : _clapname(clapname), _clapid(clapid), _idx(idx)
+    ClapBridge(const std::string &clapname, const std::string &clapid, int idx)
+        : _clapname(clapname), _clapid(clapid), _idx(idx)
     {
-      std::cout << "[clap-wraper] auv2: creating clap bridge nm=" << clapname << " id=" << clapid << " idx=" << idx << std::endl;
+      std::cout << "[clap-wraper] auv2: creating clap bridge nm=" << clapname << " id=" << clapid
+                << " idx=" << idx << std::endl;
     }
 
     void initialize()
@@ -27,7 +29,8 @@ namespace free_audio::auv2_wrapper
       {
         if (_clapname.empty())
         {
-          std::cout << "[ERROR] _clapname (" << _clapname << ") empty and no internal entry point" << std::endl;
+          std::cout << "[ERROR] _clapname (" << _clapname << ") empty and no internal entry point"
+                    << std::endl;
         }
         bool loaded{false};
         auto csp = Clap::getValidCLAPSearchPaths();
@@ -74,7 +77,8 @@ namespace free_audio::auv2_wrapper
         return;
       }
 
-      std::cout << "[clap-wrapper] auv2: Initialized '" << _desc->id << "' / '" << _desc->name << "'" << std::endl;
+      std::cout << "[clap-wrapper] auv2: Initialized '" << _desc->id << "' / '" << _desc->name << "'"
+                << std::endl;
     }
   };
 }  // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -15,296 +15,294 @@ namespace fs = ghc::filesystem;
 
 struct auInfo
 {
-    std::string name, vers, type, subt, manu, manunm, clapid, desc, clapname;
+  std::string name, vers, type, subt, manu, manunm, clapid, desc, clapname;
 
-    const std::string factoryBase{"wrapAsAUV2_inst"};
+  const std::string factoryBase{"wrapAsAUV2_inst"};
 
-    void writePListFragment(std::ostream &of, int idx) const
+  void writePListFragment(std::ostream &of, int idx) const
+  {
+    if (!clapid.empty())
     {
-        if (!clapid.empty())
-        {
-            of << "      <!-- entry for id '" << clapid << "' / index " << idx << " -->\n";
-        }
-        else
-        {
-            of << "      <!-- entry for index " << idx << " clap id unknown -->\n";
-        }
-        of << "      <dict>\n"
-           << "        <key>name</key>\n"
-           << "        <string>" << manunm << ": " << name << "</string>\n"
-           << "        <key>description</key>\n"
-           << "        <string>" << desc << "</string>\n"
-           << "        <key>factoryFunction</key>\n"
-           << "        <string>" << factoryBase << idx << "Factory"
-           << "</string>\n"
-           << "        <key>manufacturer</key>\n"
-           << "        <string>" << manu << "</string>\n"
-           << "        <key>subtype</key>\n"
-           << "        <string>" << subt << "</string>\n"
-           << "        <key>type</key>\n"
-           << "        <string>" << type << "</string>\n"
-           << "        <key>version</key>\n"
-           << "        <integer>1</integer>\n"
-           << "        <key>sandboxSafe</key>\n"
-           << "        <true/>\n"
-           << "        <key>resourceUsage</key>\n"
-           << "        <dict>\n"
-           << "           <key>network.client</key>\n"
-           << "           <true/>\n"
-           << "           <key>temporary-exception.files.all.read-write</key>\n"
-           << "           <true/>\n"
-           << "        </dict>\n"
-           << "      </dict>\n";
+      of << "      <!-- entry for id '" << clapid << "' / index " << idx << " -->\n";
     }
+    else
+    {
+      of << "      <!-- entry for index " << idx << " clap id unknown -->\n";
+    }
+    of << "      <dict>\n"
+       << "        <key>name</key>\n"
+       << "        <string>" << manunm << ": " << name << "</string>\n"
+       << "        <key>description</key>\n"
+       << "        <string>" << desc << "</string>\n"
+       << "        <key>factoryFunction</key>\n"
+       << "        <string>" << factoryBase << idx << "Factory"
+       << "</string>\n"
+       << "        <key>manufacturer</key>\n"
+       << "        <string>" << manu << "</string>\n"
+       << "        <key>subtype</key>\n"
+       << "        <string>" << subt << "</string>\n"
+       << "        <key>type</key>\n"
+       << "        <string>" << type << "</string>\n"
+       << "        <key>version</key>\n"
+       << "        <integer>1</integer>\n"
+       << "        <key>sandboxSafe</key>\n"
+       << "        <true/>\n"
+       << "        <key>resourceUsage</key>\n"
+       << "        <dict>\n"
+       << "           <key>network.client</key>\n"
+       << "           <true/>\n"
+       << "           <key>temporary-exception.files.all.read-write</key>\n"
+       << "           <true/>\n"
+       << "        </dict>\n"
+       << "      </dict>\n";
+  }
 };
 
-bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname, std::string &manu, std::string &manuName, std::vector<auInfo> &units)
+bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname, std::string &manu,
+                        std::string &manuName, std::vector<auInfo> &units)
 {
-    Clap::Library loader;
-    if (!loader.load(clapfile.c_str()))
+  Clap::Library loader;
+  if (!loader.load(clapfile.c_str()))
+  {
+    std::cout << "[ERROR] library.load of clapfile failed" << std::endl;
+    return false;
+  }
+
+  int idx{0};
+
+  if (manu.empty() && loader._pluginFactoryAUv2Info == nullptr)
+  {
+    std::cout << "[ERROR] No manufacturer provider and no auv2 info available" << std::endl;
+    return false;
+  }
+
+  if (manu.empty())
+  {
+    manu = loader._pluginFactoryAUv2Info->manufacturer_code;
+    manuName = loader._pluginFactoryAUv2Info->manufacturer_name;
+    std::cout << "  - using factor manufacturer '" << manuName << "' (" << manu << ")" << std::endl;
+  }
+
+  static const char *encoder = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+  for (const auto *clapPlug : loader.plugins)
+  {
+    auto u = auInfo();
+    u.name = clapPlug->name;
+    u.clapname = clapname;
+    u.clapid = clapPlug->id;
+    u.vers = clapPlug->version;
+    u.desc = clapPlug->description;
+
+    static_assert(sizeof(size_t) == 8);
+    size_t idHash = std::hash<std::string>{}(clapPlug->id);
+    std::string stH;
+    // We have to make an ascii-representable 4 char string. Here's a way I guess.
+    for (int i = 0; i < 4; ++i)
     {
-        std::cout << "[ERROR] library.load of clapfile failed" << std::endl;
-        return false;
+      auto q = idHash & ((1 << 6) - 1);
+      stH += encoder[q];
+      idHash = idHash >> 9; // mix it up a bit
     }
 
-    int idx{0};
+    u.subt = stH;
+    u.manu = manu;
+    u.manunm = manuName;
 
-    if (manu.empty() && loader._pluginFactoryAUv2Info == nullptr)
+    auto f = clapPlug->features[0];
+    if (f == nullptr || strcmp(f, CLAP_PLUGIN_FEATURE_INSTRUMENT) == 0)
     {
-        std::cout << "[ERROR] No manufacturer provider and no auv2 info available" << std::endl;
-        return false;
+      u.type = "aumu";
+    }
+    else if (strcmp(f, CLAP_PLUGIN_FEATURE_AUDIO_EFFECT) == 0)
+    {
+      u.type = "aufx";
+    }
+    else if (strcmp(f, CLAP_PLUGIN_FEATURE_NOTE_EFFECT) == 0)
+    {
+      u.type = "aumi";
+    }
+    else
+    {
+      std::cout << "[WARNING] can't determine instrument type. Using aumu" << std::endl;
+      u.type = "aumu";
     }
 
-    if (manu.empty())
+    if (loader._pluginFactoryAUv2Info)
     {
-        manu = loader._pluginFactoryAUv2Info->manufacturer_code;
-        manuName = loader._pluginFactoryAUv2Info->manufacturer_name;
-        std::cout << "  - using factor manufacturer '" << manuName << "' (" << manu << ")" << std::endl;
+      clap_plugin_info_as_auv2_t v2inf;
+      auto res = loader._pluginFactoryAUv2Info->get_auv2_info(loader._pluginFactoryAUv2Info, idx, &v2inf);
+      if (v2inf.au_type[0] != 0)
+      {
+        u.type = v2inf.au_type;
+      }
+      if (v2inf.au_subt[0] != 0)
+      {
+        u.subt = v2inf.au_subt;
+      }
     }
 
-    static const char *encoder =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
-    for (const auto *clapPlug : loader.plugins)
-    {
-        auto u = auInfo();
-        u.name = clapPlug->name;
-        u.clapname = clapname;
-        u.clapid = clapPlug->id;
-        u.vers = clapPlug->version;
-        u.desc = clapPlug->description;
-
-        static_assert(sizeof(size_t) == 8);
-        size_t idHash = std::hash<std::string>{}(clapPlug->id);
-        std::string stH;
-        // We have to make an ascii-representable 4 char string. Here's a way I guess.
-        for (int i=0; i<4; ++i)
-        {
-            auto q = idHash & ((1 << 6) - 1);
-            stH += encoder[q];
-            idHash = idHash >> 9; // mix it up a bit
-        }
-
-        u.subt = stH;
-        u.manu = manu;
-        u.manunm = manuName;
-
-        auto f = clapPlug->features[0];
-        if (f == nullptr || strcmp(f, CLAP_PLUGIN_FEATURE_INSTRUMENT) == 0)
-        {
-            u.type = "aumu";
-        }
-        else if (strcmp(f, CLAP_PLUGIN_FEATURE_AUDIO_EFFECT) == 0)
-        {
-            u.type = "aufx";
-        }
-        else if (strcmp(f, CLAP_PLUGIN_FEATURE_NOTE_EFFECT) == 0)
-        {
-            u.type = "aumi";
-        }
-        else
-        {
-            std::cout << "[WARNING] can't determine instrument type. Using aumu" << std::endl;
-            u.type = "aumu";
-        }
-
-        if (loader._pluginFactoryAUv2Info)
-        {
-            clap_plugin_info_as_auv2_t v2inf;
-            auto res = loader._pluginFactoryAUv2Info->get_auv2_info(loader._pluginFactoryAUv2Info,
-                                                          idx,
-                                                         &v2inf);
-            if (v2inf.au_type[0] != 0)
-            {
-                u.type = v2inf.au_type;
-            }
-            if (v2inf.au_subt[0] != 0)
-            {
-                u.subt = v2inf.au_subt;
-            }
-        }
-
-        units.push_back(u);
-        idx++;
-    }
-    return true;
+    units.push_back(u);
+    idx++;
+  }
+  return true;
 }
 
 int main(int argc, char **argv)
 {
-    if (argc < 2)
-        return 1;
+  if (argc < 2)
+    return 1;
 
-    std::cout << "clap-wrapper: auv2 configuration tool starting\n";
+  std::cout << "clap-wrapper: auv2 configuration tool starting\n";
 
-    std::vector<auInfo> units;
-    if (std::string(argv[1]) == "--explicit")
+  std::vector<auInfo> units;
+  if (std::string(argv[1]) == "--explicit")
+  {
+    if (argc != 8)
     {
-        if (argc != 8)
-        {
-            std::cout << "[ERROR] Configuration incorrect. Got " << argc << " arguments in explicit" << std::endl;
-            return 5;
-        }
-        int idx = 2;
-        auInfo u;
-        u.name = std::string(argv[idx++]);
-        u.clapname = u.name;
-        u.vers = std::string(argv[idx++]);
-        u.type = std::string(argv[idx++]);
-        u.subt = std::string(argv[idx++]);
-        u.manu = std::string(argv[idx++]);
-        u.manunm = std::string(argv[idx++]);
-        u.desc = u.name + " CLAP to AU Wrapper";
-
-        std::cout << "  - single plugin explicit mode: " << u.name << " (" << u.type << "/" << u.subt << ")" << std::endl;
-        units.push_back(u);
+      std::cout << "[ERROR] Configuration incorrect. Got " << argc << " arguments in explicit" << std::endl;
+      return 5;
     }
-    else if (std::string(argv[1]) == "--fromclap")
+    int idx = 2;
+    auInfo u;
+    u.name = std::string(argv[idx++]);
+    u.clapname = u.name;
+    u.vers = std::string(argv[idx++]);
+    u.type = std::string(argv[idx++]);
+    u.subt = std::string(argv[idx++]);
+    u.manu = std::string(argv[idx++]);
+    u.manunm = std::string(argv[idx++]);
+    u.desc = u.name + " CLAP to AU Wrapper";
+
+    std::cout << "  - single plugin explicit mode: " << u.name << " (" << u.type << "/" << u.subt << ")" << std::endl;
+    units.push_back(u);
+  }
+  else if (std::string(argv[1]) == "--fromclap")
+  {
+    if (argc < 4)
     {
-        if (argc < 4)
-        {
-            std::cout << "[ERROR] Configuration incorrect. Got " << argc << " arguments in fromclap" << std::endl;
-            return 6;
-        }
-        int idx = 2;
-        auto clapname = std::string(argv[idx++]);
-        auto clapfile = std::string(argv[idx++]);
-        auto mcode = (idx < argc) ? std::string(argv[idx++]) : std::string();
-        auto mname = (idx < argc) ? std::string(argv[idx++]) : std::string();
-
-        try {
-            auto p = fs::path{clapfile};
-            // This is a hack for now - we get to the dll
-            p = p.parent_path().parent_path().parent_path();
-            clapfile = p.u8string();
-        }
-        catch (const fs::filesystem_error &e)
-        {
-            std::cout << "[ERROR] cant get path " << e.what() << std::endl;
-            return 3;
-        }
-
-        std::cout << "  - building information from CLAP directly\n"
-                  << "  - source clap: '" << clapfile << "'" << std::endl;
-
-        if (!buildUnitsFromClap(clapfile, clapname, mcode, mname, units))
-        {
-            std::cout << "[ERROR] Can't build units from CLAP" << std::endl;
-            return 4;
-        }
-
-        if (units.empty())
-        {
-            std::cout << "[ERROR] No units from clap file\n";
-            return 5;
-        }
-
-        std::cout << "  - clap file produced " << units.size() << " units" << std::endl;
-
+      std::cout << "[ERROR] Configuration incorrect. Got " << argc << " arguments in fromclap" << std::endl;
+      return 6;
     }
-    else
+    int idx = 2;
+    auto clapname = std::string(argv[idx++]);
+    auto clapfile = std::string(argv[idx++]);
+    auto mcode = (idx < argc) ? std::string(argv[idx++]) : std::string();
+    auto mname = (idx < argc) ? std::string(argv[idx++]) : std::string();
+
+    try
     {
-        std::cout << "[ERROR] Unknown Mode : " << argv[1] << std::endl;
-        return 2;
+      auto p = fs::path{clapfile};
+      // This is a hack for now - we get to the dll
+      p = p.parent_path().parent_path().parent_path();
+      clapfile = p.u8string();
+    }
+    catch (const fs::filesystem_error &e)
+    {
+      std::cout << "[ERROR] cant get path " << e.what() << std::endl;
+      return 3;
     }
 
-    std::cout << "  - generating auv2_Info.plist from auv2_infoplist_top" << std::endl;
-    std::ifstream intop("auv2_infoplist_top");
-    if (!intop.is_open())
+    std::cout << "  - building information from CLAP directly\n"
+              << "  - source clap: '" << clapfile << "'" << std::endl;
+
+    if (!buildUnitsFromClap(clapfile, clapname, mcode, mname, units))
     {
-        std::cerr << "[ERROR] Unable to open pre-generated file auv2_infoplist_top" << std::endl;
-        return 1;
+      std::cout << "[ERROR] Can't build units from CLAP" << std::endl;
+      return 4;
     }
 
-    std::ofstream of("auv2_Info.plist");
-    if (!of.is_open())
+    if (units.empty())
     {
-        std::cerr << "[ERROR] Unable to open output file auv2_Info.plist" << std::endl;
-    }
-    of << intop.rdbuf();
-
-    of << "    <key>AudioComponents</key>\n    <array>\n";
-    int idx{0};
-    for (const auto &u : units)
-    {
-        std::cout << "    + " << u.name << " (" << u.type << "/" << u.subt << ") by " << u.manunm
-                  << " (" << u.manu << ")" << std::endl;
-        u.writePListFragment(of, idx++);
-    }
-    of << "    </array>\n";
-    of << "  </dict>\n</plist>\n";
-    of.close();
-    std::cout << "  - auv2_Info.plist generated" << std::endl;
-
-    std::cout << "  - generating generated_entrypoints.hxx" << std::endl;
-    std::ofstream cppf("generated_entrypoints.hxx");
-    if (!cppf.is_open())
-    {
-        std::cout << "[ERROR] Unable to open generated_endpoints.hxx" << std::endl;
-        return 1;
+      std::cout << "[ERROR] No units from clap file\n";
+      return 5;
     }
 
-    cppf << "#pragma once\n";
-    cppf << "#include \"detail/auv2/auv2_base_classes.h\"\n\n";
+    std::cout << "  - clap file produced " << units.size() << " units" << std::endl;
+  }
+  else
+  {
+    std::cout << "[ERROR] Unknown Mode : " << argv[1] << std::endl;
+    return 2;
+  }
 
-    idx = 0;
-    for (const auto &u : units)
+  std::cout << "  - generating auv2_Info.plist from auv2_infoplist_top" << std::endl;
+  std::ifstream intop("auv2_infoplist_top");
+  if (!intop.is_open())
+  {
+    std::cerr << "[ERROR] Unable to open pre-generated file auv2_infoplist_top" << std::endl;
+    return 1;
+  }
+
+  std::ofstream of("auv2_Info.plist");
+  if (!of.is_open())
+  {
+    std::cerr << "[ERROR] Unable to open output file auv2_Info.plist" << std::endl;
+  }
+  of << intop.rdbuf();
+
+  of << "    <key>AudioComponents</key>\n    <array>\n";
+  int idx{0};
+  for (const auto &u : units)
+  {
+    std::cout << "    + " << u.name << " (" << u.type << "/" << u.subt << ") by " << u.manunm << " (" << u.manu << ")"
+              << std::endl;
+    u.writePListFragment(of, idx++);
+  }
+  of << "    </array>\n";
+  of << "  </dict>\n</plist>\n";
+  of.close();
+  std::cout << "  - auv2_Info.plist generated" << std::endl;
+
+  std::cout << "  - generating generated_entrypoints.hxx" << std::endl;
+  std::ofstream cppf("generated_entrypoints.hxx");
+  if (!cppf.is_open())
+  {
+    std::cout << "[ERROR] Unable to open generated_endpoints.hxx" << std::endl;
+    return 1;
+  }
+
+  cppf << "#pragma once\n";
+  cppf << "#include \"detail/auv2/auv2_base_classes.h\"\n\n";
+
+  idx = 0;
+  for (const auto &u : units)
+  {
+    auto on = u.factoryBase + std::to_string(idx);
+
+    auto args = std::string("\"") + u.clapname + "\", \"" + u.clapid + "\", " + std::to_string(idx);
+
+    if (u.type == "aumu")
     {
-        auto on = u.factoryBase + std::to_string(idx);
-
-        auto args = std::string("\"") + u.clapname + "\", \"" + u.clapid + "\", " + std::to_string(idx);
-
-        if (u.type == "aumu")
-        {
-            std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_Instrument" << std::endl;
-            cppf << "struct " << on << " : free_audio::auv2_wrapper::ClapWrapper_AUV2_Instrument {\n"
-                 << "   " << on << "(AudioComponentInstance ci) :\n"
-                 << "         free_audio::auv2_wrapper::ClapWrapper_AUV2_Instrument(" << args << ", ci) {}"
-                 << "};\n"
-                 << "AUSDK_COMPONENT_ENTRY(ausdk::AUMusicDeviceFactory, " << on << ");\n";
-        }
-        else if (u.type == "aumi")
-        {
-            std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_NoteEffect" << std::endl;
-            cppf << "struct " << on << " : free_audio::auv2_wrapper::ClapWrapper_AUV2_NoteEffect {\n"
-                 << "   " << on << "(AudioComponentInstance ci) :\n"
-                 << "         free_audio::auv2_wrapper::ClapWrapper_AUV2_NoteEffect(" << args << ", ci) {}"
-                 << "};\n"
-                 << "AUSDK_COMPONENT_ENTRY(ausdk::AUBaseFactory , " << on << ");\n";
-        }
-        else if (u.type == "aufx")
-        {
-            std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_Effect" << std::endl;
-            cppf << "struct " << on << " : free_audio::auv2_wrapper::ClapWrapper_AUV2_Effect {\n"
-                 << "   " << on << "(AudioComponentInstance ci) :\n"
-                 << "         free_audio::auv2_wrapper::ClapWrapper_AUV2_Effect(" << args << ", ci) {}"
-                 << "};\n"
-                 << "AUSDK_COMPONENT_ENTRY(ausdk::AUBaseFactory, " << on << ");\n";
-        }
-
-        idx++;
+      std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_Instrument" << std::endl;
+      cppf << "struct " << on << " : free_audio::auv2_wrapper::ClapWrapper_AUV2_Instrument {\n"
+           << "   " << on << "(AudioComponentInstance ci) :\n"
+           << "         free_audio::auv2_wrapper::ClapWrapper_AUV2_Instrument(" << args << ", ci) {}"
+           << "};\n"
+           << "AUSDK_COMPONENT_ENTRY(ausdk::AUMusicDeviceFactory, " << on << ");\n";
     }
-    cppf.close();
-    std::cout << "  - generated_entrypoints.hxx generated" << std::endl;
+    else if (u.type == "aumi")
+    {
+      std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_NoteEffect" << std::endl;
+      cppf << "struct " << on << " : free_audio::auv2_wrapper::ClapWrapper_AUV2_NoteEffect {\n"
+           << "   " << on << "(AudioComponentInstance ci) :\n"
+           << "         free_audio::auv2_wrapper::ClapWrapper_AUV2_NoteEffect(" << args << ", ci) {}"
+           << "};\n"
+           << "AUSDK_COMPONENT_ENTRY(ausdk::AUBaseFactory , " << on << ");\n";
+    }
+    else if (u.type == "aufx")
+    {
+      std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_Effect" << std::endl;
+      cppf << "struct " << on << " : free_audio::auv2_wrapper::ClapWrapper_AUV2_Effect {\n"
+           << "   " << on << "(AudioComponentInstance ci) :\n"
+           << "         free_audio::auv2_wrapper::ClapWrapper_AUV2_Effect(" << args << ", ci) {}"
+           << "};\n"
+           << "AUSDK_COMPONENT_ENTRY(ausdk::AUBaseFactory, " << on << ");\n";
+    }
 
-    return 0;
+    idx++;
+  }
+  cppf.close();
+  std::cout << "  - generated_entrypoints.hxx generated" << std::endl;
+
+  return 0;
 }

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -58,8 +58,7 @@ struct auInfo
   }
 };
 
-bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname, std::string &manu,
-                        std::string &manuName, std::vector<auInfo> &units)
+bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname, std::string &manu, std::string &manuName, std::vector<auInfo> &units)
 {
   Clap::Library loader;
   if (!loader.load(clapfile.c_str()))
@@ -101,7 +100,7 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
     {
       auto q = idHash & ((1 << 6) - 1);
       stH += encoder[q];
-      idHash = idHash >> 9; // mix it up a bit
+      idHash = idHash >> 9;  // mix it up a bit
     }
 
     u.subt = stH;
@@ -149,8 +148,7 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
 
 int main(int argc, char **argv)
 {
-  if (argc < 2)
-    return 1;
+  if (argc < 2) return 1;
 
   std::cout << "clap-wrapper: auv2 configuration tool starting\n";
 
@@ -244,8 +242,7 @@ int main(int argc, char **argv)
   int idx{0};
   for (const auto &u : units)
   {
-    std::cout << "    + " << u.name << " (" << u.type << "/" << u.subt << ") by " << u.manunm << " (" << u.manu << ")"
-              << std::endl;
+    std::cout << "    + " << u.name << " (" << u.type << "/" << u.subt << ") by " << u.manunm << " (" << u.manu << ")" << std::endl;
     u.writePListFragment(of, idx++);
   }
   of << "    </array>\n";

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -58,7 +58,8 @@ struct auInfo
   }
 };
 
-bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname, std::string &manu, std::string &manuName, std::vector<auInfo> &units)
+bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname, std::string &manu,
+                        std::string &manuName, std::vector<auInfo> &units)
 {
   Clap::Library loader;
   if (!loader.load(clapfile.c_str()))
@@ -129,7 +130,8 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
     if (loader._pluginFactoryAUv2Info)
     {
       clap_plugin_info_as_auv2_t v2inf;
-      auto res = loader._pluginFactoryAUv2Info->get_auv2_info(loader._pluginFactoryAUv2Info, idx, &v2inf);
+      auto res =
+          loader._pluginFactoryAUv2Info->get_auv2_info(loader._pluginFactoryAUv2Info, idx, &v2inf);
       if (v2inf.au_type[0] != 0)
       {
         u.type = v2inf.au_type;
@@ -157,7 +159,8 @@ int main(int argc, char **argv)
   {
     if (argc != 8)
     {
-      std::cout << "[ERROR] Configuration incorrect. Got " << argc << " arguments in explicit" << std::endl;
+      std::cout << "[ERROR] Configuration incorrect. Got " << argc << " arguments in explicit"
+                << std::endl;
       return 5;
     }
     int idx = 2;
@@ -171,14 +174,16 @@ int main(int argc, char **argv)
     u.manunm = std::string(argv[idx++]);
     u.desc = u.name + " CLAP to AU Wrapper";
 
-    std::cout << "  - single plugin explicit mode: " << u.name << " (" << u.type << "/" << u.subt << ")" << std::endl;
+    std::cout << "  - single plugin explicit mode: " << u.name << " (" << u.type << "/" << u.subt << ")"
+              << std::endl;
     units.push_back(u);
   }
   else if (std::string(argv[1]) == "--fromclap")
   {
     if (argc < 4)
     {
-      std::cout << "[ERROR] Configuration incorrect. Got " << argc << " arguments in fromclap" << std::endl;
+      std::cout << "[ERROR] Configuration incorrect. Got " << argc << " arguments in fromclap"
+                << std::endl;
       return 6;
     }
     int idx = 2;
@@ -242,7 +247,8 @@ int main(int argc, char **argv)
   int idx{0};
   for (const auto &u : units)
   {
-    std::cout << "    + " << u.name << " (" << u.type << "/" << u.subt << ") by " << u.manunm << " (" << u.manu << ")" << std::endl;
+    std::cout << "    + " << u.name << " (" << u.type << "/" << u.subt << ") by " << u.manunm << " ("
+              << u.manu << ")" << std::endl;
     u.writePListFragment(of, idx++);
   }
   of << "    </array>\n";
@@ -270,7 +276,8 @@ int main(int argc, char **argv)
 
     if (u.type == "aumu")
     {
-      std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_Instrument" << std::endl;
+      std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_Instrument"
+                << std::endl;
       cppf << "struct " << on << " : free_audio::auv2_wrapper::ClapWrapper_AUV2_Instrument {\n"
            << "   " << on << "(AudioComponentInstance ci) :\n"
            << "         free_audio::auv2_wrapper::ClapWrapper_AUV2_Instrument(" << args << ", ci) {}"
@@ -279,7 +286,8 @@ int main(int argc, char **argv)
     }
     else if (u.type == "aumi")
     {
-      std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_NoteEffect" << std::endl;
+      std::cout << "    + " << u.name << " entry " << on << " from ClapWrapper_AUV2_NoteEffect"
+                << std::endl;
       cppf << "struct " << on << " : free_audio::auv2_wrapper::ClapWrapper_AUV2_NoteEffect {\n"
            << "   " << on << "(AudioComponentInstance ci) :\n"
            << "         free_audio::auv2_wrapper::ClapWrapper_AUV2_NoteEffect(" << args << ", ci) {}"

--- a/src/detail/clap/automation.h
+++ b/src/detail/clap/automation.h
@@ -6,10 +6,10 @@ namespace Clap
 {
   class IAutomation
   {
-  public:
+   public:
     virtual void onBeginEdit(clap_id id) = 0;
-    virtual void onPerformEdit(const clap_event_param_value_t *value) = 0;
+    virtual void onPerformEdit(const clap_event_param_value_t* value) = 0;
     virtual void onEndEdit(clap_id id) = 0;
     virtual ~IAutomation() {}
   };
-} // namespace Clap
+}  // namespace Clap

--- a/src/detail/clap/automation.h
+++ b/src/detail/clap/automation.h
@@ -4,12 +4,12 @@
 
 namespace Clap
 {
-	class IAutomation
-	{
-	public:
-		virtual void onBeginEdit(clap_id id) = 0;
-		virtual void onPerformEdit(const clap_event_param_value_t* value) = 0;
-		virtual void onEndEdit(clap_id id) = 0;
-		virtual ~IAutomation() {}
-	};
-}
+  class IAutomation
+  {
+  public:
+    virtual void onBeginEdit(clap_id id) = 0;
+    virtual void onPerformEdit(const clap_event_param_value_t *value) = 0;
+    virtual void onEndEdit(clap_id id) = 0;
+    virtual ~IAutomation() {}
+  };
+} // namespace Clap

--- a/src/detail/clap/automation.h
+++ b/src/detail/clap/automation.h
@@ -4,14 +4,14 @@
 
 namespace Clap
 {
-  class IAutomation
+class IAutomation
+{
+ public:
+  virtual void onBeginEdit(clap_id id) = 0;
+  virtual void onPerformEdit(const clap_event_param_value_t* value) = 0;
+  virtual void onEndEdit(clap_id id) = 0;
+  virtual ~IAutomation()
   {
-   public:
-    virtual void onBeginEdit(clap_id id) = 0;
-    virtual void onPerformEdit(const clap_event_param_value_t* value) = 0;
-    virtual void onEndEdit(clap_id id) = 0;
-    virtual ~IAutomation()
-    {
-    }
-  };
+  }
+};
 }  // namespace Clap

--- a/src/detail/clap/automation.h
+++ b/src/detail/clap/automation.h
@@ -10,6 +10,8 @@ namespace Clap
     virtual void onBeginEdit(clap_id id) = 0;
     virtual void onPerformEdit(const clap_event_param_value_t* value) = 0;
     virtual void onEndEdit(clap_id id) = 0;
-    virtual ~IAutomation() {}
+    virtual ~IAutomation()
+    {
+    }
   };
 }  // namespace Clap

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -101,7 +101,8 @@ namespace Clap
 #if MAC
     _pluginEntry = nullptr;
 
-    auto cs = CFStringCreateWithBytes(kCFAllocatorDefault, (uint8_t *)name, strlen(name), kCFStringEncodingUTF8, false);
+    auto cs = CFStringCreateWithBytes(kCFAllocatorDefault, (uint8_t *)name, strlen(name),
+                                      kCFStringEncodingUTF8, false);
     auto bundleURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, cs, kCFURLPOSIXPathStyle, true);
 
     _bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
@@ -190,9 +191,12 @@ namespace Clap
     {
       if (_pluginEntry->init(path))
       {
-        _pluginFactory = static_cast<const clap_plugin_factory *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_ID));
-        _pluginFactoryVst3Info = static_cast<const clap_plugin_factory_as_vst3 *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_VST3));
-        _pluginFactoryAUv2Info = static_cast<const clap_plugin_factory_as_auv2 *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_AUV2));
+        _pluginFactory =
+            static_cast<const clap_plugin_factory *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_ID));
+        _pluginFactoryVst3Info = static_cast<const clap_plugin_factory_as_vst3 *>(
+            _pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_VST3));
+        _pluginFactoryAUv2Info = static_cast<const clap_plugin_factory_as_auv2 *>(
+            _pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_AUV2));
 
         // detect plugins that do not check the CLAP_PLUGIN_FACTORY_ID
         if ((void *)_pluginFactory == (void *)_pluginFactoryVst3Info)
@@ -272,7 +276,8 @@ namespace Clap
     if (!selfp.empty())
     {
       std::string name = selfp.u8string();
-      CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(), name.size(), true);
+      CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(
+          0, (const unsigned char *)name.c_str(), name.size(), true);
       if (bundleUrl)
       {
         auto pluginBundle = CFBundleCreate(0, bundleUrl);

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -27,312 +27,312 @@
 namespace Clap
 {
 #if WIN
-  std::string getEnvVariable(const char *varname)
-  {
-    char *val;
-    size_t len;
-    auto err = _dupenv_s(&val, &len, varname);
-    if (err) return std::string();
-    if (val == nullptr) return std::string();
-    std::string result(val);
-    free(val);
-    return result;
-  }
+std::string getEnvVariable(const char *varname)
+{
+  char *val;
+  size_t len;
+  auto err = _dupenv_s(&val, &len, varname);
+  if (err) return std::string();
+  if (val == nullptr) return std::string();
+  std::string result(val);
+  free(val);
+  return result;
+}
 #endif
 
-  std::vector<fs::path> getValidCLAPSearchPaths()
-  {
-    std::vector<fs::path> res;
+std::vector<fs::path> getValidCLAPSearchPaths()
+{
+  std::vector<fs::path> res;
 
 #if MAC
-    extern std::vector<fs::path> getMacCLAPSearchPaths();
-    res = getMacCLAPSearchPaths();
-    // getSystemPaths(res);
+  extern std::vector<fs::path> getMacCLAPSearchPaths();
+  res = getMacCLAPSearchPaths();
+  // getSystemPaths(res);
 #endif
 
 #if LIN
-    res.emplace_back("/usr/lib/clap");
-    res.emplace_back(fs::path(getenv("HOME")) / fs::path(".clap"));
+  res.emplace_back("/usr/lib/clap");
+  res.emplace_back(fs::path(getenv("HOME")) / fs::path(".clap"));
 #endif
 
 #if WIN
+  {
+    // I think this should use SHGetKnownFilderLocation but I don't know windows well enough
+    auto p = getEnvVariable("COMMONPROGRAMFILES");
+    if (!p.empty())
     {
-      // I think this should use SHGetKnownFilderLocation but I don't know windows well enough
-      auto p = getEnvVariable("COMMONPROGRAMFILES");
-      if (!p.empty())
-      {
-        res.emplace_back(fs::path{p} / "CLAP");
-      }
-      auto q = getEnvVariable("LOCALAPPDATA");
-      if (!q.empty())
-      {
-        res.emplace_back(fs::path{q} / "Programs" / "Common" / "CLAP");
-      }
+      res.emplace_back(fs::path{p} / "CLAP");
     }
-    auto cp = getEnvVariable("CLAP_PATH");
-    auto sep = ';';
+    auto q = getEnvVariable("LOCALAPPDATA");
+    if (!q.empty())
+    {
+      res.emplace_back(fs::path{q} / "Programs" / "Common" / "CLAP");
+    }
+  }
+  auto cp = getEnvVariable("CLAP_PATH");
+  auto sep = ';';
 #else
-    std::string cp;
-    auto p = getenv("CLAP_PATH");
-    if (p)
-    {
-      cp = std::string(p);
-    }
-    auto sep = ':';
+  std::string cp;
+  auto p = getenv("CLAP_PATH");
+  if (p)
+  {
+    cp = std::string(p);
+  }
+  auto sep = ':';
 #endif
 
-    if (cp.empty())
+  if (cp.empty())
+  {
+    size_t pos;
+    while ((pos = cp.find(sep)) != std::string::npos)
     {
-      size_t pos;
-      while ((pos = cp.find(sep)) != std::string::npos)
-      {
-        auto item = cp.substr(0, pos);
-        cp = cp.substr(pos + 1);
-        res.emplace_back(fs::path{item});
-      }
-      if (cp.size()) res.emplace_back(fs::path{cp});
+      auto item = cp.substr(0, pos);
+      cp = cp.substr(pos + 1);
+      res.emplace_back(fs::path{item});
     }
-
-    return res;
+    if (cp.size()) res.emplace_back(fs::path{cp});
   }
 
-  bool Library::load(const char *name)
-  {
+  return res;
+}
+
+bool Library::load(const char *name)
+{
 #if MAC
-    _pluginEntry = nullptr;
+  _pluginEntry = nullptr;
 
-    auto cs = CFStringCreateWithBytes(kCFAllocatorDefault, (uint8_t *)name, strlen(name),
-                                      kCFStringEncodingUTF8, false);
-    auto bundleURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, cs, kCFURLPOSIXPathStyle, true);
+  auto cs = CFStringCreateWithBytes(kCFAllocatorDefault, (uint8_t *)name, strlen(name),
+                                    kCFStringEncodingUTF8, false);
+  auto bundleURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, cs, kCFURLPOSIXPathStyle, true);
 
-    _bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
-    CFRelease(bundleURL);
-    CFRelease(cs);
+  _bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
+  CFRelease(bundleURL);
+  CFRelease(cs);
 
-    if (!_bundle)
-    {
-      return false;
-    }
+  if (!_bundle)
+  {
+    return false;
+  }
 
-    auto db = CFBundleGetDataPointerForName(_bundle, CFSTR("clap_entry"));
+  auto db = CFBundleGetDataPointerForName(_bundle, CFSTR("clap_entry"));
 
-    _pluginEntry = (const clap_plugin_entry *)db;
+  _pluginEntry = (const clap_plugin_entry *)db;
 
-    setupPluginsFromPluginEntry(name);
-    return _pluginEntry != nullptr;
+  setupPluginsFromPluginEntry(name);
+  return _pluginEntry != nullptr;
 #endif
 
 #if WIN
-    if (_handle && !_selfcontained)
-    {
-      if (_pluginEntry)
-      {
-        _pluginEntry->deinit();
-      }
-      FreeLibrary(_handle);
-    }
-    _handle = 0;
-    _pluginEntry = nullptr;
-    _handle = LoadLibraryA(name);
-    if (_handle)
-    {
-      if (!getEntryFunction(_handle, name))
-      {
-        FreeLibrary(_handle);
-        _handle = NULL;
-      }
-    }
-
-    return _handle != 0;
-#endif
-
-#if LIN
-    int *iptr;
-
-    _handle = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
-    if (!_handle) return false;
-
-    iptr = (int *)dlsym(_handle, "clap_entry");
-    if (!iptr) return false;
-
-    _pluginEntry = (const clap_plugin_entry_t *)iptr;
-    setupPluginsFromPluginEntry(name);
-    return true;
-#endif
-  }
-
-  const clap_plugin_info_as_vst3_t *Library::get_vst3_info(uint32_t index)
-  {
-    if (_pluginFactoryVst3Info && _pluginFactoryVst3Info->get_vst3_info)
-    {
-      return _pluginFactoryVst3Info->get_vst3_info(_pluginFactoryVst3Info, index);
-    }
-    return nullptr;
-  }
-
-#if WIN
-  bool Library::getEntryFunction(HMODULE handle, const char *path)
-  {
-    if (handle)
-    {
-      _pluginEntry = reinterpret_cast<const clap_plugin_entry *>(GetProcAddress(handle, "clap_entry"));
-      if (_pluginEntry)
-      {
-        setupPluginsFromPluginEntry(path);
-      }
-    }
-    return (_pluginEntry && !plugins.empty());
-  }
-#endif
-
-  void Library::setupPluginsFromPluginEntry(const char *path)
-  {
-    if (clap_version_is_compatible(_pluginEntry->clap_version))
-    {
-      if (_pluginEntry->init(path))
-      {
-        _pluginFactory =
-            static_cast<const clap_plugin_factory *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_ID));
-        _pluginFactoryVst3Info = static_cast<const clap_plugin_factory_as_vst3 *>(
-            _pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_VST3));
-        _pluginFactoryAUv2Info = static_cast<const clap_plugin_factory_as_auv2 *>(
-            _pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_AUV2));
-
-        // detect plugins that do not check the CLAP_PLUGIN_FACTORY_ID
-        if ((void *)_pluginFactory == (void *)_pluginFactoryVst3Info)
-        {
-          _pluginFactoryVst3Info = nullptr;
-          _pluginFactoryAUv2Info = nullptr;
-        }
-
-        auto count = _pluginFactory->get_plugin_count(_pluginFactory);
-
-        for (decltype(count) i = 0; i < count; ++i)
-        {
-          auto desc = _pluginFactory->get_plugin_descriptor(_pluginFactory, i);
-          if (clap_version_is_compatible(desc->clap_version))
-          {
-            plugins.push_back(desc);
-          }
-          else
-          {
-            // incompatible
-          }
-        }
-      }
-    }
-  }
-
-#if WIN || LIN
-  // This is a small stub to resolve the self dll. MacOs uses a different approach
-  // in sharedLibraryBundlePath
-  static void ffeomwe()
-  {
-  }
-#endif
-
-  Library::Library()
-  {
-#if WIN
-    static TCHAR modulename[2048];
-    HMODULE selfmodule;
-    if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)ffeomwe, &selfmodule))
-    {
-      auto size = GetModuleFileName(selfmodule, modulename, 2048);
-      (void)size;
-    }
-    if (selfmodule)
-    {
-      if (this->getEntryFunction(selfmodule, (const char *)modulename))
-      {
-        _selfcontained = true;
-      }
-    }
-#endif
-
-#if LIN
-    Dl_info info;
-    if (dladdr(reinterpret_cast<const void *>(&ffeomwe), &info) && info.dli_fname[0])
-    {
-      auto lhandle = dlopen(info.dli_fname, RTLD_LOCAL | RTLD_LAZY);
-      if (lhandle)
-      {
-        auto liptr = (int *)dlsym(_handle, "clap_entry");
-        if (liptr)
-        {
-          _handle = lhandle;  // as a result the Library dtor will dlclose me
-          _pluginEntry = (const clap_plugin_entry_t *)liptr;
-          _selfcontained = true;
-
-          setupPluginsFromPluginEntry(info.dli_fname);
-        }
-      }
-    }
-#endif
-
-#if MAC
-    extern fs::path sharedLibraryBundlePath();
-    auto selfp = sharedLibraryBundlePath();
-    if (!selfp.empty())
-    {
-      std::string name = selfp.u8string();
-      CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(
-          0, (const unsigned char *)name.c_str(), name.size(), true);
-      if (bundleUrl)
-      {
-        auto pluginBundle = CFBundleCreate(0, bundleUrl);
-        CFRelease(bundleUrl);
-
-        if (pluginBundle)
-        {
-          auto db = CFBundleGetDataPointerForName(pluginBundle, CFSTR("clap_entry"));
-          if (db)
-          {
-            _bundle = pluginBundle;
-            _pluginEntry = (const clap_plugin_entry_t *)db;
-            _selfcontained = true;
-
-            setupPluginsFromPluginEntry(selfp.u8string().c_str());
-          }
-          else
-          {
-            CFRelease(pluginBundle);
-          }
-        }
-      }
-    }
-#endif
-  }
-
-  Library::~Library()
+  if (_handle && !_selfcontained)
   {
     if (_pluginEntry)
     {
       _pluginEntry->deinit();
     }
-#if MAC
-    // FIXME keep the bundle ref and free it here
-    if (_bundle)
+    FreeLibrary(_handle);
+  }
+  _handle = 0;
+  _pluginEntry = nullptr;
+  _handle = LoadLibraryA(name);
+  if (_handle)
+  {
+    if (!getEntryFunction(_handle, name))
     {
-      CFRelease(_bundle);
-      _bundle = nullptr;
+      FreeLibrary(_handle);
+      _handle = NULL;
     }
+  }
+
+  return _handle != 0;
 #endif
 
 #if LIN
-    if (_handle)
+  int *iptr;
+
+  _handle = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
+  if (!_handle) return false;
+
+  iptr = (int *)dlsym(_handle, "clap_entry");
+  if (!iptr) return false;
+
+  _pluginEntry = (const clap_plugin_entry_t *)iptr;
+  setupPluginsFromPluginEntry(name);
+  return true;
+#endif
+}
+
+const clap_plugin_info_as_vst3_t *Library::get_vst3_info(uint32_t index)
+{
+  if (_pluginFactoryVst3Info && _pluginFactoryVst3Info->get_vst3_info)
+  {
+    return _pluginFactoryVst3Info->get_vst3_info(_pluginFactoryVst3Info, index);
+  }
+  return nullptr;
+}
+
+#if WIN
+bool Library::getEntryFunction(HMODULE handle, const char *path)
+{
+  if (handle)
+  {
+    _pluginEntry = reinterpret_cast<const clap_plugin_entry *>(GetProcAddress(handle, "clap_entry"));
+    if (_pluginEntry)
     {
-      dlclose(_handle);
-      _handle = nullptr;
+      setupPluginsFromPluginEntry(path);
     }
+  }
+  return (_pluginEntry && !plugins.empty());
+}
+#endif
+
+void Library::setupPluginsFromPluginEntry(const char *path)
+{
+  if (clap_version_is_compatible(_pluginEntry->clap_version))
+  {
+    if (_pluginEntry->init(path))
+    {
+      _pluginFactory =
+          static_cast<const clap_plugin_factory *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_ID));
+      _pluginFactoryVst3Info = static_cast<const clap_plugin_factory_as_vst3 *>(
+          _pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_VST3));
+      _pluginFactoryAUv2Info = static_cast<const clap_plugin_factory_as_auv2 *>(
+          _pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_AUV2));
+
+      // detect plugins that do not check the CLAP_PLUGIN_FACTORY_ID
+      if ((void *)_pluginFactory == (void *)_pluginFactoryVst3Info)
+      {
+        _pluginFactoryVst3Info = nullptr;
+        _pluginFactoryAUv2Info = nullptr;
+      }
+
+      auto count = _pluginFactory->get_plugin_count(_pluginFactory);
+
+      for (decltype(count) i = 0; i < count; ++i)
+      {
+        auto desc = _pluginFactory->get_plugin_descriptor(_pluginFactory, i);
+        if (clap_version_is_compatible(desc->clap_version))
+        {
+          plugins.push_back(desc);
+        }
+        else
+        {
+          // incompatible
+        }
+      }
+    }
+  }
+}
+
+#if WIN || LIN
+// This is a small stub to resolve the self dll. MacOs uses a different approach
+// in sharedLibraryBundlePath
+static void ffeomwe()
+{
+}
+#endif
+
+Library::Library()
+{
+#if WIN
+  static TCHAR modulename[2048];
+  HMODULE selfmodule;
+  if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)ffeomwe, &selfmodule))
+  {
+    auto size = GetModuleFileName(selfmodule, modulename, 2048);
+    (void)size;
+  }
+  if (selfmodule)
+  {
+    if (this->getEntryFunction(selfmodule, (const char *)modulename))
+    {
+      _selfcontained = true;
+    }
+  }
+#endif
+
+#if LIN
+  Dl_info info;
+  if (dladdr(reinterpret_cast<const void *>(&ffeomwe), &info) && info.dli_fname[0])
+  {
+    auto lhandle = dlopen(info.dli_fname, RTLD_LOCAL | RTLD_LAZY);
+    if (lhandle)
+    {
+      auto liptr = (int *)dlsym(_handle, "clap_entry");
+      if (liptr)
+      {
+        _handle = lhandle;  // as a result the Library dtor will dlclose me
+        _pluginEntry = (const clap_plugin_entry_t *)liptr;
+        _selfcontained = true;
+
+        setupPluginsFromPluginEntry(info.dli_fname);
+      }
+    }
+  }
+#endif
+
+#if MAC
+  extern fs::path sharedLibraryBundlePath();
+  auto selfp = sharedLibraryBundlePath();
+  if (!selfp.empty())
+  {
+    std::string name = selfp.u8string();
+    CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(),
+                                                                 name.size(), true);
+    if (bundleUrl)
+    {
+      auto pluginBundle = CFBundleCreate(0, bundleUrl);
+      CFRelease(bundleUrl);
+
+      if (pluginBundle)
+      {
+        auto db = CFBundleGetDataPointerForName(pluginBundle, CFSTR("clap_entry"));
+        if (db)
+        {
+          _bundle = pluginBundle;
+          _pluginEntry = (const clap_plugin_entry_t *)db;
+          _selfcontained = true;
+
+          setupPluginsFromPluginEntry(selfp.u8string().c_str());
+        }
+        else
+        {
+          CFRelease(pluginBundle);
+        }
+      }
+    }
+  }
+#endif
+}
+
+Library::~Library()
+{
+  if (_pluginEntry)
+  {
+    _pluginEntry->deinit();
+  }
+#if MAC
+  // FIXME keep the bundle ref and free it here
+  if (_bundle)
+  {
+    CFRelease(_bundle);
+    _bundle = nullptr;
+  }
+#endif
+
+#if LIN
+  if (_handle)
+  {
+    dlclose(_handle);
+    _handle = nullptr;
+  }
 #endif
 
 #if WIN
-    if (_handle && !_selfcontained)
-    {
-      FreeLibrary(_handle);
-    }
-#endif
+  if (_handle && !_selfcontained)
+  {
+    FreeLibrary(_handle);
   }
+#endif
+}
 
 }  // namespace Clap

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -32,10 +32,8 @@ namespace Clap
     char *val;
     size_t len;
     auto err = _dupenv_s(&val, &len, varname);
-    if (err)
-      return std::string();
-    if (val == nullptr)
-      return std::string();
+    if (err) return std::string();
+    if (val == nullptr) return std::string();
     std::string result(val);
     free(val);
     return result;
@@ -92,8 +90,7 @@ namespace Clap
         cp = cp.substr(pos + 1);
         res.emplace_back(fs::path{item});
       }
-      if (cp.size())
-        res.emplace_back(fs::path{cp});
+      if (cp.size()) res.emplace_back(fs::path{cp});
     }
 
     return res;
@@ -152,12 +149,10 @@ namespace Clap
     int *iptr;
 
     _handle = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
-    if (!_handle)
-      return false;
+    if (!_handle) return false;
 
     iptr = (int *)dlsym(_handle, "clap_entry");
-    if (!iptr)
-      return false;
+    if (!iptr) return false;
 
     _pluginEntry = (const clap_plugin_entry_t *)iptr;
     setupPluginsFromPluginEntry(name);
@@ -196,10 +191,8 @@ namespace Clap
       if (_pluginEntry->init(path))
       {
         _pluginFactory = static_cast<const clap_plugin_factory *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_ID));
-        _pluginFactoryVst3Info =
-            static_cast<const clap_plugin_factory_as_vst3 *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_VST3));
-        _pluginFactoryAUv2Info =
-            static_cast<const clap_plugin_factory_as_auv2 *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_AUV2));
+        _pluginFactoryVst3Info = static_cast<const clap_plugin_factory_as_vst3 *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_VST3));
+        _pluginFactoryAUv2Info = static_cast<const clap_plugin_factory_as_auv2 *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_AUV2));
 
         // detect plugins that do not check the CLAP_PLUGIN_FACTORY_ID
         if ((void *)_pluginFactory == (void *)_pluginFactoryVst3Info)
@@ -261,7 +254,7 @@ namespace Clap
         auto liptr = (int *)dlsym(_handle, "clap_entry");
         if (liptr)
         {
-          _handle = lhandle; // as a result the Library dtor will dlclose me
+          _handle = lhandle;  // as a result the Library dtor will dlclose me
           _pluginEntry = (const clap_plugin_entry_t *)liptr;
           _selfcontained = true;
 
@@ -277,8 +270,7 @@ namespace Clap
     if (!selfp.empty())
     {
       std::string name = selfp.u8string();
-      CFURLRef bundleUrl =
-          CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(), name.size(), true);
+      CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(), name.size(), true);
       if (bundleUrl)
       {
         auto pluginBundle = CFBundleCreate(0, bundleUrl);
@@ -336,4 +328,4 @@ namespace Clap
 #endif
   }
 
-} // namespace Clap
+}  // namespace Clap

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -222,7 +222,9 @@ namespace Clap
 #if WIN || LIN
   // This is a small stub to resolve the self dll. MacOs uses a different approach
   // in sharedLibraryBundlePath
-  static void ffeomwe() {}
+  static void ffeomwe()
+  {
+  }
 #endif
 
   Library::Library()

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -24,20 +24,21 @@
 #include <iostream>
 #endif
 
-
 namespace Clap
 {
 #if WIN
-  std::string getEnvVariable(const char* varname)
+  std::string getEnvVariable(const char *varname)
   {
-    char* val;
+    char *val;
     size_t len;
     auto err = _dupenv_s(&val, &len, varname);
-    if (err) return std::string();
-    if (val == nullptr) return std::string();
+    if (err)
+      return std::string();
+    if (val == nullptr)
+      return std::string();
     std::string result(val);
     free(val);
-    return result;      
+    return result;
   }
 #endif
 
@@ -62,12 +63,12 @@ namespace Clap
       auto p = getEnvVariable("COMMONPROGRAMFILES");
       if (!p.empty())
       {
-        res.emplace_back(fs::path{ p } / "CLAP");
+        res.emplace_back(fs::path{p} / "CLAP");
       }
       auto q = getEnvVariable("LOCALAPPDATA");
       if (!q.empty())
       {
-        res.emplace_back(fs::path{ q } / "Programs" / "Common" / "CLAP");
+        res.emplace_back(fs::path{q} / "Programs" / "Common" / "CLAP");
       }
     }
     auto cp = getEnvVariable("CLAP_PATH");
@@ -89,39 +90,38 @@ namespace Clap
       {
         auto item = cp.substr(0, pos);
         cp = cp.substr(pos + 1);
-        res.emplace_back(fs::path{ item });
+        res.emplace_back(fs::path{item});
       }
       if (cp.size())
-        res.emplace_back(fs::path{ cp });
+        res.emplace_back(fs::path{cp});
     }
 
     return res;
   }
 
-  bool Library::load(const char* name)
+  bool Library::load(const char *name)
   {
 #if MAC
-     _pluginEntry = nullptr;
+    _pluginEntry = nullptr;
 
-     auto cs = CFStringCreateWithBytes(kCFAllocatorDefault, (uint8_t *)name, strlen(name),
-                                       kCFStringEncodingUTF8, false);
-     auto bundleURL =
-             CFURLCreateWithFileSystemPath(kCFAllocatorDefault, cs, kCFURLPOSIXPathStyle, true);
+    auto cs = CFStringCreateWithBytes(kCFAllocatorDefault, (uint8_t *)name, strlen(name), kCFStringEncodingUTF8, false);
+    auto bundleURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, cs, kCFURLPOSIXPathStyle, true);
 
-     _bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
-     CFRelease(bundleURL);
-     CFRelease(cs);
+    _bundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
+    CFRelease(bundleURL);
+    CFRelease(cs);
 
-     if (!_bundle) {
-        return false;
-     }
+    if (!_bundle)
+    {
+      return false;
+    }
 
-     auto db = CFBundleGetDataPointerForName(_bundle, CFSTR("clap_entry"));
+    auto db = CFBundleGetDataPointerForName(_bundle, CFSTR("clap_entry"));
 
-     _pluginEntry = (const clap_plugin_entry *)db;
+    _pluginEntry = (const clap_plugin_entry *)db;
 
-     setupPluginsFromPluginEntry(name);
-     return _pluginEntry != nullptr;
+    setupPluginsFromPluginEntry(name);
+    return _pluginEntry != nullptr;
 #endif
 
 #if WIN
@@ -149,23 +149,23 @@ namespace Clap
 #endif
 
 #if LIN
-      int *iptr;
+    int *iptr;
 
-      _handle = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
-      if (!_handle)
-          return false;
+    _handle = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
+    if (!_handle)
+      return false;
 
-      iptr = (int *)dlsym(_handle, "clap_entry");
-      if (!iptr)
-          return false;
+    iptr = (int *)dlsym(_handle, "clap_entry");
+    if (!iptr)
+      return false;
 
-      _pluginEntry = (const clap_plugin_entry_t *)iptr;
-      setupPluginsFromPluginEntry(name);
-      return true;
+    _pluginEntry = (const clap_plugin_entry_t *)iptr;
+    setupPluginsFromPluginEntry(name);
+    return true;
 #endif
   }
 
-  const clap_plugin_info_as_vst3_t* Library::get_vst3_info(uint32_t index)
+  const clap_plugin_info_as_vst3_t *Library::get_vst3_info(uint32_t index)
   {
     if (_pluginFactoryVst3Info && _pluginFactoryVst3Info->get_vst3_info)
     {
@@ -175,49 +175,55 @@ namespace Clap
   }
 
 #if WIN
-  bool Library::getEntryFunction(HMODULE handle, const char* path)
+  bool Library::getEntryFunction(HMODULE handle, const char *path)
   {
     if (handle)
     {
-      _pluginEntry = reinterpret_cast<const clap_plugin_entry*>(GetProcAddress(handle, "clap_entry"));
+      _pluginEntry = reinterpret_cast<const clap_plugin_entry *>(GetProcAddress(handle, "clap_entry"));
       if (_pluginEntry)
       {
-         setupPluginsFromPluginEntry(path);
+        setupPluginsFromPluginEntry(path);
       }
     }
     return (_pluginEntry && !plugins.empty());
   }
 #endif
 
-  void Library::setupPluginsFromPluginEntry(const char* path) {
-     if (clap_version_is_compatible(_pluginEntry->clap_version)) {
-        if (_pluginEntry->init(path)) {
-           _pluginFactory =
-                   static_cast<const clap_plugin_factory *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_ID));
-           _pluginFactoryVst3Info =
-                  static_cast<const clap_plugin_factory_as_vst3*>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_VST3));
-           _pluginFactoryAUv2Info =
-               static_cast<const clap_plugin_factory_as_auv2*>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_AUV2));
+  void Library::setupPluginsFromPluginEntry(const char *path)
+  {
+    if (clap_version_is_compatible(_pluginEntry->clap_version))
+    {
+      if (_pluginEntry->init(path))
+      {
+        _pluginFactory = static_cast<const clap_plugin_factory *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_ID));
+        _pluginFactoryVst3Info =
+            static_cast<const clap_plugin_factory_as_vst3 *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_VST3));
+        _pluginFactoryAUv2Info =
+            static_cast<const clap_plugin_factory_as_auv2 *>(_pluginEntry->get_factory(CLAP_PLUGIN_FACTORY_INFO_AUV2));
 
-           // detect plugins that do not check the CLAP_PLUGIN_FACTORY_ID
-           if ((void*)_pluginFactory == (void*)_pluginFactoryVst3Info)
-           {
-             _pluginFactoryVst3Info = nullptr;
-             _pluginFactoryAUv2Info = nullptr;
-           }
-
-           auto count = _pluginFactory->get_plugin_count(_pluginFactory);
-
-           for (decltype(count) i = 0; i < count; ++i) {
-              auto desc = _pluginFactory->get_plugin_descriptor(_pluginFactory, i);
-              if (clap_version_is_compatible(desc->clap_version)) {
-                 plugins.push_back(desc);
-              } else {
-                 // incompatible
-              }
-           }
+        // detect plugins that do not check the CLAP_PLUGIN_FACTORY_ID
+        if ((void *)_pluginFactory == (void *)_pluginFactoryVst3Info)
+        {
+          _pluginFactoryVst3Info = nullptr;
+          _pluginFactoryAUv2Info = nullptr;
         }
-     }
+
+        auto count = _pluginFactory->get_plugin_count(_pluginFactory);
+
+        for (decltype(count) i = 0; i < count; ++i)
+        {
+          auto desc = _pluginFactory->get_plugin_descriptor(_pluginFactory, i);
+          if (clap_version_is_compatible(desc->clap_version))
+          {
+            plugins.push_back(desc);
+          }
+          else
+          {
+            // incompatible
+          }
+        }
+      }
+    }
   }
 
 #if WIN || LIN
@@ -238,7 +244,7 @@ namespace Clap
     }
     if (selfmodule)
     {
-      if (this->getEntryFunction(selfmodule, (const char*)modulename))
+      if (this->getEntryFunction(selfmodule, (const char *)modulename))
       {
         _selfcontained = true;
       }
@@ -247,8 +253,7 @@ namespace Clap
 
 #if LIN
     Dl_info info;
-    if (dladdr(reinterpret_cast<const void *>(&ffeomwe), &info) &&
-        info.dli_fname[0])
+    if (dladdr(reinterpret_cast<const void *>(&ffeomwe), &info) && info.dli_fname[0])
     {
       auto lhandle = dlopen(info.dli_fname, RTLD_LOCAL | RTLD_LAZY);
       if (lhandle)
@@ -256,11 +261,11 @@ namespace Clap
         auto liptr = (int *)dlsym(_handle, "clap_entry");
         if (liptr)
         {
-              _handle = lhandle; // as a result the Library dtor will dlclose me
-              _pluginEntry = (const clap_plugin_entry_t *)liptr;
-              _selfcontained = true;
+          _handle = lhandle; // as a result the Library dtor will dlclose me
+          _pluginEntry = (const clap_plugin_entry_t *)liptr;
+          _selfcontained = true;
 
-              setupPluginsFromPluginEntry(info.dli_fname);
+          setupPluginsFromPluginEntry(info.dli_fname);
         }
       }
     }
@@ -272,9 +277,8 @@ namespace Clap
     if (!selfp.empty())
     {
       std::string name = selfp.u8string();
-      CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation (0,
-                                                                   (const unsigned char*)name.c_str (),
-                                                                   name.size(), true);
+      CFURLRef bundleUrl =
+          CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(), name.size(), true);
       if (bundleUrl)
       {
         auto pluginBundle = CFBundleCreate(0, bundleUrl);
@@ -285,22 +289,20 @@ namespace Clap
           auto db = CFBundleGetDataPointerForName(pluginBundle, CFSTR("clap_entry"));
           if (db)
           {
-             _bundle = pluginBundle;
-             _pluginEntry = (const clap_plugin_entry_t *)db;
-             _selfcontained = true;
+            _bundle = pluginBundle;
+            _pluginEntry = (const clap_plugin_entry_t *)db;
+            _selfcontained = true;
 
-             setupPluginsFromPluginEntry(selfp.u8string().c_str());
+            setupPluginsFromPluginEntry(selfp.u8string().c_str());
           }
           else
           {
-             CFRelease(pluginBundle);
+            CFRelease(pluginBundle);
           }
         }
       }
     }
 #endif
-
-
   }
 
   Library::~Library()
@@ -321,8 +323,8 @@ namespace Clap
 #if LIN
     if (_handle)
     {
-        dlclose(_handle);
-        _handle = nullptr;
+      dlclose(_handle);
+      _handle = nullptr;
     }
 #endif
 
@@ -334,4 +336,4 @@ namespace Clap
 #endif
   }
 
-}
+} // namespace Clap

--- a/src/detail/clap/fsutil.h
+++ b/src/detail/clap/fsutil.h
@@ -1,4 +1,4 @@
-/*
+/* 
 
     Copyright (c) 2022 Timo Kaluza (defiantnerd)
                        Paul Walker
@@ -46,17 +46,17 @@ namespace Clap
 
   class Library
   {
-  public:
+   public:
     Library();
     ~Library();
-    bool load(const char *name);
+    bool load(const char* name);
 
-    const clap_plugin_entry_t *_pluginEntry = nullptr;
-    const clap_plugin_factory_t *_pluginFactory = nullptr;
-    const clap_plugin_factory_as_vst3 *_pluginFactoryVst3Info = nullptr;
-    const clap_plugin_factory_as_auv2 *_pluginFactoryAUv2Info = nullptr;
-    std::vector<const clap_plugin_descriptor_t *> plugins;
-    const clap_plugin_info_as_vst3_t *get_vst3_info(uint32_t index);
+    const clap_plugin_entry_t* _pluginEntry = nullptr;
+    const clap_plugin_factory_t* _pluginFactory = nullptr;
+    const clap_plugin_factory_as_vst3* _pluginFactoryVst3Info = nullptr;
+    const clap_plugin_factory_as_auv2* _pluginFactoryAUv2Info = nullptr;
+    std::vector<const clap_plugin_descriptor_t*> plugins;
+    const clap_plugin_info_as_vst3_t* get_vst3_info(uint32_t index);
 
     bool hasEntryPoint() const
     {
@@ -73,22 +73,22 @@ namespace Clap
 #endif
     }
 
-  private:
+   private:
 #if MAC
     CFBundleRef _bundle{nullptr};
 #endif
 
 #if LIN
-    void *_handle{nullptr};
+    void* _handle{nullptr};
 #endif
 
 #if WIN
     HMODULE _handle = 0;
-    bool getEntryFunction(HMODULE handle, const char *path);
+    bool getEntryFunction(HMODULE handle, const char* path);
 #endif
 
-    void setupPluginsFromPluginEntry(const char *p);
+    void setupPluginsFromPluginEntry(const char* p);
     bool _selfcontained = false;
   };
 
-} // namespace Clap
+}  // namespace Clap

--- a/src/detail/clap/fsutil.h
+++ b/src/detail/clap/fsutil.h
@@ -40,55 +40,55 @@ namespace fs = std::filesystem;
 namespace Clap
 {
 
-  std::vector<fs::path> getValidCLAPSearchPaths();
-  class Plugin;
-  class IHost;
+std::vector<fs::path> getValidCLAPSearchPaths();
+class Plugin;
+class IHost;
 
-  class Library
+class Library
+{
+ public:
+  Library();
+  ~Library();
+  bool load(const char* name);
+
+  const clap_plugin_entry_t* _pluginEntry = nullptr;
+  const clap_plugin_factory_t* _pluginFactory = nullptr;
+  const clap_plugin_factory_as_vst3* _pluginFactoryVst3Info = nullptr;
+  const clap_plugin_factory_as_auv2* _pluginFactoryAUv2Info = nullptr;
+  std::vector<const clap_plugin_descriptor_t*> plugins;
+  const clap_plugin_info_as_vst3_t* get_vst3_info(uint32_t index);
+
+  bool hasEntryPoint() const
   {
-   public:
-    Library();
-    ~Library();
-    bool load(const char* name);
-
-    const clap_plugin_entry_t* _pluginEntry = nullptr;
-    const clap_plugin_factory_t* _pluginFactory = nullptr;
-    const clap_plugin_factory_as_vst3* _pluginFactoryVst3Info = nullptr;
-    const clap_plugin_factory_as_auv2* _pluginFactoryAUv2Info = nullptr;
-    std::vector<const clap_plugin_descriptor_t*> plugins;
-    const clap_plugin_info_as_vst3_t* get_vst3_info(uint32_t index);
-
-    bool hasEntryPoint() const
-    {
 #if WIN
-      return _handle != 0 || _selfcontained;
+    return _handle != 0 || _selfcontained;
 #endif
 
 #if MAC
-      return _bundle != nullptr || _selfcontained;
+    return _bundle != nullptr || _selfcontained;
 #endif
 
 #if LIN
-      return _handle != nullptr || _selfcontained;
+    return _handle != nullptr || _selfcontained;
 #endif
-    }
+  }
 
-   private:
+ private:
 #if MAC
-    CFBundleRef _bundle{nullptr};
+  CFBundleRef _bundle{nullptr};
 #endif
 
 #if LIN
-    void* _handle{nullptr};
+  void* _handle{nullptr};
 #endif
 
 #if WIN
-    HMODULE _handle = 0;
-    bool getEntryFunction(HMODULE handle, const char* path);
+  HMODULE _handle = 0;
+  bool getEntryFunction(HMODULE handle, const char* path);
 #endif
 
-    void setupPluginsFromPluginEntry(const char* p);
-    bool _selfcontained = false;
-  };
+  void setupPluginsFromPluginEntry(const char* p);
+  bool _selfcontained = false;
+};
 
 }  // namespace Clap

--- a/src/detail/clap/fsutil.h
+++ b/src/detail/clap/fsutil.h
@@ -1,4 +1,4 @@
-/* 
+/*
 
     Copyright (c) 2022 Timo Kaluza (defiantnerd)
                        Paul Walker
@@ -49,48 +49,46 @@ namespace Clap
   public:
     Library();
     ~Library();
-    bool load(const char* name);
-    
-    const clap_plugin_entry_t* _pluginEntry = nullptr;
-    const clap_plugin_factory_t* _pluginFactory = nullptr;
-    const clap_plugin_factory_as_vst3* _pluginFactoryVst3Info = nullptr;
-    const clap_plugin_factory_as_auv2* _pluginFactoryAUv2Info = nullptr;
-    std::vector<const clap_plugin_descriptor_t*> plugins;
-    const clap_plugin_info_as_vst3_t* get_vst3_info(uint32_t index);
+    bool load(const char *name);
 
-    bool hasEntryPoint() const {
+    const clap_plugin_entry_t *_pluginEntry = nullptr;
+    const clap_plugin_factory_t *_pluginFactory = nullptr;
+    const clap_plugin_factory_as_vst3 *_pluginFactoryVst3Info = nullptr;
+    const clap_plugin_factory_as_auv2 *_pluginFactoryAUv2Info = nullptr;
+    std::vector<const clap_plugin_descriptor_t *> plugins;
+    const clap_plugin_info_as_vst3_t *get_vst3_info(uint32_t index);
+
+    bool hasEntryPoint() const
+    {
 #if WIN
-        return _handle != 0 || _selfcontained;
+      return _handle != 0 || _selfcontained;
 #endif
 
 #if MAC
-        return _bundle != nullptr || _selfcontained;
+      return _bundle != nullptr || _selfcontained;
 #endif
 
 #if LIN
-        return _handle != nullptr || _selfcontained;
+      return _handle != nullptr || _selfcontained;
 #endif
     }
 
   private:
 #if MAC
-   CFBundleRef _bundle{nullptr};
+    CFBundleRef _bundle{nullptr};
 #endif
 
 #if LIN
     void *_handle{nullptr};
 #endif
 
-
 #if WIN
     HMODULE _handle = 0;
-    bool getEntryFunction(HMODULE handle, const char* path);
+    bool getEntryFunction(HMODULE handle, const char *path);
 #endif
 
-    void setupPluginsFromPluginEntry(const char* p);
+    void setupPluginsFromPluginEntry(const char *p);
     bool _selfcontained = false;
   };
 
-}
-
-
+} // namespace Clap

--- a/src/detail/clap/mac_helpers.mm
+++ b/src/detail/clap/mac_helpers.mm
@@ -58,7 +58,8 @@ namespace Clap
     if (!bundlePath.empty())
     {
       std::string name = bundlePath.u8string();
-      CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(), name.size(), true);
+      CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(
+          0, (const unsigned char *)name.c_str(), name.size(), true);
       if (bundleUrl)
       {
         auto pluginBundle = CFBundleCreate(0, bundleUrl);

--- a/src/detail/clap/mac_helpers.mm
+++ b/src/detail/clap/mac_helpers.mm
@@ -1,8 +1,8 @@
-/* 
+/*
 
     Copyright (c) 2022 Paul Walker
                        Timo Kaluza (defiantnerd)
-                       
+
 
     This file is part of the clap-wrappers project which is released under MIT License.
     See file LICENSE or go to https://github.com/defiantnerd/clap-wrapper for full license details.
@@ -23,14 +23,12 @@ namespace fs = ghc::filesystem;
 
 #include <Foundation/Foundation.h>
 
-
 namespace Clap
 {
   fs::path sharedLibraryBundlePath()
   {
     Dl_info info;
-    if (!dladdr(reinterpret_cast<const void *>(&sharedLibraryBundlePath), &info) ||
-        !info.dli_fname[0])
+    if (!dladdr(reinterpret_cast<const void *>(&sharedLibraryBundlePath), &info) || !info.dli_fname[0])
     {
       // If dladdr(3) returns zero, dlerror(3) won't know why either
       return {};
@@ -45,64 +43,62 @@ namespace Clap
         return res.parent_path();
       }
     }
-    catch(const fs::filesystem_error &)
+    catch (const fs::filesystem_error &)
     {
       // oh well
     }
     return {};
   }
 
-    std::vector<fs::path> getMacCLAPSearchPaths() {
-      auto res = std::vector<fs::path>();
+  std::vector<fs::path> getMacCLAPSearchPaths()
+  {
+    auto res = std::vector<fs::path>();
 
-      auto bundlePath = sharedLibraryBundlePath();
-      if (!bundlePath.empty())
+    auto bundlePath = sharedLibraryBundlePath();
+    if (!bundlePath.empty())
+    {
+      std::string name = bundlePath.u8string();
+      CFURLRef bundleUrl =
+          CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(), name.size(), true);
+      if (bundleUrl)
       {
-        std::string name = bundlePath.u8string();
-        CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation (0,
-                                                                   (const unsigned char*)name.c_str (),
-                                                                   name.size(), true);
-       if (bundleUrl)
-       {
-         auto pluginBundle = CFBundleCreate (0, bundleUrl);
-         CFRelease (bundleUrl);
+        auto pluginBundle = CFBundleCreate(0, bundleUrl);
+        CFRelease(bundleUrl);
 
-         if (pluginBundle)
-         {
-           auto pluginFoldersUrl = CFBundleCopyBuiltInPlugInsURL(pluginBundle);
+        if (pluginBundle)
+        {
+          auto pluginFoldersUrl = CFBundleCopyBuiltInPlugInsURL(pluginBundle);
 
-           if (pluginFoldersUrl)
-           {
-             // Remember CFURL and NSURL are toll free bridged
-             auto *ns = (NSURL *)pluginFoldersUrl;
-             auto pp = fs::path{[ns fileSystemRepresentation]};
-             res.push_back(pp);
-             CFRelease(pluginFoldersUrl);
-           }
-           CFRelease(pluginBundle);
-         }
-       }
+          if (pluginFoldersUrl)
+          {
+            // Remember CFURL and NSURL are toll free bridged
+            auto *ns = (NSURL *)pluginFoldersUrl;
+            auto pp = fs::path{[ns fileSystemRepresentation]};
+            res.push_back(pp);
+            CFRelease(pluginFoldersUrl);
+          }
+          CFRelease(pluginBundle);
+        }
       }
-
-       auto *fileManager = [NSFileManager defaultManager];
-       auto *userLibURLs = [fileManager URLsForDirectory:NSLibraryDirectory
-                                               inDomains:NSUserDomainMask];
-       auto *sysLibURLs = [fileManager URLsForDirectory:NSLibraryDirectory
-                                              inDomains:NSLocalDomainMask];
-
-       if (userLibURLs) {
-          auto *u = [userLibURLs objectAtIndex:0];
-          auto p =
-                  fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
-          res.push_back(p);
-       }
-
-       if (sysLibURLs) {
-          auto *u = [sysLibURLs objectAtIndex:0];
-          auto p =
-                  fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
-          res.push_back(p);
-       }
-       return res;
     }
+
+    auto *fileManager = [NSFileManager defaultManager];
+    auto *userLibURLs = [fileManager URLsForDirectory:NSLibraryDirectory inDomains:NSUserDomainMask];
+    auto *sysLibURLs = [fileManager URLsForDirectory:NSLibraryDirectory inDomains:NSLocalDomainMask];
+
+    if (userLibURLs)
+    {
+      auto *u = [userLibURLs objectAtIndex:0];
+      auto p = fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
+      res.push_back(p);
+    }
+
+    if (sysLibURLs)
+    {
+      auto *u = [sysLibURLs objectAtIndex:0];
+      auto p = fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
+      res.push_back(p);
+    }
+    return res;
+  }
 }

--- a/src/detail/clap/mac_helpers.mm
+++ b/src/detail/clap/mac_helpers.mm
@@ -1,8 +1,8 @@
-/*
+/* 
 
     Copyright (c) 2022 Paul Walker
                        Timo Kaluza (defiantnerd)
-
+                       
 
     This file is part of the clap-wrappers project which is released under MIT License.
     See file LICENSE or go to https://github.com/defiantnerd/clap-wrapper for full license details.
@@ -36,7 +36,7 @@ namespace Clap
     try
     {
       auto res = fs::path{info.dli_fname};
-      res = res.parent_path().parent_path(); // this might throw if not in bundle so catch
+      res = res.parent_path().parent_path();  // this might throw if not in bundle so catch
       if (res.filename().u8string() == "Contents" && res.has_parent_path())
       {
         // We are properly situated in a bundle in either a MacOS ir an iOS location
@@ -58,8 +58,7 @@ namespace Clap
     if (!bundlePath.empty())
     {
       std::string name = bundlePath.u8string();
-      CFURLRef bundleUrl =
-          CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(), name.size(), true);
+      CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(), name.size(), true);
       if (bundleUrl)
       {
         auto pluginBundle = CFBundleCreate(0, bundleUrl);

--- a/src/detail/clap/mac_helpers.mm
+++ b/src/detail/clap/mac_helpers.mm
@@ -25,80 +25,80 @@ namespace fs = ghc::filesystem;
 
 namespace Clap
 {
-  fs::path sharedLibraryBundlePath()
+fs::path sharedLibraryBundlePath()
+{
+  Dl_info info;
+  if (!dladdr(reinterpret_cast<const void *>(&sharedLibraryBundlePath), &info) || !info.dli_fname[0])
   {
-    Dl_info info;
-    if (!dladdr(reinterpret_cast<const void *>(&sharedLibraryBundlePath), &info) || !info.dli_fname[0])
-    {
-      // If dladdr(3) returns zero, dlerror(3) won't know why either
-      return {};
-    }
-    try
-    {
-      auto res = fs::path{info.dli_fname};
-      res = res.parent_path().parent_path();  // this might throw if not in bundle so catch
-      if (res.filename().u8string() == "Contents" && res.has_parent_path())
-      {
-        // We are properly situated in a bundle in either a MacOS ir an iOS location
-        return res.parent_path();
-      }
-    }
-    catch (const fs::filesystem_error &)
-    {
-      // oh well
-    }
+    // If dladdr(3) returns zero, dlerror(3) won't know why either
     return {};
   }
-
-  std::vector<fs::path> getMacCLAPSearchPaths()
+  try
   {
-    auto res = std::vector<fs::path>();
-
-    auto bundlePath = sharedLibraryBundlePath();
-    if (!bundlePath.empty())
+    auto res = fs::path{info.dli_fname};
+    res = res.parent_path().parent_path();  // this might throw if not in bundle so catch
+    if (res.filename().u8string() == "Contents" && res.has_parent_path())
     {
-      std::string name = bundlePath.u8string();
-      CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(
-          0, (const unsigned char *)name.c_str(), name.size(), true);
-      if (bundleUrl)
+      // We are properly situated in a bundle in either a MacOS ir an iOS location
+      return res.parent_path();
+    }
+  }
+  catch (const fs::filesystem_error &)
+  {
+    // oh well
+  }
+  return {};
+}
+
+std::vector<fs::path> getMacCLAPSearchPaths()
+{
+  auto res = std::vector<fs::path>();
+
+  auto bundlePath = sharedLibraryBundlePath();
+  if (!bundlePath.empty())
+  {
+    std::string name = bundlePath.u8string();
+    CFURLRef bundleUrl = CFURLCreateFromFileSystemRepresentation(0, (const unsigned char *)name.c_str(),
+                                                                 name.size(), true);
+    if (bundleUrl)
+    {
+      auto pluginBundle = CFBundleCreate(0, bundleUrl);
+      CFRelease(bundleUrl);
+
+      if (pluginBundle)
       {
-        auto pluginBundle = CFBundleCreate(0, bundleUrl);
-        CFRelease(bundleUrl);
+        auto pluginFoldersUrl = CFBundleCopyBuiltInPlugInsURL(pluginBundle);
 
-        if (pluginBundle)
+        if (pluginFoldersUrl)
         {
-          auto pluginFoldersUrl = CFBundleCopyBuiltInPlugInsURL(pluginBundle);
-
-          if (pluginFoldersUrl)
-          {
-            // Remember CFURL and NSURL are toll free bridged
-            auto *ns = (NSURL *)pluginFoldersUrl;
-            auto pp = fs::path{[ns fileSystemRepresentation]};
-            res.push_back(pp);
-            CFRelease(pluginFoldersUrl);
-          }
-          CFRelease(pluginBundle);
+          // Remember CFURL and NSURL are toll free bridged
+          auto *ns = (NSURL *)pluginFoldersUrl;
+          auto pp = fs::path{[ns fileSystemRepresentation]};
+          res.push_back(pp);
+          CFRelease(pluginFoldersUrl);
         }
+        CFRelease(pluginBundle);
       }
     }
-
-    auto *fileManager = [NSFileManager defaultManager];
-    auto *userLibURLs = [fileManager URLsForDirectory:NSLibraryDirectory inDomains:NSUserDomainMask];
-    auto *sysLibURLs = [fileManager URLsForDirectory:NSLibraryDirectory inDomains:NSLocalDomainMask];
-
-    if (userLibURLs)
-    {
-      auto *u = [userLibURLs objectAtIndex:0];
-      auto p = fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
-      res.push_back(p);
-    }
-
-    if (sysLibURLs)
-    {
-      auto *u = [sysLibURLs objectAtIndex:0];
-      auto p = fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
-      res.push_back(p);
-    }
-    return res;
   }
+
+  auto *fileManager = [NSFileManager defaultManager];
+  auto *userLibURLs = [fileManager URLsForDirectory:NSLibraryDirectory inDomains:NSUserDomainMask];
+  auto *sysLibURLs = [fileManager URLsForDirectory:NSLibraryDirectory inDomains:NSLocalDomainMask];
+
+  if (userLibURLs)
+  {
+    auto *u = [userLibURLs objectAtIndex:0];
+    auto p = fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
+    res.push_back(p);
+  }
+
+  if (sysLibURLs)
+  {
+    auto *u = [sysLibURLs objectAtIndex:0];
+    auto p = fs::path{[u fileSystemRepresentation]} / "Audio" / "Plug-Ins" / "CLAP";
+    res.push_back(p);
+  }
+  return res;
+}
 }

--- a/src/detail/sha1.cpp
+++ b/src/detail/sha1.cpp
@@ -8,335 +8,334 @@ static constexpr bool isBigEndian = false;
 
 namespace Crypto
 {
-  class Sha1
+class Sha1
+{
+ public:
+  Sha1()
   {
-   public:
-    Sha1()
-    {
-      reset();
-    }
-    Sha1(const unsigned char* message_array, size_t length)
-    {
-      reset();
-      input(message_array, length);
-    }
-    void input(const unsigned char* message_array, size_t length);
-    struct sha1hash hash();
-
-   private:
-    void reset();
-    void processMessageBlock();
-    void padmessage();
-    inline uint32_t circularShift(int bits, uint32_t word)
-    {
-      return ((word << bits) & 0xFFFFFFFF) | ((word & 0xFFFFFFFF) >> (32 - bits));
-    }
-
-    unsigned H[5] =  // Message digest buffers
-        {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0};
-
-    uint32_t _lengthLow = 0;    // Message length in bits
-    uint32_t _length_high = 0;  // Message length in bits
-
-    unsigned char _messageBlock[64] = {0};  // 512-bit message blocks
-    int _messageBlockIndex = 0;             // Index into message block array
-
-    bool _computed = false;   // Is the digest computed?
-    bool _corrupted = false;  // Is the message digest corruped?
-  };
-
-  void Sha1::reset()
+    reset();
+  }
+  Sha1(const unsigned char* message_array, size_t length)
   {
-    _lengthLow = 0;
-    _length_high = 0;
-    _messageBlockIndex = 0;
+    reset();
+    input(message_array, length);
+  }
+  void input(const unsigned char* message_array, size_t length);
+  struct sha1hash hash();
 
-    H[0] = 0x67452301;
-    H[1] = 0xEFCDAB89;
-    H[2] = 0x98BADCFE;
-    H[3] = 0x10325476;
-    H[4] = 0xC3D2E1F0;
-
-    _computed = false;
-    _corrupted = false;
+ private:
+  void reset();
+  void processMessageBlock();
+  void padmessage();
+  inline uint32_t circularShift(int bits, uint32_t word)
+  {
+    return ((word << bits) & 0xFFFFFFFF) | ((word & 0xFFFFFFFF) >> (32 - bits));
   }
 
-  void Sha1::input(const unsigned char* message_array, size_t length)
+  unsigned H[5] =  // Message digest buffers
+      {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0};
+
+  uint32_t _lengthLow = 0;    // Message length in bits
+  uint32_t _length_high = 0;  // Message length in bits
+
+  unsigned char _messageBlock[64] = {0};  // 512-bit message blocks
+  int _messageBlockIndex = 0;             // Index into message block array
+
+  bool _computed = false;   // Is the digest computed?
+  bool _corrupted = false;  // Is the message digest corruped?
+};
+
+void Sha1::reset()
+{
+  _lengthLow = 0;
+  _length_high = 0;
+  _messageBlockIndex = 0;
+
+  H[0] = 0x67452301;
+  H[1] = 0xEFCDAB89;
+  H[2] = 0x98BADCFE;
+  H[3] = 0x10325476;
+  H[4] = 0xC3D2E1F0;
+
+  _computed = false;
+  _corrupted = false;
+}
+
+void Sha1::input(const unsigned char* message_array, size_t length)
+{
+  if (length == 0)
   {
-    if (length == 0)
-    {
-      return;
-    }
-
-    if (_computed || _corrupted)
-    {
-      _corrupted = true;
-      return;
-    }
-
-    if (_messageBlockIndex >= 64)
-    {
-      return;
-    }
-
-    while (length-- && !_corrupted)
-    {
-      _messageBlock[_messageBlockIndex++] = (*message_array & 0xFF);
-
-      _lengthLow += 8;
-      _lengthLow &= 0xFFFFFFFF;  // Force it to 32 bits
-      if (_lengthLow == 0)
-      {
-        _length_high++;
-        _length_high &= 0xFFFFFFFF;  // Force it to 32 bits
-        if (_length_high == 0)
-        {
-          _corrupted = true;  // Message is too long
-        }
-      }
-
-      if (_messageBlockIndex == 64)
-      {
-        processMessageBlock();
-      }
-
-      message_array++;
-    }
+    return;
   }
 
-  void Sha1::processMessageBlock()
+  if (_computed || _corrupted)
   {
-    const unsigned K[] = {// Constants defined for SHA-1
-                          0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6};
-    int t;                   // Loop counter
-    unsigned temp;           // Temporary word value
-    unsigned W[80];          // Word sequence
-    unsigned A, B, C, D, E;  // Word buffers
+    _corrupted = true;
+    return;
+  }
 
-    /*
+  if (_messageBlockIndex >= 64)
+  {
+    return;
+  }
+
+  while (length-- && !_corrupted)
+  {
+    _messageBlock[_messageBlockIndex++] = (*message_array & 0xFF);
+
+    _lengthLow += 8;
+    _lengthLow &= 0xFFFFFFFF;  // Force it to 32 bits
+    if (_lengthLow == 0)
+    {
+      _length_high++;
+      _length_high &= 0xFFFFFFFF;  // Force it to 32 bits
+      if (_length_high == 0)
+      {
+        _corrupted = true;  // Message is too long
+      }
+    }
+
+    if (_messageBlockIndex == 64)
+    {
+      processMessageBlock();
+    }
+
+    message_array++;
+  }
+}
+
+void Sha1::processMessageBlock()
+{
+  const unsigned K[] = {// Constants defined for SHA-1
+                        0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6};
+  int t;                   // Loop counter
+  unsigned temp;           // Temporary word value
+  unsigned W[80];          // Word sequence
+  unsigned A, B, C, D, E;  // Word buffers
+
+  /*
      *  Initialize the first 16 words in the array W
      */
-    for (t = 0; t < 16; t++)
-    {
-      W[t] = ((unsigned)_messageBlock[t * 4]) << 24;
-      W[t] |= ((unsigned)_messageBlock[t * 4 + 1]) << 16;
-      W[t] |= ((unsigned)_messageBlock[t * 4 + 2]) << 8;
-      W[t] |= ((unsigned)_messageBlock[t * 4 + 3]);
-    }
-
-    for (t = 16; t < 80; t++)
-    {
-      W[t] = circularShift(1, W[t - 3] ^ W[t - 8] ^ W[t - 14] ^ W[t - 16]);
-    }
-
-    A = H[0];
-    B = H[1];
-    C = H[2];
-    D = H[3];
-    E = H[4];
-
-    for (t = 0; t < 20; t++)
-    {
-      temp = circularShift(5, A) + ((B & C) | ((~B) & D)) + E + W[t] + K[0];
-      temp &= 0xFFFFFFFF;
-      E = D;
-      D = C;
-      C = circularShift(30, B);
-      B = A;
-      A = temp;
-    }
-
-    for (t = 20; t < 40; t++)
-    {
-      temp = circularShift(5, A) + (B ^ C ^ D) + E + W[t] + K[1];
-      temp &= 0xFFFFFFFF;
-      E = D;
-      D = C;
-      C = circularShift(30, B);
-      B = A;
-      A = temp;
-    }
-
-    for (t = 40; t < 60; t++)
-    {
-      temp = circularShift(5, A) + ((B & C) | (B & D) | (C & D)) + E + W[t] + K[2];
-      temp &= 0xFFFFFFFF;
-      E = D;
-      D = C;
-      C = circularShift(30, B);
-      B = A;
-      A = temp;
-    }
-
-    for (t = 60; t < 80; t++)
-    {
-      temp = circularShift(5, A) + (B ^ C ^ D) + E + W[t] + K[3];
-      temp &= 0xFFFFFFFF;
-      E = D;
-      D = C;
-      C = circularShift(30, B);
-      B = A;
-      A = temp;
-    }
-
-    H[0] = (H[0] + A) & 0xFFFFFFFF;
-    H[1] = (H[1] + B) & 0xFFFFFFFF;
-    H[2] = (H[2] + C) & 0xFFFFFFFF;
-    H[3] = (H[3] + D) & 0xFFFFFFFF;
-    H[4] = (H[4] + E) & 0xFFFFFFFF;
-
-    _messageBlockIndex = 0;
+  for (t = 0; t < 16; t++)
+  {
+    W[t] = ((unsigned)_messageBlock[t * 4]) << 24;
+    W[t] |= ((unsigned)_messageBlock[t * 4 + 1]) << 16;
+    W[t] |= ((unsigned)_messageBlock[t * 4 + 2]) << 8;
+    W[t] |= ((unsigned)_messageBlock[t * 4 + 3]);
   }
 
-  void Sha1::padmessage()
+  for (t = 16; t < 80; t++)
   {
-    /*
+    W[t] = circularShift(1, W[t - 3] ^ W[t - 8] ^ W[t - 14] ^ W[t - 16]);
+  }
+
+  A = H[0];
+  B = H[1];
+  C = H[2];
+  D = H[3];
+  E = H[4];
+
+  for (t = 0; t < 20; t++)
+  {
+    temp = circularShift(5, A) + ((B & C) | ((~B) & D)) + E + W[t] + K[0];
+    temp &= 0xFFFFFFFF;
+    E = D;
+    D = C;
+    C = circularShift(30, B);
+    B = A;
+    A = temp;
+  }
+
+  for (t = 20; t < 40; t++)
+  {
+    temp = circularShift(5, A) + (B ^ C ^ D) + E + W[t] + K[1];
+    temp &= 0xFFFFFFFF;
+    E = D;
+    D = C;
+    C = circularShift(30, B);
+    B = A;
+    A = temp;
+  }
+
+  for (t = 40; t < 60; t++)
+  {
+    temp = circularShift(5, A) + ((B & C) | (B & D) | (C & D)) + E + W[t] + K[2];
+    temp &= 0xFFFFFFFF;
+    E = D;
+    D = C;
+    C = circularShift(30, B);
+    B = A;
+    A = temp;
+  }
+
+  for (t = 60; t < 80; t++)
+  {
+    temp = circularShift(5, A) + (B ^ C ^ D) + E + W[t] + K[3];
+    temp &= 0xFFFFFFFF;
+    E = D;
+    D = C;
+    C = circularShift(30, B);
+    B = A;
+    A = temp;
+  }
+
+  H[0] = (H[0] + A) & 0xFFFFFFFF;
+  H[1] = (H[1] + B) & 0xFFFFFFFF;
+  H[2] = (H[2] + C) & 0xFFFFFFFF;
+  H[3] = (H[3] + D) & 0xFFFFFFFF;
+  H[4] = (H[4] + E) & 0xFFFFFFFF;
+
+  _messageBlockIndex = 0;
+}
+
+void Sha1::padmessage()
+{
+  /*
        *  Check to see if the current message block is too small to hold
        *  the initial padding bits and length.  If so, we will pad the
        *  block, process it, and then continue padding into a second block.
        */
-    if (_messageBlockIndex > 55)
+  if (_messageBlockIndex > 55)
+  {
+    _messageBlock[_messageBlockIndex++] = 0x80;
+    while (_messageBlockIndex < 64)
     {
-      _messageBlock[_messageBlockIndex++] = 0x80;
-      while (_messageBlockIndex < 64)
-      {
-        _messageBlock[_messageBlockIndex++] = 0;
-      }
-
-      processMessageBlock();
-
-      while (_messageBlockIndex < 56)
-      {
-        _messageBlock[_messageBlockIndex++] = 0;
-      }
+      _messageBlock[_messageBlockIndex++] = 0;
     }
-    else
-    {
-      _messageBlock[_messageBlockIndex++] = 0x80;
-      while (_messageBlockIndex < 56)
-      {
-        _messageBlock[_messageBlockIndex++] = 0;
-      }
-    }
-
-    /*
-     *  Store the message length as the last 8 octets
-     */
-    _messageBlock[56] = (_length_high >> 24) & 0xFF;
-    _messageBlock[57] = (_length_high >> 16) & 0xFF;
-    _messageBlock[58] = (_length_high >> 8) & 0xFF;
-    _messageBlock[59] = (_length_high)&0xFF;
-    _messageBlock[60] = (_lengthLow >> 24) & 0xFF;
-    _messageBlock[61] = (_lengthLow >> 16) & 0xFF;
-    _messageBlock[62] = (_lengthLow >> 8) & 0xFF;
-    _messageBlock[63] = (_lengthLow)&0xFF;
 
     processMessageBlock();
-  }
 
-  struct sha1hash Sha1::hash()
-  {
-    padmessage();
-
-    struct sha1hash r;
-    int i = 0;
-
-    r.bytes[i++] = (H[0] >> 24) & 0xFF;
-    r.bytes[i++] = (H[0] >> 16) & 0xFF;
-    r.bytes[i++] = (H[0] >> 8) & 0xFF;
-    r.bytes[i++] = (H[0]) & 0xFF;
-
-    r.bytes[i++] = (H[1] >> 24) & 0xFF;
-    r.bytes[i++] = (H[1] >> 16) & 0xFF;
-    r.bytes[i++] = (H[1] >> 8) & 0xFF;
-    r.bytes[i++] = (H[1]) & 0xFF;
-
-    r.bytes[i++] = (H[2] >> 24) & 0xFF;
-    r.bytes[i++] = (H[2] >> 16) & 0xFF;
-    r.bytes[i++] = (H[2] >> 8) & 0xFF;
-    r.bytes[i++] = (H[2]) & 0xFF;
-
-    r.bytes[i++] = (H[3] >> 24) & 0xFF;
-    r.bytes[i++] = (H[3] >> 16) & 0xFF;
-    r.bytes[i++] = (H[3] >> 8) & 0xFF;
-    r.bytes[i++] = (H[3]) & 0xFF;
-
-    r.bytes[i++] = (H[4] >> 24) & 0xFF;
-    r.bytes[i++] = (H[4] >> 16) & 0xFF;
-    r.bytes[i++] = (H[4] >> 8) & 0xFF;
-    r.bytes[i++] = (H[4]) & 0xFF;
-
-    reset();
-
-    return r;
-  }
-
-  struct sha1hash sha1(const char* text, size_t len)
-  {
-    Sha1 x((const unsigned char*)(text), len);
-    return x.hash();
-  }
-
-  uint32_t swapOrder32(uint32_t n)
-  {
-    if (!isBigEndian)
+    while (_messageBlockIndex < 56)
     {
-      return ((n >> 24) & 0x000000FF) | ((n >> 8) & 0x0000FF00) | ((n << 8) & 0x00FF0000) |
-             ((n << 24) & 0xFF000000);
+      _messageBlock[_messageBlockIndex++] = 0;
     }
-    else
+  }
+  else
+  {
+    _messageBlock[_messageBlockIndex++] = 0x80;
+    while (_messageBlockIndex < 56)
     {
-      return n;
+      _messageBlock[_messageBlockIndex++] = 0;
     }
   }
 
-  uint16_t swapOrder16(uint16_t n)
+  /*
+     *  Store the message length as the last 8 octets
+     */
+  _messageBlock[56] = (_length_high >> 24) & 0xFF;
+  _messageBlock[57] = (_length_high >> 16) & 0xFF;
+  _messageBlock[58] = (_length_high >> 8) & 0xFF;
+  _messageBlock[59] = (_length_high)&0xFF;
+  _messageBlock[60] = (_lengthLow >> 24) & 0xFF;
+  _messageBlock[61] = (_lengthLow >> 16) & 0xFF;
+  _messageBlock[62] = (_lengthLow >> 8) & 0xFF;
+  _messageBlock[63] = (_lengthLow)&0xFF;
+
+  processMessageBlock();
+}
+
+struct sha1hash Sha1::hash()
+{
+  padmessage();
+
+  struct sha1hash r;
+  int i = 0;
+
+  r.bytes[i++] = (H[0] >> 24) & 0xFF;
+  r.bytes[i++] = (H[0] >> 16) & 0xFF;
+  r.bytes[i++] = (H[0] >> 8) & 0xFF;
+  r.bytes[i++] = (H[0]) & 0xFF;
+
+  r.bytes[i++] = (H[1] >> 24) & 0xFF;
+  r.bytes[i++] = (H[1] >> 16) & 0xFF;
+  r.bytes[i++] = (H[1] >> 8) & 0xFF;
+  r.bytes[i++] = (H[1]) & 0xFF;
+
+  r.bytes[i++] = (H[2] >> 24) & 0xFF;
+  r.bytes[i++] = (H[2] >> 16) & 0xFF;
+  r.bytes[i++] = (H[2] >> 8) & 0xFF;
+  r.bytes[i++] = (H[2]) & 0xFF;
+
+  r.bytes[i++] = (H[3] >> 24) & 0xFF;
+  r.bytes[i++] = (H[3] >> 16) & 0xFF;
+  r.bytes[i++] = (H[3] >> 8) & 0xFF;
+  r.bytes[i++] = (H[3]) & 0xFF;
+
+  r.bytes[i++] = (H[4] >> 24) & 0xFF;
+  r.bytes[i++] = (H[4] >> 16) & 0xFF;
+  r.bytes[i++] = (H[4] >> 8) & 0xFF;
+  r.bytes[i++] = (H[4]) & 0xFF;
+
+  reset();
+
+  return r;
+}
+
+struct sha1hash sha1(const char* text, size_t len)
+{
+  Sha1 x((const unsigned char*)(text), len);
+  return x.hash();
+}
+
+uint32_t swapOrder32(uint32_t n)
+{
+  if (!isBigEndian)
   {
-    if (!isBigEndian)
-    {
-      return ((n >> 8) & 0x00FF) | ((n << 8) & 0xFF00);
-    }
+    return ((n >> 24) & 0x000000FF) | ((n >> 8) & 0x0000FF00) | ((n << 8) & 0x00FF0000) |
+           ((n << 24) & 0xFF000000);
+  }
+  else
+  {
     return n;
   }
+}
 
-  /* Name string is a fully-qualified domain name */
-  uuid_object NameSpace_DNS = {/* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
-                               0x6ba7b810, 0x9dad, 0x11d1,
-                               0x80,       0xb4,   {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
-
-  uuid_object create_sha1_guid_from_name(const char* name, size_t namelen)
+uint16_t swapOrder16(uint16_t n)
+{
+  if (!isBigEndian)
   {
-    uuid_object uuid;
-
-    /*put name space ID in network byte order so it hashes the same
-      no matter what endian machine we're on */
-    // namespace DNS
-    uuid_object net_nsid = {
-        /* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
-        0x6ba7b810, 0x9dad, 0x11d1, 0x80, 0xb4, {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
-
-    net_nsid.time_low = swapOrder32(net_nsid.time_low);
-    net_nsid.time_mid = swapOrder16(net_nsid.time_mid);
-    net_nsid.time_hi_and_version = swapOrder16(net_nsid.time_hi_and_version);
-
-    Sha1 c;
-    c.input((const uint8_t*)&net_nsid, sizeof(net_nsid));
-    c.input((const uint8_t*)name, namelen);
-    auto hash = c.hash();
-
-    /* convert UUID to local byte order */
-    memcpy(&uuid, hash.bytes, sizeof(uuid));
-    uuid.time_low = swapOrder32(uuid.time_low);
-    uuid.time_mid = swapOrder16(uuid.time_mid);
-    uuid.time_hi_and_version = swapOrder16(uuid.time_hi_and_version);
-
-    const auto v = 5;
-    /* put in the variant and version bits */
-    uuid.time_hi_and_version &= 0x0FFF;
-    uuid.time_hi_and_version |= (v << 12);
-    uuid.clock_seq_hi_and_reserved &= 0x3F;
-    uuid.clock_seq_hi_and_reserved |= 0x80;
-
-    return uuid;
+    return ((n >> 8) & 0x00FF) | ((n << 8) & 0xFF00);
   }
+  return n;
+}
+
+/* Name string is a fully-qualified domain name */
+uuid_object NameSpace_DNS = {/* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
+                             0x6ba7b810, 0x9dad, 0x11d1,
+                             0x80,       0xb4,   {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
+
+uuid_object create_sha1_guid_from_name(const char* name, size_t namelen)
+{
+  uuid_object uuid;
+
+  /*put name space ID in network byte order so it hashes the same
+      no matter what endian machine we're on */
+  // namespace DNS
+  uuid_object net_nsid = {/* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
+                          0x6ba7b810, 0x9dad, 0x11d1, 0x80, 0xb4, {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
+
+  net_nsid.time_low = swapOrder32(net_nsid.time_low);
+  net_nsid.time_mid = swapOrder16(net_nsid.time_mid);
+  net_nsid.time_hi_and_version = swapOrder16(net_nsid.time_hi_and_version);
+
+  Sha1 c;
+  c.input((const uint8_t*)&net_nsid, sizeof(net_nsid));
+  c.input((const uint8_t*)name, namelen);
+  auto hash = c.hash();
+
+  /* convert UUID to local byte order */
+  memcpy(&uuid, hash.bytes, sizeof(uuid));
+  uuid.time_low = swapOrder32(uuid.time_low);
+  uuid.time_mid = swapOrder16(uuid.time_mid);
+  uuid.time_hi_and_version = swapOrder16(uuid.time_hi_and_version);
+
+  const auto v = 5;
+  /* put in the variant and version bits */
+  uuid.time_hi_and_version &= 0x0FFF;
+  uuid.time_hi_and_version |= (v << 12);
+  uuid.clock_seq_hi_and_reserved &= 0x3F;
+  uuid.clock_seq_hi_and_reserved |= 0x80;
+
+  return uuid;
+}
 }  // namespace Crypto

--- a/src/detail/sha1.cpp
+++ b/src/detail/sha1.cpp
@@ -11,7 +11,10 @@ namespace Crypto
   class Sha1
   {
    public:
-    Sha1() { reset(); }
+    Sha1()
+    {
+      reset();
+    }
     Sha1(const unsigned char* message_array, size_t length)
     {
       reset();
@@ -24,7 +27,10 @@ namespace Crypto
     void reset();
     void processMessageBlock();
     void padmessage();
-    inline uint32_t circularShift(int bits, uint32_t word) { return ((word << bits) & 0xFFFFFFFF) | ((word & 0xFFFFFFFF) >> (32 - bits)); }
+    inline uint32_t circularShift(int bits, uint32_t word)
+    {
+      return ((word << bits) & 0xFFFFFFFF) | ((word & 0xFFFFFFFF) >> (32 - bits));
+    }
 
     unsigned H[5] =  // Message digest buffers
         {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0};

--- a/src/detail/sha1.cpp
+++ b/src/detail/sha1.cpp
@@ -281,7 +281,8 @@ namespace Crypto
   {
     if (!isBigEndian)
     {
-      return ((n >> 24) & 0x000000FF) | ((n >> 8) & 0x0000FF00) | ((n << 8) & 0x00FF0000) | ((n << 24) & 0xFF000000);
+      return ((n >> 24) & 0x000000FF) | ((n >> 8) & 0x0000FF00) | ((n << 8) & 0x00FF0000) |
+             ((n << 24) & 0xFF000000);
     }
     else
     {
@@ -300,7 +301,8 @@ namespace Crypto
 
   /* Name string is a fully-qualified domain name */
   uuid_object NameSpace_DNS = {/* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
-                               0x6ba7b810, 0x9dad, 0x11d1, 0x80, 0xb4, {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
+                               0x6ba7b810, 0x9dad, 0x11d1,
+                               0x80,       0xb4,   {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
 
   uuid_object create_sha1_guid_from_name(const char* name, size_t namelen)
   {
@@ -309,8 +311,9 @@ namespace Crypto
     /*put name space ID in network byte order so it hashes the same
       no matter what endian machine we're on */
     // namespace DNS
-    uuid_object net_nsid = {/* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
-                            0x6ba7b810, 0x9dad, 0x11d1, 0x80, 0xb4, {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
+    uuid_object net_nsid = {
+        /* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
+        0x6ba7b810, 0x9dad, 0x11d1, 0x80, 0xb4, {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
 
     net_nsid.time_low = swapOrder32(net_nsid.time_low);
     net_nsid.time_mid = swapOrder16(net_nsid.time_mid);

--- a/src/detail/sha1.cpp
+++ b/src/detail/sha1.cpp
@@ -10,36 +10,33 @@ namespace Crypto
 {
   class Sha1
   {
-  public:
+   public:
     Sha1() { reset(); }
-    Sha1(const unsigned char *message_array, size_t length)
+    Sha1(const unsigned char* message_array, size_t length)
     {
       reset();
       input(message_array, length);
     }
-    void input(const unsigned char *message_array, size_t length);
+    void input(const unsigned char* message_array, size_t length);
     struct sha1hash hash();
 
-  private:
+   private:
     void reset();
     void processMessageBlock();
     void padmessage();
-    inline uint32_t circularShift(int bits, uint32_t word)
-    {
-      return ((word << bits) & 0xFFFFFFFF) | ((word & 0xFFFFFFFF) >> (32 - bits));
-    }
+    inline uint32_t circularShift(int bits, uint32_t word) { return ((word << bits) & 0xFFFFFFFF) | ((word & 0xFFFFFFFF) >> (32 - bits)); }
 
-    unsigned H[5] = // Message digest buffers
+    unsigned H[5] =  // Message digest buffers
         {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0};
 
-    uint32_t _lengthLow = 0;   // Message length in bits
-    uint32_t _length_high = 0; // Message length in bits
+    uint32_t _lengthLow = 0;    // Message length in bits
+    uint32_t _length_high = 0;  // Message length in bits
 
-    unsigned char _messageBlock[64] = {0}; // 512-bit message blocks
-    int _messageBlockIndex = 0;            // Index into message block array
+    unsigned char _messageBlock[64] = {0};  // 512-bit message blocks
+    int _messageBlockIndex = 0;             // Index into message block array
 
-    bool _computed = false;  // Is the digest computed?
-    bool _corrupted = false; // Is the message digest corruped?
+    bool _computed = false;   // Is the digest computed?
+    bool _corrupted = false;  // Is the message digest corruped?
   };
 
   void Sha1::reset()
@@ -58,7 +55,7 @@ namespace Crypto
     _corrupted = false;
   }
 
-  void Sha1::input(const unsigned char *message_array, size_t length)
+  void Sha1::input(const unsigned char* message_array, size_t length)
   {
     if (length == 0)
     {
@@ -81,14 +78,14 @@ namespace Crypto
       _messageBlock[_messageBlockIndex++] = (*message_array & 0xFF);
 
       _lengthLow += 8;
-      _lengthLow &= 0xFFFFFFFF; // Force it to 32 bits
+      _lengthLow &= 0xFFFFFFFF;  // Force it to 32 bits
       if (_lengthLow == 0)
       {
         _length_high++;
-        _length_high &= 0xFFFFFFFF; // Force it to 32 bits
+        _length_high &= 0xFFFFFFFF;  // Force it to 32 bits
         if (_length_high == 0)
         {
-          _corrupted = true; // Message is too long
+          _corrupted = true;  // Message is too long
         }
       }
 
@@ -105,10 +102,10 @@ namespace Crypto
   {
     const unsigned K[] = {// Constants defined for SHA-1
                           0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6};
-    int t;                  // Loop counter
-    unsigned temp;          // Temporary word value
-    unsigned W[80];         // Word sequence
-    unsigned A, B, C, D, E; // Word buffers
+    int t;                   // Loop counter
+    unsigned temp;           // Temporary word value
+    unsigned W[80];          // Word sequence
+    unsigned A, B, C, D, E;  // Word buffers
 
     /*
      *  Initialize the first 16 words in the array W
@@ -188,10 +185,10 @@ namespace Crypto
   void Sha1::padmessage()
   {
     /*
-     *  Check to see if the current message block is too small to hold
-     *  the initial padding bits and length.  If so, we will pad the
-     *  block, process it, and then continue padding into a second block.
-     */
+       *  Check to see if the current message block is too small to hold
+       *  the initial padding bits and length.  If so, we will pad the
+       *  block, process it, and then continue padding into a second block.
+       */
     if (_messageBlockIndex > 55)
     {
       _messageBlock[_messageBlockIndex++] = 0x80;
@@ -268,9 +265,9 @@ namespace Crypto
     return r;
   }
 
-  struct sha1hash sha1(const char *text, size_t len)
+  struct sha1hash sha1(const char* text, size_t len)
   {
-    Sha1 x((const unsigned char *)(text), len);
+    Sha1 x((const unsigned char*)(text), len);
     return x.hash();
   }
 
@@ -299,9 +296,8 @@ namespace Crypto
   uuid_object NameSpace_DNS = {/* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
                                0x6ba7b810, 0x9dad, 0x11d1, 0x80, 0xb4, {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
 
-  uuid_object create_sha1_guid_from_name(const char *name, size_t namelen)
+  uuid_object create_sha1_guid_from_name(const char* name, size_t namelen)
   {
-
     uuid_object uuid;
 
     /*put name space ID in network byte order so it hashes the same
@@ -315,8 +311,8 @@ namespace Crypto
     net_nsid.time_hi_and_version = swapOrder16(net_nsid.time_hi_and_version);
 
     Sha1 c;
-    c.input((const uint8_t *)&net_nsid, sizeof(net_nsid));
-    c.input((const uint8_t *)name, namelen);
+    c.input((const uint8_t*)&net_nsid, sizeof(net_nsid));
+    c.input((const uint8_t*)name, namelen);
     auto hash = c.hash();
 
     /* convert UUID to local byte order */
@@ -334,4 +330,4 @@ namespace Crypto
 
     return uuid;
   }
-} // namespace Crypto
+}  // namespace Crypto

--- a/src/detail/sha1.cpp
+++ b/src/detail/sha1.cpp
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <string.h>
 
-
 static constexpr bool isBigEndian = false;
 
 namespace Crypto
@@ -13,13 +12,14 @@ namespace Crypto
   {
   public:
     Sha1() { reset(); }
-    Sha1(const unsigned char* message_array, size_t length)
+    Sha1(const unsigned char *message_array, size_t length)
     {
       reset();
       input(message_array, length);
     }
-    void input(const unsigned char* message_array, size_t length);
+    void input(const unsigned char *message_array, size_t length);
     struct sha1hash hash();
+
   private:
     void reset();
     void processMessageBlock();
@@ -29,24 +29,17 @@ namespace Crypto
       return ((word << bits) & 0xFFFFFFFF) | ((word & 0xFFFFFFFF) >> (32 - bits));
     }
 
-    unsigned H[5] =                           // Message digest buffers
-    {
-      0x67452301,
-      0xEFCDAB89,
-      0x98BADCFE,
-      0x10325476,
-      0xC3D2E1F0
-    };
+    unsigned H[5] = // Message digest buffers
+        {0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0};
 
-    uint32_t _lengthLow = 0;                  // Message length in bits
-    uint32_t _length_high = 0;                 // Message length in bits
+    uint32_t _lengthLow = 0;   // Message length in bits
+    uint32_t _length_high = 0; // Message length in bits
 
-    unsigned char _messageBlock[64] = { 0 };    // 512-bit message blocks
-    int _messageBlockIndex = 0;              // Index into message block array
+    unsigned char _messageBlock[64] = {0}; // 512-bit message blocks
+    int _messageBlockIndex = 0;            // Index into message block array
 
-    bool _computed = false;                    // Is the digest computed?
-    bool _corrupted = false;                   // Is the message digest corruped?
-
+    bool _computed = false;  // Is the digest computed?
+    bool _corrupted = false; // Is the message digest corruped?
   };
 
   void Sha1::reset()
@@ -65,7 +58,7 @@ namespace Crypto
     _corrupted = false;
   }
 
-  void Sha1::input(const unsigned char* message_array, size_t length)
+  void Sha1::input(const unsigned char *message_array, size_t length)
   {
     if (length == 0)
     {
@@ -88,14 +81,14 @@ namespace Crypto
       _messageBlock[_messageBlockIndex++] = (*message_array & 0xFF);
 
       _lengthLow += 8;
-      _lengthLow &= 0xFFFFFFFF;               // Force it to 32 bits
+      _lengthLow &= 0xFFFFFFFF; // Force it to 32 bits
       if (_lengthLow == 0)
       {
         _length_high++;
-        _length_high &= 0xFFFFFFFF;          // Force it to 32 bits
+        _length_high &= 0xFFFFFFFF; // Force it to 32 bits
         if (_length_high == 0)
         {
-          _corrupted = true;               // Message is too long
+          _corrupted = true; // Message is too long
         }
       }
 
@@ -110,16 +103,12 @@ namespace Crypto
 
   void Sha1::processMessageBlock()
   {
-    const unsigned K[] = {               // Constants defined for SHA-1
-         0x5A827999,
-         0x6ED9EBA1,
-         0x8F1BBCDC,
-         0xCA62C1D6
-    };
-    int         t;                          // Loop counter
-    unsigned    temp;                       // Temporary word value
-    unsigned    W[80];                      // Word sequence
-    unsigned    A, B, C, D, E;              // Word buffers
+    const unsigned K[] = {// Constants defined for SHA-1
+                          0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xCA62C1D6};
+    int t;                  // Loop counter
+    unsigned temp;          // Temporary word value
+    unsigned W[80];         // Word sequence
+    unsigned A, B, C, D, E; // Word buffers
 
     /*
      *  Initialize the first 16 words in the array W
@@ -167,8 +156,7 @@ namespace Crypto
 
     for (t = 40; t < 60; t++)
     {
-      temp = circularShift(5, A) +
-        ((B & C) | (B & D) | (C & D)) + E + W[t] + K[2];
+      temp = circularShift(5, A) + ((B & C) | (B & D) | (C & D)) + E + W[t] + K[2];
       temp &= 0xFFFFFFFF;
       E = D;
       D = C;
@@ -200,10 +188,10 @@ namespace Crypto
   void Sha1::padmessage()
   {
     /*
-       *  Check to see if the current message block is too small to hold
-       *  the initial padding bits and length.  If so, we will pad the
-       *  block, process it, and then continue padding into a second block.
-       */
+     *  Check to see if the current message block is too small to hold
+     *  the initial padding bits and length.  If so, we will pad the
+     *  block, process it, and then continue padding into a second block.
+     */
     if (_messageBlockIndex > 55)
     {
       _messageBlock[_messageBlockIndex++] = 0x80;
@@ -226,7 +214,6 @@ namespace Crypto
       {
         _messageBlock[_messageBlockIndex++] = 0;
       }
-
     }
 
     /*
@@ -235,11 +222,11 @@ namespace Crypto
     _messageBlock[56] = (_length_high >> 24) & 0xFF;
     _messageBlock[57] = (_length_high >> 16) & 0xFF;
     _messageBlock[58] = (_length_high >> 8) & 0xFF;
-    _messageBlock[59] = (_length_high) & 0xFF;
+    _messageBlock[59] = (_length_high)&0xFF;
     _messageBlock[60] = (_lengthLow >> 24) & 0xFF;
     _messageBlock[61] = (_lengthLow >> 16) & 0xFF;
     _messageBlock[62] = (_lengthLow >> 8) & 0xFF;
-    _messageBlock[63] = (_lengthLow) & 0xFF;
+    _messageBlock[63] = (_lengthLow)&0xFF;
 
     processMessageBlock();
   }
@@ -281,10 +268,9 @@ namespace Crypto
     return r;
   }
 
-
-  struct sha1hash sha1(const char* text, size_t len)
+  struct sha1hash sha1(const char *text, size_t len)
   {
-    Sha1 x((const unsigned char*)(text), len);
+    Sha1 x((const unsigned char *)(text), len);
     return x.hash();
   }
 
@@ -292,11 +278,7 @@ namespace Crypto
   {
     if (!isBigEndian)
     {
-      return
-        ((n >> 24) & 0x000000FF) |
-        ((n >> 8) & 0x0000FF00) |
-        ((n << 8) & 0x00FF0000) |
-        ((n << 24) & 0xFF000000);
+      return ((n >> 24) & 0x000000FF) | ((n >> 8) & 0x0000FF00) | ((n << 8) & 0x00FF0000) | ((n << 24) & 0xFF000000);
     }
     else
     {
@@ -308,43 +290,33 @@ namespace Crypto
   {
     if (!isBigEndian)
     {
-      return
-        ((n >> 8) & 0x00FF) |
-        ((n << 8) & 0xFF00);
+      return ((n >> 8) & 0x00FF) | ((n << 8) & 0xFF00);
     }
     return n;
   }
 
   /* Name string is a fully-qualified domain name */
-  uuid_object NameSpace_DNS = { /* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
-      0x6ba7b810,
-      0x9dad,
-      0x11d1,
-      0x80, 0xb4, { 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8 }
-  };
+  uuid_object NameSpace_DNS = {/* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
+                               0x6ba7b810, 0x9dad, 0x11d1, 0x80, 0xb4, {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
 
-  uuid_object create_sha1_guid_from_name(const char* name, size_t namelen)
+  uuid_object create_sha1_guid_from_name(const char *name, size_t namelen)
   {
 
     uuid_object uuid;
 
     /*put name space ID in network byte order so it hashes the same
       no matter what endian machine we're on */
-      // namespace DNS
-    uuid_object net_nsid = { /* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
-      0x6ba7b810,
-      0x9dad,
-      0x11d1,
-      0x80, 0xb4, { 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8 }
-    };
+    // namespace DNS
+    uuid_object net_nsid = {/* 6ba7b810-9dad-11d1-80b4-00c04fd430c8 */
+                            0x6ba7b810, 0x9dad, 0x11d1, 0x80, 0xb4, {0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}};
 
     net_nsid.time_low = swapOrder32(net_nsid.time_low);
     net_nsid.time_mid = swapOrder16(net_nsid.time_mid);
     net_nsid.time_hi_and_version = swapOrder16(net_nsid.time_hi_and_version);
 
     Sha1 c;
-    c.input((const uint8_t*)&net_nsid, sizeof(net_nsid));
-    c.input((const uint8_t*)name, namelen);
+    c.input((const uint8_t *)&net_nsid, sizeof(net_nsid));
+    c.input((const uint8_t *)name, namelen);
     auto hash = c.hash();
 
     /* convert UUID to local byte order */
@@ -362,4 +334,4 @@ namespace Crypto
 
     return uuid;
   }
-}
+} // namespace Crypto

--- a/src/detail/sha1.h
+++ b/src/detail/sha1.h
@@ -6,23 +6,23 @@
 namespace Crypto
 {
 
-  struct sha1hash
-  {
-    uint8_t bytes[20];
-  };
+struct sha1hash
+{
+  uint8_t bytes[20];
+};
 
-  struct sha1hash sha1(const char* text, size_t len);
+struct sha1hash sha1(const char* text, size_t len);
 
-  typedef struct uuid_object_
-  {
-    uint32_t time_low;
-    uint16_t time_mid;
-    uint16_t time_hi_and_version;
-    uint8_t clock_seq_hi_and_reserved;
-    uint8_t clock_seq_low;
-    uint8_t node[6];
-  } uuid_object;
+typedef struct uuid_object_
+{
+  uint32_t time_low;
+  uint16_t time_mid;
+  uint16_t time_hi_and_version;
+  uint8_t clock_seq_hi_and_reserved;
+  uint8_t clock_seq_low;
+  uint8_t node[6];
+} uuid_object;
 
-  uuid_object create_sha1_guid_from_name(const char* name, size_t namelen);
+uuid_object create_sha1_guid_from_name(const char* name, size_t namelen);
 
 }  // namespace Crypto

--- a/src/detail/sha1.h
+++ b/src/detail/sha1.h
@@ -11,7 +11,7 @@ namespace Crypto
     uint8_t bytes[20];
   };
 
-  struct sha1hash sha1(const char *text, size_t len);
+  struct sha1hash sha1(const char* text, size_t len);
 
   typedef struct uuid_object_
   {
@@ -23,6 +23,6 @@ namespace Crypto
     uint8_t node[6];
   } uuid_object;
 
-  uuid_object create_sha1_guid_from_name(const char *name, size_t namelen);
+  uuid_object create_sha1_guid_from_name(const char* name, size_t namelen);
 
-} // namespace Crypto
+}  // namespace Crypto

--- a/src/detail/sha1.h
+++ b/src/detail/sha1.h
@@ -11,20 +11,18 @@ namespace Crypto
     uint8_t bytes[20];
   };
 
-  struct sha1hash sha1(const char* text, size_t len);
+  struct sha1hash sha1(const char *text, size_t len);
 
-  typedef struct uuid_object_ {
-    uint32_t  time_low;
-    uint16_t  time_mid;
-    uint16_t  time_hi_and_version;
-    uint8_t   clock_seq_hi_and_reserved;
-    uint8_t   clock_seq_low;
-    uint8_t   node[6];
-  } uuid_object;  
+  typedef struct uuid_object_
+  {
+    uint32_t time_low;
+    uint16_t time_mid;
+    uint16_t time_hi_and_version;
+    uint8_t clock_seq_hi_and_reserved;
+    uint8_t clock_seq_low;
+    uint8_t node[6];
+  } uuid_object;
 
-  uuid_object create_sha1_guid_from_name(const char* name, size_t namelen);  
-  
-}
+  uuid_object create_sha1_guid_from_name(const char *name, size_t namelen);
 
-
-
+} // namespace Crypto

--- a/src/detail/vst3/categories.cpp
+++ b/src/detail/vst3/categories.cpp
@@ -48,64 +48,61 @@
 using namespace Steinberg;
 using namespace Steinberg::Vst;
 
-// clang-format off
 static const struct _translate
 {
   const char* clapattribute;
   const char* vst3attribute;
-} translationTable[] =
-{
-  // CLAP main categories
-  {   CLAP_PLUGIN_FEATURE_INSTRUMENT            , PlugType::kInstrument },
-  {   CLAP_PLUGIN_FEATURE_AUDIO_EFFECT          , PlugType::kFx},
-  {   CLAP_PLUGIN_FEATURE_NOTE_EFFECT           , PlugType::kInstrumentSynth}, // it seems there is no type for a sequencer etc
-  {   CLAP_PLUGIN_FEATURE_DRUM                  , PlugType::kInstrumentDrum},
-  {   CLAP_PLUGIN_FEATURE_ANALYZER              , PlugType::kAnalyzer},
+} translationTable[] = {
+    // CLAP main categories
+    {CLAP_PLUGIN_FEATURE_INSTRUMENT, PlugType::kInstrument},
+    {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, PlugType::kFx},
+    {CLAP_PLUGIN_FEATURE_NOTE_EFFECT,
+     PlugType::kInstrumentSynth},  // it seems there is no type for a sequencer etc
+    {CLAP_PLUGIN_FEATURE_DRUM, PlugType::kInstrumentDrum},
+    {CLAP_PLUGIN_FEATURE_ANALYZER, PlugType::kAnalyzer},
 
-  // CLAP sub categories
-  {   CLAP_PLUGIN_FEATURE_SYNTHESIZER           , "Synth"},
-  {   CLAP_PLUGIN_FEATURE_SAMPLER               , "Sampler"},
-  {   CLAP_PLUGIN_FEATURE_DRUM                  , "Drum"},
-  {   CLAP_PLUGIN_FEATURE_DRUM_MACHINE          , "Drum"},
+    // CLAP sub categories
+    {CLAP_PLUGIN_FEATURE_SYNTHESIZER, "Synth"},
+    {CLAP_PLUGIN_FEATURE_SAMPLER, "Sampler"},
+    {CLAP_PLUGIN_FEATURE_DRUM, "Drum"},
+    {CLAP_PLUGIN_FEATURE_DRUM_MACHINE, "Drum"},
 
-  {   CLAP_PLUGIN_FEATURE_FILTER                , "Filter"},
-  {   CLAP_PLUGIN_FEATURE_PHASER                , "Modulation"          },
-  {   CLAP_PLUGIN_FEATURE_EQUALIZER             , "EQ"},
-  {   CLAP_PLUGIN_FEATURE_DEESSER               , "Restoration"},
-  {   CLAP_PLUGIN_FEATURE_PHASE_VOCODER         , "Modulation"},
-  {   CLAP_PLUGIN_FEATURE_GRANULAR              , "Synth"},
-  {   CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER     , "Modulator"},
-  {   CLAP_PLUGIN_FEATURE_PITCH_SHIFTER         , "Pitch Shifter"},
+    {CLAP_PLUGIN_FEATURE_FILTER, "Filter"},
+    {CLAP_PLUGIN_FEATURE_PHASER, "Modulation"},
+    {CLAP_PLUGIN_FEATURE_EQUALIZER, "EQ"},
+    {CLAP_PLUGIN_FEATURE_DEESSER, "Restoration"},
+    {CLAP_PLUGIN_FEATURE_PHASE_VOCODER, "Modulation"},
+    {CLAP_PLUGIN_FEATURE_GRANULAR, "Synth"},
+    {CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER, "Modulator"},
+    {CLAP_PLUGIN_FEATURE_PITCH_SHIFTER, "Pitch Shifter"},
 
-  {   CLAP_PLUGIN_FEATURE_DISTORTION            , "Distortion"},
-  {   CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER      , "Distortion"},
-  {   CLAP_PLUGIN_FEATURE_COMPRESSOR            , "Dynamics"},
-  {   CLAP_PLUGIN_FEATURE_LIMITER               , "Dynamics"},
+    {CLAP_PLUGIN_FEATURE_DISTORTION, "Distortion"},
+    {CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER, "Distortion"},
+    {CLAP_PLUGIN_FEATURE_COMPRESSOR, "Dynamics"},
+    {CLAP_PLUGIN_FEATURE_LIMITER, "Dynamics"},
 
-  {   CLAP_PLUGIN_FEATURE_FLANGER               , "Modulation"},
-  // {   CLAP_PLUGIN_FEATURE_FLANGER               , "Flanger"},
-  {   CLAP_PLUGIN_FEATURE_CHORUS                , "Modulation"},
-  // {   CLAP_PLUGIN_FEATURE_CHORUS                , "Chorus"},
-  {   CLAP_PLUGIN_FEATURE_DELAY                 , "Delay"},
-  {   CLAP_PLUGIN_FEATURE_REVERB                , "Reverb"},
+    {CLAP_PLUGIN_FEATURE_FLANGER, "Modulation"},
+    // {   CLAP_PLUGIN_FEATURE_FLANGER               , "Flanger"},
+    {CLAP_PLUGIN_FEATURE_CHORUS, "Modulation"},
+    // {   CLAP_PLUGIN_FEATURE_CHORUS                , "Chorus"},
+    {CLAP_PLUGIN_FEATURE_DELAY, "Delay"},
+    {CLAP_PLUGIN_FEATURE_REVERB, "Reverb"},
 
-  {   CLAP_PLUGIN_FEATURE_TREMOLO               , "Modulation"},
-  {   CLAP_PLUGIN_FEATURE_GLITCH                , "Modulation"},
+    {CLAP_PLUGIN_FEATURE_TREMOLO, "Modulation"},
+    {CLAP_PLUGIN_FEATURE_GLITCH, "Modulation"},
 
-  {   CLAP_PLUGIN_FEATURE_UTILITY               , "Tools"},
-  {   CLAP_PLUGIN_FEATURE_PITCH_CORRECTION      , "Pitch Shift"},
-  {   CLAP_PLUGIN_FEATURE_RESTORATION           , "Restoration"},
+    {CLAP_PLUGIN_FEATURE_UTILITY, "Tools"},
+    {CLAP_PLUGIN_FEATURE_PITCH_CORRECTION, "Pitch Shift"},
+    {CLAP_PLUGIN_FEATURE_RESTORATION, "Restoration"},
 
-  {   CLAP_PLUGIN_FEATURE_MULTI_EFFECTS         , "Tools"},
+    {CLAP_PLUGIN_FEATURE_MULTI_EFFECTS, "Tools"},
 
-  {   CLAP_PLUGIN_FEATURE_MIXING                , "Mixing"},
-  {   CLAP_PLUGIN_FEATURE_MASTERING             , "Mastering"},
+    {CLAP_PLUGIN_FEATURE_MIXING, "Mixing"},
+    {CLAP_PLUGIN_FEATURE_MASTERING, "Mastering"},
 
-  {   "external"                                , "External"},
+    {"external", "External"},
 
-  {nullptr, nullptr}
-};
-// clang-format on
+    {nullptr, nullptr}};
 
 std::string clapCategoriesToVST3(const char* const* clap_categories)
 {

--- a/src/detail/vst3/categories.cpp
+++ b/src/detail/vst3/categories.cpp
@@ -48,61 +48,64 @@
 using namespace Steinberg;
 using namespace Steinberg::Vst;
 
+// clang-format off
 static const struct _translate
 {
   const char* clapattribute;
   const char* vst3attribute;
-} translationTable[] = {
-    // CLAP main categories
-    {CLAP_PLUGIN_FEATURE_INSTRUMENT, PlugType::kInstrument},
-    {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, PlugType::kFx},
-    {CLAP_PLUGIN_FEATURE_NOTE_EFFECT,
-     PlugType::kInstrumentSynth},  // it seems there is no type for a sequencer etc
-    {CLAP_PLUGIN_FEATURE_DRUM, PlugType::kInstrumentDrum},
-    {CLAP_PLUGIN_FEATURE_ANALYZER, PlugType::kAnalyzer},
+} translationTable[] =
+{
+  // CLAP main categories
+  {   CLAP_PLUGIN_FEATURE_INSTRUMENT            , PlugType::kInstrument },
+  {   CLAP_PLUGIN_FEATURE_AUDIO_EFFECT          , PlugType::kFx},
+  {   CLAP_PLUGIN_FEATURE_NOTE_EFFECT           , PlugType::kInstrumentSynth}, // it seems there is no type for a sequencer etc
+  {   CLAP_PLUGIN_FEATURE_DRUM                  , PlugType::kInstrumentDrum},
+  {   CLAP_PLUGIN_FEATURE_ANALYZER              , PlugType::kAnalyzer},
 
-    // CLAP sub categories
-    {CLAP_PLUGIN_FEATURE_SYNTHESIZER, "Synth"},
-    {CLAP_PLUGIN_FEATURE_SAMPLER, "Sampler"},
-    {CLAP_PLUGIN_FEATURE_DRUM, "Drum"},
-    {CLAP_PLUGIN_FEATURE_DRUM_MACHINE, "Drum"},
+  // CLAP sub categories
+  {   CLAP_PLUGIN_FEATURE_SYNTHESIZER           , "Synth"},
+  {   CLAP_PLUGIN_FEATURE_SAMPLER               , "Sampler"},
+  {   CLAP_PLUGIN_FEATURE_DRUM                  , "Drum"},
+  {   CLAP_PLUGIN_FEATURE_DRUM_MACHINE          , "Drum"},
 
-    {CLAP_PLUGIN_FEATURE_FILTER, "Filter"},
-    {CLAP_PLUGIN_FEATURE_PHASER, "Modulation"},
-    {CLAP_PLUGIN_FEATURE_EQUALIZER, "EQ"},
-    {CLAP_PLUGIN_FEATURE_DEESSER, "Restoration"},
-    {CLAP_PLUGIN_FEATURE_PHASE_VOCODER, "Modulation"},
-    {CLAP_PLUGIN_FEATURE_GRANULAR, "Synth"},
-    {CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER, "Modulator"},
-    {CLAP_PLUGIN_FEATURE_PITCH_SHIFTER, "Pitch Shifter"},
+  {   CLAP_PLUGIN_FEATURE_FILTER                , "Filter"},
+  {   CLAP_PLUGIN_FEATURE_PHASER                , "Modulation"          },
+  {   CLAP_PLUGIN_FEATURE_EQUALIZER             , "EQ"},
+  {   CLAP_PLUGIN_FEATURE_DEESSER               , "Restoration"},
+  {   CLAP_PLUGIN_FEATURE_PHASE_VOCODER         , "Modulation"},
+  {   CLAP_PLUGIN_FEATURE_GRANULAR              , "Synth"},
+  {   CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER     , "Modulator"},
+  {   CLAP_PLUGIN_FEATURE_PITCH_SHIFTER         , "Pitch Shifter"},
 
-    {CLAP_PLUGIN_FEATURE_DISTORTION, "Distortion"},
-    {CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER, "Distortion"},
-    {CLAP_PLUGIN_FEATURE_COMPRESSOR, "Dynamics"},
-    {CLAP_PLUGIN_FEATURE_LIMITER, "Dynamics"},
+  {   CLAP_PLUGIN_FEATURE_DISTORTION            , "Distortion"},
+  {   CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER      , "Distortion"},
+  {   CLAP_PLUGIN_FEATURE_COMPRESSOR            , "Dynamics"},
+  {   CLAP_PLUGIN_FEATURE_LIMITER               , "Dynamics"},
 
-    {CLAP_PLUGIN_FEATURE_FLANGER, "Modulation"},
-    // {   CLAP_PLUGIN_FEATURE_FLANGER               , "Flanger"},
-    {CLAP_PLUGIN_FEATURE_CHORUS, "Modulation"},
-    // {   CLAP_PLUGIN_FEATURE_CHORUS                , "Chorus"},
-    {CLAP_PLUGIN_FEATURE_DELAY, "Delay"},
-    {CLAP_PLUGIN_FEATURE_REVERB, "Reverb"},
+  {   CLAP_PLUGIN_FEATURE_FLANGER               , "Modulation"},
+  // {   CLAP_PLUGIN_FEATURE_FLANGER               , "Flanger"},
+  {   CLAP_PLUGIN_FEATURE_CHORUS                , "Modulation"},
+  // {   CLAP_PLUGIN_FEATURE_CHORUS                , "Chorus"},
+  {   CLAP_PLUGIN_FEATURE_DELAY                 , "Delay"},
+  {   CLAP_PLUGIN_FEATURE_REVERB                , "Reverb"},
 
-    {CLAP_PLUGIN_FEATURE_TREMOLO, "Modulation"},
-    {CLAP_PLUGIN_FEATURE_GLITCH, "Modulation"},
+  {   CLAP_PLUGIN_FEATURE_TREMOLO               , "Modulation"},
+  {   CLAP_PLUGIN_FEATURE_GLITCH                , "Modulation"},
 
-    {CLAP_PLUGIN_FEATURE_UTILITY, "Tools"},
-    {CLAP_PLUGIN_FEATURE_PITCH_CORRECTION, "Pitch Shift"},
-    {CLAP_PLUGIN_FEATURE_RESTORATION, "Restoration"},
+  {   CLAP_PLUGIN_FEATURE_UTILITY               , "Tools"},
+  {   CLAP_PLUGIN_FEATURE_PITCH_CORRECTION      , "Pitch Shift"},
+  {   CLAP_PLUGIN_FEATURE_RESTORATION           , "Restoration"},
 
-    {CLAP_PLUGIN_FEATURE_MULTI_EFFECTS, "Tools"},
+  {   CLAP_PLUGIN_FEATURE_MULTI_EFFECTS         , "Tools"},
 
-    {CLAP_PLUGIN_FEATURE_MIXING, "Mixing"},
-    {CLAP_PLUGIN_FEATURE_MASTERING, "Mastering"},
+  {   CLAP_PLUGIN_FEATURE_MIXING                , "Mixing"},
+  {   CLAP_PLUGIN_FEATURE_MASTERING             , "Mastering"},
 
-    {"external", "External"},
+  {   "external"                                , "External"},
 
-    {nullptr, nullptr}};
+  {nullptr, nullptr}
+};
+// clang-format off
 
 std::string clapCategoriesToVST3(const char* const* clap_categories)
 {
@@ -128,8 +131,8 @@ std::string clapCategoriesToVST3(const char* const* clap_categories)
     {
       r2.push_back(i);
     }
-  }
-
+  }  
+  
   std::string result;
   for (auto& i : r2)
   {
@@ -146,4 +149,5 @@ std::string clapCategoriesToVST3(const char* const* clap_categories)
   }
   result.pop_back();
   return result;
+
 }

--- a/src/detail/vst3/categories.cpp
+++ b/src/detail/vst3/categories.cpp
@@ -105,7 +105,7 @@ static const struct _translate
 
   {nullptr, nullptr}
 };
-// clang-format off
+// clang-format on
 
 std::string clapCategoriesToVST3(const char* const* clap_categories)
 {
@@ -131,8 +131,8 @@ std::string clapCategoriesToVST3(const char* const* clap_categories)
     {
       r2.push_back(i);
     }
-  }  
-  
+  }
+
   std::string result;
   for (auto& i : r2)
   {
@@ -149,5 +149,4 @@ std::string clapCategoriesToVST3(const char* const* clap_categories)
   }
   result.pop_back();
   return result;
-
 }

--- a/src/detail/vst3/categories.cpp
+++ b/src/detail/vst3/categories.cpp
@@ -48,60 +48,64 @@
 using namespace Steinberg;
 using namespace Steinberg::Vst;
 
+// clang-format off
 static const struct _translate
 {
   const char* clapattribute;
   const char* vst3attribute;
-} translationTable[] = {
-    // CLAP main categories
-    {CLAP_PLUGIN_FEATURE_INSTRUMENT, PlugType::kInstrument},
-    {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, PlugType::kFx},
-    {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, PlugType::kInstrumentSynth},  // it seems there is no type for a sequencer etc
-    {CLAP_PLUGIN_FEATURE_DRUM, PlugType::kInstrumentDrum},
-    {CLAP_PLUGIN_FEATURE_ANALYZER, PlugType::kAnalyzer},
+} translationTable[] =
+{
+  // CLAP main categories
+  {   CLAP_PLUGIN_FEATURE_INSTRUMENT            , PlugType::kInstrument },
+  {   CLAP_PLUGIN_FEATURE_AUDIO_EFFECT          , PlugType::kFx},
+  {   CLAP_PLUGIN_FEATURE_NOTE_EFFECT           , PlugType::kInstrumentSynth}, // it seems there is no type for a sequencer etc
+  {   CLAP_PLUGIN_FEATURE_DRUM                  , PlugType::kInstrumentDrum},
+  {   CLAP_PLUGIN_FEATURE_ANALYZER              , PlugType::kAnalyzer},
 
-    // CLAP sub categories
-    {CLAP_PLUGIN_FEATURE_SYNTHESIZER, "Synth"},
-    {CLAP_PLUGIN_FEATURE_SAMPLER, "Sampler"},
-    {CLAP_PLUGIN_FEATURE_DRUM, "Drum"},
-    {CLAP_PLUGIN_FEATURE_DRUM_MACHINE, "Drum"},
+  // CLAP sub categories
+  {   CLAP_PLUGIN_FEATURE_SYNTHESIZER           , "Synth"},
+  {   CLAP_PLUGIN_FEATURE_SAMPLER               , "Sampler"},
+  {   CLAP_PLUGIN_FEATURE_DRUM                  , "Drum"},
+  {   CLAP_PLUGIN_FEATURE_DRUM_MACHINE          , "Drum"},
 
-    {CLAP_PLUGIN_FEATURE_FILTER, "Filter"},
-    {CLAP_PLUGIN_FEATURE_PHASER, "Modulation"},
-    {CLAP_PLUGIN_FEATURE_EQUALIZER, "EQ"},
-    {CLAP_PLUGIN_FEATURE_DEESSER, "Restoration"},
-    {CLAP_PLUGIN_FEATURE_PHASE_VOCODER, "Modulation"},
-    {CLAP_PLUGIN_FEATURE_GRANULAR, "Synth"},
-    {CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER, "Modulator"},
-    {CLAP_PLUGIN_FEATURE_PITCH_SHIFTER, "Pitch Shifter"},
+  {   CLAP_PLUGIN_FEATURE_FILTER                , "Filter"},
+  {   CLAP_PLUGIN_FEATURE_PHASER                , "Modulation"          },
+  {   CLAP_PLUGIN_FEATURE_EQUALIZER             , "EQ"},
+  {   CLAP_PLUGIN_FEATURE_DEESSER               , "Restoration"},
+  {   CLAP_PLUGIN_FEATURE_PHASE_VOCODER         , "Modulation"},
+  {   CLAP_PLUGIN_FEATURE_GRANULAR              , "Synth"},
+  {   CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER     , "Modulator"},
+  {   CLAP_PLUGIN_FEATURE_PITCH_SHIFTER         , "Pitch Shifter"},
 
-    {CLAP_PLUGIN_FEATURE_DISTORTION, "Distortion"},
-    {CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER, "Distortion"},
-    {CLAP_PLUGIN_FEATURE_COMPRESSOR, "Dynamics"},
-    {CLAP_PLUGIN_FEATURE_LIMITER, "Dynamics"},
+  {   CLAP_PLUGIN_FEATURE_DISTORTION            , "Distortion"},
+  {   CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER      , "Distortion"},
+  {   CLAP_PLUGIN_FEATURE_COMPRESSOR            , "Dynamics"},
+  {   CLAP_PLUGIN_FEATURE_LIMITER               , "Dynamics"},
 
-    {CLAP_PLUGIN_FEATURE_FLANGER, "Modulation"},
-    // {   CLAP_PLUGIN_FEATURE_FLANGER               , "Flanger"},
-    {CLAP_PLUGIN_FEATURE_CHORUS, "Modulation"},
-    // {   CLAP_PLUGIN_FEATURE_CHORUS                , "Chorus"},
-    {CLAP_PLUGIN_FEATURE_DELAY, "Delay"},
-    {CLAP_PLUGIN_FEATURE_REVERB, "Reverb"},
+  {   CLAP_PLUGIN_FEATURE_FLANGER               , "Modulation"},
+  // {   CLAP_PLUGIN_FEATURE_FLANGER               , "Flanger"},
+  {   CLAP_PLUGIN_FEATURE_CHORUS                , "Modulation"},
+  // {   CLAP_PLUGIN_FEATURE_CHORUS                , "Chorus"},
+  {   CLAP_PLUGIN_FEATURE_DELAY                 , "Delay"},
+  {   CLAP_PLUGIN_FEATURE_REVERB                , "Reverb"},
 
-    {CLAP_PLUGIN_FEATURE_TREMOLO, "Modulation"},
-    {CLAP_PLUGIN_FEATURE_GLITCH, "Modulation"},
+  {   CLAP_PLUGIN_FEATURE_TREMOLO               , "Modulation"},
+  {   CLAP_PLUGIN_FEATURE_GLITCH                , "Modulation"},
 
-    {CLAP_PLUGIN_FEATURE_UTILITY, "Tools"},
-    {CLAP_PLUGIN_FEATURE_PITCH_CORRECTION, "Pitch Shift"},
-    {CLAP_PLUGIN_FEATURE_RESTORATION, "Restoration"},
+  {   CLAP_PLUGIN_FEATURE_UTILITY               , "Tools"},
+  {   CLAP_PLUGIN_FEATURE_PITCH_CORRECTION      , "Pitch Shift"},
+  {   CLAP_PLUGIN_FEATURE_RESTORATION           , "Restoration"},
 
-    {CLAP_PLUGIN_FEATURE_MULTI_EFFECTS, "Tools"},
+  {   CLAP_PLUGIN_FEATURE_MULTI_EFFECTS         , "Tools"},
 
-    {CLAP_PLUGIN_FEATURE_MIXING, "Mixing"},
-    {CLAP_PLUGIN_FEATURE_MASTERING, "Mastering"},
+  {   CLAP_PLUGIN_FEATURE_MIXING                , "Mixing"},
+  {   CLAP_PLUGIN_FEATURE_MASTERING             , "Mastering"},
 
-    {"external", "External"},
+  {   "external"                                , "External"},
 
-    {nullptr, nullptr}};
+  {nullptr, nullptr}
+};
+// clang-format on
 
 std::string clapCategoriesToVST3(const char* const* clap_categories)
 {

--- a/src/detail/vst3/categories.cpp
+++ b/src/detail/vst3/categories.cpp
@@ -1,6 +1,6 @@
 /*
     converting CLAP categories to VST3 categories
-
+    
     Copyright (c) 2022 Timo Kaluza (defiantnerd)
 
     This file is part of the clap-wrappers project which is released under MIT License.
@@ -50,13 +50,13 @@ using namespace Steinberg::Vst;
 
 static const struct _translate
 {
-  const char *clapattribute;
-  const char *vst3attribute;
+  const char* clapattribute;
+  const char* vst3attribute;
 } translationTable[] = {
     // CLAP main categories
     {CLAP_PLUGIN_FEATURE_INSTRUMENT, PlugType::kInstrument},
     {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, PlugType::kFx},
-    {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, PlugType::kInstrumentSynth}, // it seems there is no type for a sequencer etc
+    {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, PlugType::kInstrumentSynth},  // it seems there is no type for a sequencer etc
     {CLAP_PLUGIN_FEATURE_DRUM, PlugType::kInstrumentDrum},
     {CLAP_PLUGIN_FEATURE_ANALYZER, PlugType::kAnalyzer},
 
@@ -103,7 +103,7 @@ static const struct _translate
 
     {nullptr, nullptr}};
 
-std::string clapCategoriesToVST3(const char *const *clap_categories)
+std::string clapCategoriesToVST3(const char* const* clap_categories)
 {
   std::vector<std::string> r;
   auto f = clap_categories;
@@ -121,7 +121,7 @@ std::string clapCategoriesToVST3(const char *const *clap_categories)
     ++f;
   }
   std::vector<std::string> r2;
-  for (auto &i : r)
+  for (auto& i : r)
   {
     if (std::find(r2.begin(), r2.end(), i) == r2.end())
     {
@@ -130,7 +130,7 @@ std::string clapCategoriesToVST3(const char *const *clap_categories)
   }
 
   std::string result;
-  for (auto &i : r2)
+  for (auto& i : r2)
   {
     if (result.size() + i.size() <= Steinberg::PClassInfo2::kSubCategoriesSize)
     {

--- a/src/detail/vst3/categories.cpp
+++ b/src/detail/vst3/categories.cpp
@@ -1,6 +1,6 @@
 /*
     converting CLAP categories to VST3 categories
-    
+
     Copyright (c) 2022 Timo Kaluza (defiantnerd)
 
     This file is part of the clap-wrappers project which is released under MIT License.
@@ -50,62 +50,60 @@ using namespace Steinberg::Vst;
 
 static const struct _translate
 {
-  const char* clapattribute;
-  const char* vst3attribute;
-} translationTable[] =
-{
-  // CLAP main categories
-  {   CLAP_PLUGIN_FEATURE_INSTRUMENT            , PlugType::kInstrument },
-  {   CLAP_PLUGIN_FEATURE_AUDIO_EFFECT          , PlugType::kFx},
-  {   CLAP_PLUGIN_FEATURE_NOTE_EFFECT           , PlugType::kInstrumentSynth}, // it seems there is no type for a sequencer etc
-  {   CLAP_PLUGIN_FEATURE_DRUM                  , PlugType::kInstrumentDrum},
-  {   CLAP_PLUGIN_FEATURE_ANALYZER              , PlugType::kAnalyzer},
+  const char *clapattribute;
+  const char *vst3attribute;
+} translationTable[] = {
+    // CLAP main categories
+    {CLAP_PLUGIN_FEATURE_INSTRUMENT, PlugType::kInstrument},
+    {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, PlugType::kFx},
+    {CLAP_PLUGIN_FEATURE_NOTE_EFFECT, PlugType::kInstrumentSynth}, // it seems there is no type for a sequencer etc
+    {CLAP_PLUGIN_FEATURE_DRUM, PlugType::kInstrumentDrum},
+    {CLAP_PLUGIN_FEATURE_ANALYZER, PlugType::kAnalyzer},
 
-  // CLAP sub categories
-  {   CLAP_PLUGIN_FEATURE_SYNTHESIZER           , "Synth"},
-  {   CLAP_PLUGIN_FEATURE_SAMPLER               , "Sampler"},
-  {   CLAP_PLUGIN_FEATURE_DRUM                  , "Drum"},
-  {   CLAP_PLUGIN_FEATURE_DRUM_MACHINE          , "Drum"},
+    // CLAP sub categories
+    {CLAP_PLUGIN_FEATURE_SYNTHESIZER, "Synth"},
+    {CLAP_PLUGIN_FEATURE_SAMPLER, "Sampler"},
+    {CLAP_PLUGIN_FEATURE_DRUM, "Drum"},
+    {CLAP_PLUGIN_FEATURE_DRUM_MACHINE, "Drum"},
 
-  {   CLAP_PLUGIN_FEATURE_FILTER                , "Filter"},
-  {   CLAP_PLUGIN_FEATURE_PHASER                , "Modulation"          },
-  {   CLAP_PLUGIN_FEATURE_EQUALIZER             , "EQ"},
-  {   CLAP_PLUGIN_FEATURE_DEESSER               , "Restoration"},
-  {   CLAP_PLUGIN_FEATURE_PHASE_VOCODER         , "Modulation"},
-  {   CLAP_PLUGIN_FEATURE_GRANULAR              , "Synth"},
-  {   CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER     , "Modulator"},
-  {   CLAP_PLUGIN_FEATURE_PITCH_SHIFTER         , "Pitch Shifter"},
+    {CLAP_PLUGIN_FEATURE_FILTER, "Filter"},
+    {CLAP_PLUGIN_FEATURE_PHASER, "Modulation"},
+    {CLAP_PLUGIN_FEATURE_EQUALIZER, "EQ"},
+    {CLAP_PLUGIN_FEATURE_DEESSER, "Restoration"},
+    {CLAP_PLUGIN_FEATURE_PHASE_VOCODER, "Modulation"},
+    {CLAP_PLUGIN_FEATURE_GRANULAR, "Synth"},
+    {CLAP_PLUGIN_FEATURE_FREQUENCY_SHIFTER, "Modulator"},
+    {CLAP_PLUGIN_FEATURE_PITCH_SHIFTER, "Pitch Shifter"},
 
-  {   CLAP_PLUGIN_FEATURE_DISTORTION            , "Distortion"},
-  {   CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER      , "Distortion"},
-  {   CLAP_PLUGIN_FEATURE_COMPRESSOR            , "Dynamics"},
-  {   CLAP_PLUGIN_FEATURE_LIMITER               , "Dynamics"},
+    {CLAP_PLUGIN_FEATURE_DISTORTION, "Distortion"},
+    {CLAP_PLUGIN_FEATURE_TRANSIENT_SHAPER, "Distortion"},
+    {CLAP_PLUGIN_FEATURE_COMPRESSOR, "Dynamics"},
+    {CLAP_PLUGIN_FEATURE_LIMITER, "Dynamics"},
 
-  {   CLAP_PLUGIN_FEATURE_FLANGER               , "Modulation"},
-  // {   CLAP_PLUGIN_FEATURE_FLANGER               , "Flanger"},
-  {   CLAP_PLUGIN_FEATURE_CHORUS                , "Modulation"},
-  // {   CLAP_PLUGIN_FEATURE_CHORUS                , "Chorus"},
-  {   CLAP_PLUGIN_FEATURE_DELAY                 , "Delay"},
-  {   CLAP_PLUGIN_FEATURE_REVERB                , "Reverb"},
+    {CLAP_PLUGIN_FEATURE_FLANGER, "Modulation"},
+    // {   CLAP_PLUGIN_FEATURE_FLANGER               , "Flanger"},
+    {CLAP_PLUGIN_FEATURE_CHORUS, "Modulation"},
+    // {   CLAP_PLUGIN_FEATURE_CHORUS                , "Chorus"},
+    {CLAP_PLUGIN_FEATURE_DELAY, "Delay"},
+    {CLAP_PLUGIN_FEATURE_REVERB, "Reverb"},
 
-  {   CLAP_PLUGIN_FEATURE_TREMOLO               , "Modulation"},
-  {   CLAP_PLUGIN_FEATURE_GLITCH                , "Modulation"},
+    {CLAP_PLUGIN_FEATURE_TREMOLO, "Modulation"},
+    {CLAP_PLUGIN_FEATURE_GLITCH, "Modulation"},
 
-  {   CLAP_PLUGIN_FEATURE_UTILITY               , "Tools"},
-  {   CLAP_PLUGIN_FEATURE_PITCH_CORRECTION      , "Pitch Shift"},
-  {   CLAP_PLUGIN_FEATURE_RESTORATION           , "Restoration"},
+    {CLAP_PLUGIN_FEATURE_UTILITY, "Tools"},
+    {CLAP_PLUGIN_FEATURE_PITCH_CORRECTION, "Pitch Shift"},
+    {CLAP_PLUGIN_FEATURE_RESTORATION, "Restoration"},
 
-  {   CLAP_PLUGIN_FEATURE_MULTI_EFFECTS         , "Tools"},
+    {CLAP_PLUGIN_FEATURE_MULTI_EFFECTS, "Tools"},
 
-  {   CLAP_PLUGIN_FEATURE_MIXING                , "Mixing"},
-  {   CLAP_PLUGIN_FEATURE_MASTERING             , "Mastering"},
+    {CLAP_PLUGIN_FEATURE_MIXING, "Mixing"},
+    {CLAP_PLUGIN_FEATURE_MASTERING, "Mastering"},
 
-  {   "external"                                , "External"},
+    {"external", "External"},
 
-  {nullptr, nullptr}
-};
+    {nullptr, nullptr}};
 
-std::string clapCategoriesToVST3(const char* const* clap_categories)
+std::string clapCategoriesToVST3(const char *const *clap_categories)
 {
   std::vector<std::string> r;
   auto f = clap_categories;
@@ -123,16 +121,16 @@ std::string clapCategoriesToVST3(const char* const* clap_categories)
     ++f;
   }
   std::vector<std::string> r2;
-  for (auto& i : r)
+  for (auto &i : r)
   {
     if (std::find(r2.begin(), r2.end(), i) == r2.end())
     {
       r2.push_back(i);
     }
-  }  
-  
+  }
+
   std::string result;
-  for (auto& i : r2)
+  for (auto &i : r2)
   {
     if (result.size() + i.size() <= Steinberg::PClassInfo2::kSubCategoriesSize)
     {
@@ -147,5 +145,4 @@ std::string clapCategoriesToVST3(const char* const* clap_categories)
   }
   result.pop_back();
   return result;
-
 }

--- a/src/detail/vst3/categories.h
+++ b/src/detail/vst3/categories.h
@@ -3,4 +3,4 @@
 // see categories.cpp for details
 
 #include <string>
-std::string clapCategoriesToVST3(const char *const *clap_categories);
+std::string clapCategoriesToVST3(const char* const* clap_categories);

--- a/src/detail/vst3/categories.h
+++ b/src/detail/vst3/categories.h
@@ -3,4 +3,4 @@
 // see categories.cpp for details
 
 #include <string>
-std::string clapCategoriesToVST3(const char* const* clap_categories);
+std::string clapCategoriesToVST3(const char *const *clap_categories);

--- a/src/detail/vst3/os/linux.cpp
+++ b/src/detail/vst3/os/linux.cpp
@@ -1,12 +1,12 @@
 /**
- *		the Linux helper
- *
- *		provides services for all plugin instances regarding Linux
- *		- global timer object
- *		- dispatch to UI thread
- *		- get binary name
- *
- */
+*		the Linux helper
+* 
+*		provides services for all plugin instances regarding Linux
+*		- global timer object
+*		- dispatch to UI thread
+*		- get binary name
+* 
+*/
 
 #include "public.sdk/source/main/moduleinit.h"
 #include "osutil.h"
@@ -17,19 +17,19 @@
 
 namespace os
 {
-  void log(const char *text) { fprintf(stderr, "%s\n", text); }
+  void log(const char* text) { fprintf(stderr, "%s\n", text); }
 
   class LinuxHelper
   {
-  public:
+   public:
     void init();
     void terminate();
-    void attach(IPlugObject *plugobject);
-    void detach(IPlugObject *plugobject);
+    void attach(IPlugObject* plugobject);
+    void detach(IPlugObject* plugobject);
 
-  private:
+   private:
     void executeDefered();
-    std::vector<IPlugObject *> _plugs;
+    std::vector<IPlugObject*> _plugs;
   } gLinuxHelper;
 
 #if 0
@@ -79,7 +79,7 @@ namespace os
   static std::string getModuleName()
   {
     Dl_info info;
-    if (dladdr((void *)getModuleName, &info))
+    if (dladdr((void*)getModuleName, &info))
     {
       return info.dli_fname;
     }
@@ -163,22 +163,19 @@ namespace os
       p->onIdle();
     }
   }
-  void LinuxHelper::attach(IPlugObject *plugobject) { _plugs.push_back(plugobject); }
+  void LinuxHelper::attach(IPlugObject* plugobject) { _plugs.push_back(plugobject); }
 
-  void LinuxHelper::detach(IPlugObject *plugobject)
-  {
-    _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
-  }
+  void LinuxHelper::detach(IPlugObject* plugobject) { _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end()); }
 
-} // namespace os
+}  // namespace os
 
 namespace os
 {
   // [UI Thread]
-  void attach(IPlugObject *plugobject) { gLinuxHelper.attach(plugobject); }
+  void attach(IPlugObject* plugobject) { gLinuxHelper.attach(plugobject); }
 
   // [UI Thread]
-  void detach(IPlugObject *plugobject) { gLinuxHelper.detach(plugobject); }
+  void detach(IPlugObject* plugobject) { gLinuxHelper.detach(plugobject); }
 
   uint64_t getTickInMS() { return clock(); }
-} // namespace os
+}  // namespace os

--- a/src/detail/vst3/os/linux.cpp
+++ b/src/detail/vst3/os/linux.cpp
@@ -17,23 +17,23 @@
 
 namespace os
 {
-  void log(const char* text)
-  {
-    fprintf(stderr, "%s\n", text);
-  }
+void log(const char* text)
+{
+  fprintf(stderr, "%s\n", text);
+}
 
-  class LinuxHelper
-  {
-   public:
-    void init();
-    void terminate();
-    void attach(IPlugObject* plugobject);
-    void detach(IPlugObject* plugobject);
+class LinuxHelper
+{
+ public:
+  void init();
+  void terminate();
+  void attach(IPlugObject* plugobject);
+  void detach(IPlugObject* plugobject);
 
-   private:
-    void executeDefered();
-    std::vector<IPlugObject*> _plugs;
-  } gLinuxHelper;
+ private:
+  void executeDefered();
+  std::vector<IPlugObject*> _plugs;
+} gLinuxHelper;
 
 #if 0
 	class WindowsHelper
@@ -52,8 +52,8 @@ namespace os
 	} gWindowsHelper;
 #endif
 
-  static Steinberg::ModuleInitializer createMessageWindow([] { gLinuxHelper.init(); });
-  static Steinberg::ModuleTerminator dropMessageWindow([] { gLinuxHelper.terminate(); });
+static Steinberg::ModuleInitializer createMessageWindow([] { gLinuxHelper.init(); });
+static Steinberg::ModuleTerminator dropMessageWindow([] { gLinuxHelper.terminate(); });
 
 #if 0
 	static char* getModuleNameA()
@@ -79,40 +79,40 @@ namespace os
 	}
 #endif
 
-  static std::string getModuleName()
+static std::string getModuleName()
+{
+  Dl_info info;
+  if (dladdr((void*)getModuleName, &info))
   {
-    Dl_info info;
-    if (dladdr((void*)getModuleName, &info))
+    return info.dli_fname;
+  }
+  return nullptr;
+}
+
+std::string getParentFolderName()
+{
+  std::filesystem::path n = getModuleName();
+  if (n.has_parent_path())
+  {
+    auto p = n.parent_path();
+    if (p.has_filename())
     {
-      return info.dli_fname;
+      return p.filename().u8string();
     }
-    return nullptr;
   }
 
-  std::string getParentFolderName()
-  {
-    std::filesystem::path n = getModuleName();
-    if (n.has_parent_path())
-    {
-      auto p = n.parent_path();
-      if (p.has_filename())
-      {
-        return p.filename().u8string();
-      }
-    }
+  return std::string();
+}
 
-    return std::string();
-  }
-
-  std::string getBinaryName()
+std::string getBinaryName()
+{
+  std::filesystem::path n = getModuleName();
+  if (n.has_filename())
   {
-    std::filesystem::path n = getModuleName();
-    if (n.has_filename())
-    {
-      return n.stem().u8string();
-    }
-    return std::string();
+    return n.stem().u8string();
   }
+  return std::string();
+}
 
 #if 0
 	LRESULT WindowsHelper::Wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
@@ -155,49 +155,49 @@ namespace os
 	}
 
 #endif
-  void LinuxHelper::init()
-  {
-  }
+void LinuxHelper::init()
+{
+}
 
-  void LinuxHelper::terminate()
-  {
-  }
+void LinuxHelper::terminate()
+{
+}
 
-  void LinuxHelper::executeDefered()
+void LinuxHelper::executeDefered()
+{
+  for (auto p : _plugs)
   {
-    for (auto p : _plugs)
-    {
-      p->onIdle();
-    }
+    p->onIdle();
   }
-  void LinuxHelper::attach(IPlugObject* plugobject)
-  {
-    _plugs.push_back(plugobject);
-  }
+}
+void LinuxHelper::attach(IPlugObject* plugobject)
+{
+  _plugs.push_back(plugobject);
+}
 
-  void LinuxHelper::detach(IPlugObject* plugobject)
-  {
-    _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
-  }
+void LinuxHelper::detach(IPlugObject* plugobject)
+{
+  _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
+}
 
 }  // namespace os
 
 namespace os
 {
-  // [UI Thread]
-  void attach(IPlugObject* plugobject)
-  {
-    gLinuxHelper.attach(plugobject);
-  }
+// [UI Thread]
+void attach(IPlugObject* plugobject)
+{
+  gLinuxHelper.attach(plugobject);
+}
 
-  // [UI Thread]
-  void detach(IPlugObject* plugobject)
-  {
-    gLinuxHelper.detach(plugobject);
-  }
+// [UI Thread]
+void detach(IPlugObject* plugobject)
+{
+  gLinuxHelper.detach(plugobject);
+}
 
-  uint64_t getTickInMS()
-  {
-    return clock();
-  }
+uint64_t getTickInMS()
+{
+  return clock();
+}
 }  // namespace os

--- a/src/detail/vst3/os/linux.cpp
+++ b/src/detail/vst3/os/linux.cpp
@@ -17,7 +17,10 @@
 
 namespace os
 {
-  void log(const char* text) { fprintf(stderr, "%s\n", text); }
+  void log(const char* text)
+  {
+    fprintf(stderr, "%s\n", text);
+  }
 
   class LinuxHelper
   {
@@ -152,9 +155,13 @@ namespace os
 	}
 
 #endif
-  void LinuxHelper::init() {}
+  void LinuxHelper::init()
+  {
+  }
 
-  void LinuxHelper::terminate() {}
+  void LinuxHelper::terminate()
+  {
+  }
 
   void LinuxHelper::executeDefered()
   {
@@ -163,19 +170,34 @@ namespace os
       p->onIdle();
     }
   }
-  void LinuxHelper::attach(IPlugObject* plugobject) { _plugs.push_back(plugobject); }
+  void LinuxHelper::attach(IPlugObject* plugobject)
+  {
+    _plugs.push_back(plugobject);
+  }
 
-  void LinuxHelper::detach(IPlugObject* plugobject) { _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end()); }
+  void LinuxHelper::detach(IPlugObject* plugobject)
+  {
+    _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
+  }
 
 }  // namespace os
 
 namespace os
 {
   // [UI Thread]
-  void attach(IPlugObject* plugobject) { gLinuxHelper.attach(plugobject); }
+  void attach(IPlugObject* plugobject)
+  {
+    gLinuxHelper.attach(plugobject);
+  }
 
   // [UI Thread]
-  void detach(IPlugObject* plugobject) { gLinuxHelper.detach(plugobject); }
+  void detach(IPlugObject* plugobject)
+  {
+    gLinuxHelper.detach(plugobject);
+  }
 
-  uint64_t getTickInMS() { return clock(); }
+  uint64_t getTickInMS()
+  {
+    return clock();
+  }
 }  // namespace os

--- a/src/detail/vst3/os/linux.cpp
+++ b/src/detail/vst3/os/linux.cpp
@@ -1,12 +1,12 @@
 /**
-*		the Linux helper
-* 
-*		provides services for all plugin instances regarding Linux
-*		- global timer object
-*		- dispatch to UI thread
-*		- get binary name
-* 
-*/
+ *		the Linux helper
+ *
+ *		provides services for all plugin instances regarding Linux
+ *		- global timer object
+ *		- dispatch to UI thread
+ *		- get binary name
+ *
+ */
 
 #include "public.sdk/source/main/moduleinit.h"
 #include "osutil.h"
@@ -17,25 +17,22 @@
 
 namespace os
 {
-	void log(const char* text)
-	{
-		fprintf(stderr, "%s\n", text);
-	}
+  void log(const char *text) { fprintf(stderr, "%s\n", text); }
 
-	class LinuxHelper
-	{
-	public:
-		void init();
-		void terminate();
-		void attach(IPlugObject* plugobject);
-		void detach(IPlugObject* plugobject);
+  class LinuxHelper
+  {
+  public:
+    void init();
+    void terminate();
+    void attach(IPlugObject *plugobject);
+    void detach(IPlugObject *plugobject);
 
-	private:
-		void executeDefered();
-		std::vector<IPlugObject*> _plugs;
-	} gLinuxHelper;
+  private:
+    void executeDefered();
+    std::vector<IPlugObject *> _plugs;
+  } gLinuxHelper;
 
-	#if 0
+#if 0
 	class WindowsHelper
 	{
 	public:
@@ -52,8 +49,8 @@ namespace os
 	} gWindowsHelper;
 #endif
 
-	static Steinberg::ModuleInitializer createMessageWindow([] { gLinuxHelper.init(); });
-	static Steinberg::ModuleTerminator dropMessageWindow([] { gLinuxHelper.terminate(); });
+  static Steinberg::ModuleInitializer createMessageWindow([] { gLinuxHelper.init(); });
+  static Steinberg::ModuleTerminator dropMessageWindow([] { gLinuxHelper.terminate(); });
 
 #if 0
 	static char* getModuleNameA()
@@ -79,40 +76,40 @@ namespace os
 	}
 #endif
 
-	static std::string getModuleName()
-	{
-		Dl_info info;
-		if ( dladdr((void*)getModuleName,&info) )
-		{
-			return info.dli_fname;
-		}
-		return nullptr;
-	}
+  static std::string getModuleName()
+  {
+    Dl_info info;
+    if (dladdr((void *)getModuleName, &info))
+    {
+      return info.dli_fname;
+    }
+    return nullptr;
+  }
 
-	std::string getParentFolderName()
-	{
-		std::filesystem::path n = getModuleName();
-		if (n.has_parent_path())
-		{
-			auto p = n.parent_path();
-			if (p.has_filename())
-			{
-				return p.filename().u8string();
-			}
-		}
+  std::string getParentFolderName()
+  {
+    std::filesystem::path n = getModuleName();
+    if (n.has_parent_path())
+    {
+      auto p = n.parent_path();
+      if (p.has_filename())
+      {
+        return p.filename().u8string();
+      }
+    }
 
-		return std::string();
-	}
+    return std::string();
+  }
 
-	std::string getBinaryName()
-	{
-		std::filesystem::path n = getModuleName();
-		if (n.has_filename())
-		{
-			return n.stem().u8string();
-		}
-		return std::string();
-	}
+  std::string getBinaryName()
+  {
+    std::filesystem::path n = getModuleName();
+    if (n.has_filename())
+    {
+      return n.stem().u8string();
+    }
+    return std::string();
+  }
 
 #if 0
 	LRESULT WindowsHelper::Wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
@@ -155,52 +152,33 @@ namespace os
 	}
 
 #endif
-	void LinuxHelper::init()
-	{
+  void LinuxHelper::init() {}
 
-	}
+  void LinuxHelper::terminate() {}
 
-	void LinuxHelper::terminate()
-	{
+  void LinuxHelper::executeDefered()
+  {
+    for (auto p : _plugs)
+    {
+      p->onIdle();
+    }
+  }
+  void LinuxHelper::attach(IPlugObject *plugobject) { _plugs.push_back(plugobject); }
 
-	}
+  void LinuxHelper::detach(IPlugObject *plugobject)
+  {
+    _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
+  }
 
-	void LinuxHelper::executeDefered()
-	{
-		for (auto p : _plugs)
-		{
-			p->onIdle();
-		}
-	}
-	void LinuxHelper::attach(IPlugObject* plugobject)
-	{
-		_plugs.push_back(plugobject);
-	}
-
-	void LinuxHelper::detach(IPlugObject * plugobject)
-	{
-		_plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
-	}
-
-}
+} // namespace os
 
 namespace os
 {
-	// [UI Thread]
-	void attach(IPlugObject* plugobject)
-	{
-		gLinuxHelper.attach(plugobject);
-	}
+  // [UI Thread]
+  void attach(IPlugObject *plugobject) { gLinuxHelper.attach(plugobject); }
 
-	// [UI Thread]
-	void detach(IPlugObject* plugobject)
-	{
-		gLinuxHelper.detach(plugobject);
-	}
+  // [UI Thread]
+  void detach(IPlugObject *plugobject) { gLinuxHelper.detach(plugobject); }
 
-	uint64_t getTickInMS()
-	{
-		return clock();
-	}
-}
-
+  uint64_t getTickInMS() { return clock(); }
+} // namespace os

--- a/src/detail/vst3/os/macos.mm
+++ b/src/detail/vst3/os/macos.mm
@@ -78,7 +78,9 @@ namespace os
     {
       CFRunLoopTimerContext context = {};
       context.info = this;
-      _timer = CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + (kIntervall * 0.001f), kIntervall * 0.001f, 0, 0, timerCallback, &context);
+      _timer =
+          CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + (kIntervall * 0.001f),
+                               kIntervall * 0.001f, 0, 0, timerCallback, &context);
       if (_timer) CFRunLoopAddTimer(CFRunLoopGetCurrent(), _timer, kCFRunLoopCommonModes);
     }
     _plugs.push_back(plugobject);
@@ -132,7 +134,8 @@ namespace os
 
   std::string getParentFolderName()
   {
-    NSString* identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
+    NSString* identifier =
+        [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
     fs::path n = [identifier UTF8String];
     if (n.has_parent_path())
     {
@@ -152,7 +155,8 @@ namespace os
     // NSString* identifier = [[NSBundle mainBundle] bundleIdentifier];
 
     // this is needed:
-    NSString* identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
+    NSString* identifier =
+        [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
     fs::path k = [identifier UTF8String];
     return k.stem();
   }

--- a/src/detail/vst3/os/macos.mm
+++ b/src/detail/vst3/os/macos.mm
@@ -1,14 +1,14 @@
 #define NOMINMAX 1
 
 /**
- *		the macos helper
- *
- *		provides services for all plugin instances regarding macos
- *        - global timer object
- *        - dispatch to UI thread
- *        - get the bundle name
- *
- */
+*		the macos helper
+* 
+*		provides services for all plugin instances regarding macos
+*        - global timer object
+*        - dispatch to UI thread
+*        - get the bundle name
+* 
+*/
 
 #include <Foundation/Foundation.h>
 #include "public.sdk/source/main/moduleinit.h"
@@ -25,21 +25,21 @@ namespace fs = ghc::filesystem;
 
 namespace os
 {
-  void log(const char *text) { NSLog(@"%s", text); }
+  void log(const char* text) { NSLog(@"%s", text); }
 
   class MacOSHelper
   {
-  public:
+   public:
     void init();
     void terminate();
-    void attach(IPlugObject *plugobject);
-    void detach(IPlugObject *plugobject);
+    void attach(IPlugObject* plugobject);
+    void detach(IPlugObject* plugobject);
 
-  private:
-    static void timerCallback(CFRunLoopTimerRef t, void *info);
+   private:
+    static void timerCallback(CFRunLoopTimerRef t, void* info);
     void executeDefered();
     CFRunLoopTimerRef _timer = nullptr;
-    std::vector<IPlugObject *> _plugs;
+    std::vector<IPlugObject*> _plugs;
   } gMacOSHelper;
 
   static Steinberg::ModuleInitializer createMessageWindow([] { gMacOSHelper.init(); });
@@ -57,29 +57,27 @@ namespace os
     }
   }
 
-  void MacOSHelper::timerCallback(CFRunLoopTimerRef t, void *info)
+  void MacOSHelper::timerCallback(CFRunLoopTimerRef t, void* info)
   {
-    auto self = static_cast<MacOSHelper *>(info);
+    auto self = static_cast<MacOSHelper*>(info);
     self->executeDefered();
   }
 
   static float kIntervall = 10.f;
 
-  void MacOSHelper::attach(IPlugObject *plugobject)
+  void MacOSHelper::attach(IPlugObject* plugobject)
   {
     if (_plugs.empty())
     {
       CFRunLoopTimerContext context = {};
       context.info = this;
-      _timer = CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + (kIntervall * 0.001f),
-                                    kIntervall * 0.001f, 0, 0, timerCallback, &context);
-      if (_timer)
-        CFRunLoopAddTimer(CFRunLoopGetCurrent(), _timer, kCFRunLoopCommonModes);
+      _timer = CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + (kIntervall * 0.001f), kIntervall * 0.001f, 0, 0, timerCallback, &context);
+      if (_timer) CFRunLoopAddTimer(CFRunLoopGetCurrent(), _timer, kCFRunLoopCommonModes);
     }
     _plugs.push_back(plugobject);
   }
 
-  void MacOSHelper::detach(IPlugObject *plugobject)
+  void MacOSHelper::detach(IPlugObject* plugobject)
   {
     _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
     if (_plugs.empty())
@@ -109,16 +107,16 @@ namespace os
 namespace os
 {
   // [UI Thread]
-  void attach(IPlugObject *plugobject) { gMacOSHelper.attach(plugobject); }
+  void attach(IPlugObject* plugobject) { gMacOSHelper.attach(plugobject); }
 
   // [UI Thread]
-  void detach(IPlugObject *plugobject) { gMacOSHelper.detach(plugobject); }
+  void detach(IPlugObject* plugobject) { gMacOSHelper.detach(plugobject); }
 
   uint64_t getTickInMS() { return (::clock() * 1000) / CLOCKS_PER_SEC; }
 
   std::string getParentFolderName()
   {
-    NSString *identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
+    NSString* identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
     fs::path n = [identifier UTF8String];
     if (n.has_parent_path())
     {
@@ -138,7 +136,7 @@ namespace os
     // NSString* identifier = [[NSBundle mainBundle] bundleIdentifier];
 
     // this is needed:
-    NSString *identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
+    NSString* identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
     fs::path k = [identifier UTF8String];
     return k.stem();
   }

--- a/src/detail/vst3/os/macos.mm
+++ b/src/detail/vst3/os/macos.mm
@@ -1,15 +1,14 @@
 #define NOMINMAX 1
 
-
 /**
-*		the macos helper
-* 
-*		provides services for all plugin instances regarding macos
-*        - global timer object
-*        - dispatch to UI thread
-*        - get the bundle name
-* 
-*/
+ *		the macos helper
+ *
+ *		provides services for all plugin instances regarding macos
+ *        - global timer object
+ *        - dispatch to UI thread
+ *        - get the bundle name
+ *
+ */
 
 #include <Foundation/Foundation.h>
 #include "public.sdk/source/main/moduleinit.h"
@@ -26,114 +25,100 @@ namespace fs = ghc::filesystem;
 
 namespace os
 {
-	void log(const char* text)
-	{
-	  NSLog(@"%s", text);
-	}
+  void log(const char *text) { NSLog(@"%s", text); }
 
-	class MacOSHelper
-	{
-	public:
-	  void init();
-	  void terminate();
-	  void attach(IPlugObject* plugobject);
-	  void detach(IPlugObject* plugobject);
-	private:
-		static void timerCallback(CFRunLoopTimerRef t, void* info);
-		void executeDefered();
-		CFRunLoopTimerRef _timer = nullptr;
-		std::vector<IPlugObject*> _plugs;
-	} gMacOSHelper;
-
-	static Steinberg::ModuleInitializer createMessageWindow([] { gMacOSHelper.init(); });
-	static Steinberg::ModuleTerminator dropMessageWindow([] { gMacOSHelper.terminate(); });
-
-	void MacOSHelper::init()
-	{
-
-	}
-
-	void MacOSHelper::terminate()
-	{
-
-	}
-
-	void MacOSHelper::executeDefered()
-	{
-		for (auto p : _plugs)
-		{
-			p->onIdle();
-		}
-	}
-
-  void MacOSHelper::timerCallback(CFRunLoopTimerRef t, void* info)
+  class MacOSHelper
   {
-    auto self = static_cast<MacOSHelper*>(info);
+  public:
+    void init();
+    void terminate();
+    void attach(IPlugObject *plugobject);
+    void detach(IPlugObject *plugobject);
+
+  private:
+    static void timerCallback(CFRunLoopTimerRef t, void *info);
+    void executeDefered();
+    CFRunLoopTimerRef _timer = nullptr;
+    std::vector<IPlugObject *> _plugs;
+  } gMacOSHelper;
+
+  static Steinberg::ModuleInitializer createMessageWindow([] { gMacOSHelper.init(); });
+  static Steinberg::ModuleTerminator dropMessageWindow([] { gMacOSHelper.terminate(); });
+
+  void MacOSHelper::init() {}
+
+  void MacOSHelper::terminate() {}
+
+  void MacOSHelper::executeDefered()
+  {
+    for (auto p : _plugs)
+    {
+      p->onIdle();
+    }
+  }
+
+  void MacOSHelper::timerCallback(CFRunLoopTimerRef t, void *info)
+  {
+    auto self = static_cast<MacOSHelper *>(info);
     self->executeDefered();
   }
 
   static float kIntervall = 10.f;
 
-	void MacOSHelper::attach(IPlugObject* plugobject)
-	{
-	  if ( _plugs.empty() )
-	  {
-	  	CFRunLoopTimerContext context = {};
-	  	context.info = this;
-	  	_timer = CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + (kIntervall * 0.001f), kIntervall * 0.001f, 0, 0, timerCallback, &context);
-                if (_timer)
-	  	    CFRunLoopAddTimer(CFRunLoopGetCurrent(), _timer, kCFRunLoopCommonModes);
-	  }
-	  _plugs.push_back(plugobject);
-	}
+  void MacOSHelper::attach(IPlugObject *plugobject)
+  {
+    if (_plugs.empty())
+    {
+      CFRunLoopTimerContext context = {};
+      context.info = this;
+      _timer = CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + (kIntervall * 0.001f),
+                                    kIntervall * 0.001f, 0, 0, timerCallback, &context);
+      if (_timer)
+        CFRunLoopAddTimer(CFRunLoopGetCurrent(), _timer, kCFRunLoopCommonModes);
+    }
+    _plugs.push_back(plugobject);
+  }
 
-	void MacOSHelper::detach(IPlugObject * plugobject)
-	{
-	  _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
-	  if ( _plugs.empty() )
-	  {
-            if (_timer)
-            {
-                CFRunLoopTimerInvalidate(_timer);
-                CFRelease(_timer);
-            }
-            _timer = nullptr;
-	  }
-	}
+  void MacOSHelper::detach(IPlugObject *plugobject)
+  {
+    _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
+    if (_plugs.empty())
+    {
+      if (_timer)
+      {
+        CFRunLoopTimerInvalidate(_timer);
+        CFRelease(_timer);
+      }
+      _timer = nullptr;
+    }
+  }
 
 }
 
 // the dummy class so we can use NSBundle bundleForClass
 @interface clapwrapper_dummy_object_to_trick_the_os : NSObject
-- (void) fun;
+- (void)fun;
 @end
 
 @implementation clapwrapper_dummy_object_to_trick_the_os
-- (void) fun{}
+- (void)fun
+{
+}
 @end
 
 namespace os
 {
-	// [UI Thread]
-	void attach(IPlugObject* plugobject)
-	{
-		gMacOSHelper.attach(plugobject);
-	}
+  // [UI Thread]
+  void attach(IPlugObject *plugobject) { gMacOSHelper.attach(plugobject); }
 
-	// [UI Thread]
-	void detach(IPlugObject* plugobject)
-	{
-		gMacOSHelper.detach(plugobject);
-	}
+  // [UI Thread]
+  void detach(IPlugObject *plugobject) { gMacOSHelper.detach(plugobject); }
 
-	uint64_t getTickInMS()
-	{
-		return (::clock() * 1000) / CLOCKS_PER_SEC;
-	}
+  uint64_t getTickInMS() { return (::clock() * 1000) / CLOCKS_PER_SEC; }
 
   std::string getParentFolderName()
   {
-    NSString* identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
+    NSString *identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
     fs::path n = [identifier UTF8String];
     if (n.has_parent_path())
     {
@@ -143,7 +128,7 @@ namespace os
         return p.filename().u8string();
       }
     }
-    
+
     return std::string();
   }
 
@@ -151,9 +136,9 @@ namespace os
   {
     // this is useless
     // NSString* identifier = [[NSBundle mainBundle] bundleIdentifier];
-    
+
     // this is needed:
-    NSString* identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
+    NSString *identifier = [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
     fs::path k = [identifier UTF8String];
     return k.stem();
   }

--- a/src/detail/vst3/os/macos.mm
+++ b/src/detail/vst3/os/macos.mm
@@ -25,7 +25,10 @@ namespace fs = ghc::filesystem;
 
 namespace os
 {
-  void log(const char* text) { NSLog(@"%s", text); }
+  void log(const char* text)
+  {
+    NSLog(@"%s", text);
+  }
 
   class MacOSHelper
   {
@@ -45,9 +48,13 @@ namespace os
   static Steinberg::ModuleInitializer createMessageWindow([] { gMacOSHelper.init(); });
   static Steinberg::ModuleTerminator dropMessageWindow([] { gMacOSHelper.terminate(); });
 
-  void MacOSHelper::init() {}
+  void MacOSHelper::init()
+  {
+  }
 
-  void MacOSHelper::terminate() {}
+  void MacOSHelper::terminate()
+  {
+  }
 
   void MacOSHelper::executeDefered()
   {
@@ -107,12 +114,21 @@ namespace os
 namespace os
 {
   // [UI Thread]
-  void attach(IPlugObject* plugobject) { gMacOSHelper.attach(plugobject); }
+  void attach(IPlugObject* plugobject)
+  {
+    gMacOSHelper.attach(plugobject);
+  }
 
   // [UI Thread]
-  void detach(IPlugObject* plugobject) { gMacOSHelper.detach(plugobject); }
+  void detach(IPlugObject* plugobject)
+  {
+    gMacOSHelper.detach(plugobject);
+  }
 
-  uint64_t getTickInMS() { return (::clock() * 1000) / CLOCKS_PER_SEC; }
+  uint64_t getTickInMS()
+  {
+    return (::clock() * 1000) / CLOCKS_PER_SEC;
+  }
 
   std::string getParentFolderName()
   {

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -17,7 +17,9 @@ namespace os
   {
    public:
     virtual void onIdle() = 0;
-    virtual ~IPlugObject() {}
+    virtual ~IPlugObject()
+    {
+    }
   };
   void attach(IPlugObject* plugobject);
   void detach(IPlugObject* plugobject);
@@ -63,7 +65,10 @@ namespace util
   class fixedqueue
   {
    public:
-    inline void push(const T& val) { push(&val); }
+    inline void push(const T& val)
+    {
+      push(&val);
+    }
     inline void push(const T* val)
     {
       _elements[_head] = *val;

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-                a minimalistic OS layer
+		a minimalistic OS layer
 
 */
 
@@ -15,26 +15,27 @@ namespace os
 {
   class IPlugObject
   {
-  public:
+   public:
     virtual void onIdle() = 0;
     virtual ~IPlugObject() {}
   };
-  void attach(IPlugObject *plugobject);
-  void detach(IPlugObject *plugobject);
+  void attach(IPlugObject* plugobject);
+  void detach(IPlugObject* plugobject);
   uint64_t getTickInMS();
   std::string getParentFolderName();
   std::string getBinaryName();
 
-  void log(const char *text);
+  void log(const char* text);
 
-  template <typename... Args> void log(const char *format_str, Args &&...args)
+  template <typename... Args>
+  void log(const char* format_str, Args&&... args)
   {
     fmt::memory_buffer buf;
     fmt::format_to(std::back_inserter(buf), format_str, args...);
     buf.push_back(0);
-    log((const char *)buf.data());
+    log((const char*)buf.data());
   };
-} // namespace os
+}  // namespace os
 
 #ifndef CLAP_WRAPPER_LOGLEVEL
 #define CLAP_WRAPPER_LOGLEVEL 2
@@ -58,16 +59,17 @@ namespace os
 namespace util
 {
 
-  template <typename T, uint32_t Q> class fixedqueue
+  template <typename T, uint32_t Q>
+  class fixedqueue
   {
-  public:
-    inline void push(const T &val) { push(&val); }
-    inline void push(const T *val)
+   public:
+    inline void push(const T& val) { push(&val); }
+    inline void push(const T* val)
     {
       _elements[_head] = *val;
       _head = (_head + 1) % Q;
     }
-    inline bool pop(T &out)
+    inline bool pop(T& out)
     {
       if (_head == _tail)
       {
@@ -78,9 +80,9 @@ namespace util
       return true;
     }
 
-  private:
+   private:
     T _elements[Q] = {};
     std::atomic_uint32_t _head = 0u;
     std::atomic_uint32_t _tail = 0u;
   };
-}; // namespace util
+};  // namespace util

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-		a minimalistic OS layer
+                a minimalistic OS layer
 
 */
 
@@ -11,31 +11,30 @@
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 
-
 namespace os
 {
-	class IPlugObject
-	{
-	public:
-		virtual void onIdle() = 0;
-		virtual ~IPlugObject() {}
-	};
-	void attach(IPlugObject* plugobject);
-	void detach(IPlugObject* plugobject);
-	uint64_t getTickInMS();
-	std::string getParentFolderName();
-	std::string getBinaryName();
+  class IPlugObject
+  {
+  public:
+    virtual void onIdle() = 0;
+    virtual ~IPlugObject() {}
+  };
+  void attach(IPlugObject *plugobject);
+  void detach(IPlugObject *plugobject);
+  uint64_t getTickInMS();
+  std::string getParentFolderName();
+  std::string getBinaryName();
 
-	void log(const char* text);
+  void log(const char *text);
 
-	template <typename... Args>
-	void log(const char* format_str, Args&&... args) {
-		fmt::memory_buffer buf;
-		fmt::format_to(std::back_inserter(buf), format_str, args...);
-		buf.push_back(0);
-		log((const char*)buf.data());
-	};
-}
+  template <typename... Args> void log(const char *format_str, Args &&...args)
+  {
+    fmt::memory_buffer buf;
+    fmt::format_to(std::back_inserter(buf), format_str, args...);
+    buf.push_back(0);
+    log((const char *)buf.data());
+  };
+} // namespace os
 
 #ifndef CLAP_WRAPPER_LOGLEVEL
 #define CLAP_WRAPPER_LOGLEVEL 2
@@ -59,32 +58,29 @@ namespace os
 namespace util
 {
 
-	template<typename T, uint32_t Q>
-	class fixedqueue
-	{
-	public:
-		inline void push(const T& val)
-		{
-			push(&val);
-		}
-		inline void push(const T* val)
-		{			
-			_elements[_head] = *val;
-			_head = (_head + 1) % Q;
-		}
-		inline bool pop(T& out)
-		{
-			if (_head == _tail)
-			{
-				return false;
-			}
-			out = _elements[_tail];
-			_tail = (_tail + 1) % Q;
-			return true;
-		}
-	private:
-		T _elements[Q] = { };
-		std::atomic_uint32_t _head = 0u;
-		std::atomic_uint32_t _tail = 0u;
-	};
-};
+  template <typename T, uint32_t Q> class fixedqueue
+  {
+  public:
+    inline void push(const T &val) { push(&val); }
+    inline void push(const T *val)
+    {
+      _elements[_head] = *val;
+      _head = (_head + 1) % Q;
+    }
+    inline bool pop(T &out)
+    {
+      if (_head == _tail)
+      {
+        return false;
+      }
+      out = _elements[_tail];
+      _tail = (_tail + 1) % Q;
+      return true;
+    }
+
+  private:
+    T _elements[Q] = {};
+    std::atomic_uint32_t _head = 0u;
+    std::atomic_uint32_t _tail = 0u;
+  };
+}; // namespace util

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -13,30 +13,30 @@
 
 namespace os
 {
-  class IPlugObject
+class IPlugObject
+{
+ public:
+  virtual void onIdle() = 0;
+  virtual ~IPlugObject()
   {
-   public:
-    virtual void onIdle() = 0;
-    virtual ~IPlugObject()
-    {
-    }
-  };
-  void attach(IPlugObject* plugobject);
-  void detach(IPlugObject* plugobject);
-  uint64_t getTickInMS();
-  std::string getParentFolderName();
-  std::string getBinaryName();
+  }
+};
+void attach(IPlugObject* plugobject);
+void detach(IPlugObject* plugobject);
+uint64_t getTickInMS();
+std::string getParentFolderName();
+std::string getBinaryName();
 
-  void log(const char* text);
+void log(const char* text);
 
-  template <typename... Args>
-  void log(const char* format_str, Args&&... args)
-  {
-    fmt::memory_buffer buf;
-    fmt::format_to(std::back_inserter(buf), format_str, args...);
-    buf.push_back(0);
-    log((const char*)buf.data());
-  };
+template <typename... Args>
+void log(const char* format_str, Args&&... args)
+{
+  fmt::memory_buffer buf;
+  fmt::format_to(std::back_inserter(buf), format_str, args...);
+  buf.push_back(0);
+  log((const char*)buf.data());
+};
 }  // namespace os
 
 #ifndef CLAP_WRAPPER_LOGLEVEL
@@ -61,33 +61,33 @@ namespace os
 namespace util
 {
 
-  template <typename T, uint32_t Q>
-  class fixedqueue
+template <typename T, uint32_t Q>
+class fixedqueue
+{
+ public:
+  inline void push(const T& val)
   {
-   public:
-    inline void push(const T& val)
+    push(&val);
+  }
+  inline void push(const T* val)
+  {
+    _elements[_head] = *val;
+    _head = (_head + 1) % Q;
+  }
+  inline bool pop(T& out)
+  {
+    if (_head == _tail)
     {
-      push(&val);
+      return false;
     }
-    inline void push(const T* val)
-    {
-      _elements[_head] = *val;
-      _head = (_head + 1) % Q;
-    }
-    inline bool pop(T& out)
-    {
-      if (_head == _tail)
-      {
-        return false;
-      }
-      out = _elements[_tail];
-      _tail = (_tail + 1) % Q;
-      return true;
-    }
+    out = _elements[_tail];
+    _tail = (_tail + 1) % Q;
+    return true;
+  }
 
-   private:
-    T _elements[Q] = {};
-    std::atomic_uint32_t _head = 0u;
-    std::atomic_uint32_t _tail = 0u;
-  };
+ private:
+  T _elements[Q] = {};
+  std::atomic_uint32_t _head = 0u;
+  std::atomic_uint32_t _tail = 0u;
+};
 };  // namespace util

--- a/src/detail/vst3/os/windows.cpp
+++ b/src/detail/vst3/os/windows.cpp
@@ -137,15 +137,30 @@ namespace os
     for (auto&& p : _plugs) p->onIdle();
   }
 
-  void WindowsHelper::attach(IPlugObject* plugobject) { _plugs.push_back(plugobject); }
+  void WindowsHelper::attach(IPlugObject* plugobject)
+  {
+    _plugs.push_back(plugobject);
+  }
 
-  void WindowsHelper::detach(IPlugObject* plugobject) { _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end()); }
+  void WindowsHelper::detach(IPlugObject* plugobject)
+  {
+    _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
+  }
 
   // [UI Thread]
-  void attach(IPlugObject* plugobject) { gWindowsHelper.attach(plugobject); }
+  void attach(IPlugObject* plugobject)
+  {
+    gWindowsHelper.attach(plugobject);
+  }
 
   // [UI Thread]
-  void detach(IPlugObject* plugobject) { gWindowsHelper.detach(plugobject); }
+  void detach(IPlugObject* plugobject)
+  {
+    gWindowsHelper.detach(plugobject);
+  }
 
-  uint64_t getTickInMS() { return GetTickCount64(); }
+  uint64_t getTickInMS()
+  {
+    return GetTickCount64();
+  }
 }  // namespace os

--- a/src/detail/vst3/os/windows.cpp
+++ b/src/detail/vst3/os/windows.cpp
@@ -1,13 +1,13 @@
 #define NOMINMAX 1
 
 /**
-*		the windows helper
-* 
-*		provides services for all plugin instances regarding Windows
-*		- global timer object
-*		- dispatch to UI thread
-* 
-*/
+ *		the windows helper
+ *
+ *		provides services for all plugin instances regarding Windows
+ *		- global timer object
+ *		- dispatch to UI thread
+ *
+ */
 
 #include <Windows.h>
 #include <tchar.h>
@@ -21,147 +21,135 @@ extern HINSTANCE ghInst;
 namespace os
 {
 
-	void log(const char* text)
-	{
-		OutputDebugStringA(text);
-		OutputDebugStringA("\n");
+  void log(const char *text)
+  {
+    OutputDebugStringA(text);
+    OutputDebugStringA("\n");
+  }
 
-	}
+  class WindowsHelper
+  {
+  public:
+    void init();
+    void terminate();
+    void attach(IPlugObject *plugobject);
+    void detach(IPlugObject *plugobject);
 
-	class WindowsHelper
-	{
-	public:
-		void init();
-		void terminate();
-		void attach(IPlugObject* plugobject);
-		void detach(IPlugObject* plugobject);
-	private:
-		void executeDefered();
-		static LRESULT Wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
-		HWND _msgWin = 0;
-		UINT_PTR _timer = 0;
-		std::vector<IPlugObject*> _plugs;
-	} gWindowsHelper;
+  private:
+    void executeDefered();
+    static LRESULT Wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    HWND _msgWin = 0;
+    UINT_PTR _timer = 0;
+    std::vector<IPlugObject *> _plugs;
+  } gWindowsHelper;
 
-	static Steinberg::ModuleInitializer createMessageWindow([] { gWindowsHelper.init(); });
-	static Steinberg::ModuleTerminator dropMessageWindow([] { gWindowsHelper.terminate(); });
+  static Steinberg::ModuleInitializer createMessageWindow([] { gWindowsHelper.init(); });
+  static Steinberg::ModuleTerminator dropMessageWindow([] { gWindowsHelper.terminate(); });
 
-	static char* getModuleNameA()
-	{
-		static char modulename[2048];
-		HMODULE selfmodule;
-		if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)getModuleNameA, &selfmodule))
-		{
-			auto size = GetModuleFileNameA(selfmodule, modulename, 2048);
-		}
-		return modulename;
-	}
+  static char *getModuleNameA()
+  {
+    static char modulename[2048];
+    HMODULE selfmodule;
+    if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)getModuleNameA, &selfmodule))
+    {
+      auto size = GetModuleFileNameA(selfmodule, modulename, 2048);
+    }
+    return modulename;
+  }
 
-	static TCHAR* getModuleName()
-	{
-		static TCHAR modulename[2048];
-		HMODULE selfmodule;
-		if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)getModuleName, &selfmodule))
-		{
-			auto size = GetModuleFileName(selfmodule, modulename, 2048);
-		}
-		return modulename;
-	}
+  static TCHAR *getModuleName()
+  {
+    static TCHAR modulename[2048];
+    HMODULE selfmodule;
+    if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)getModuleName, &selfmodule))
+    {
+      auto size = GetModuleFileName(selfmodule, modulename, 2048);
+    }
+    return modulename;
+  }
 
-	std::string getParentFolderName()
-	{
-		std::filesystem::path n = getModuleNameA();
-		if (n.has_parent_path())
-		{
-			auto p = n.parent_path();
-			if (p.has_filename())
-			{
-				return p.filename().u8string();
-			}
-		}
+  std::string getParentFolderName()
+  {
+    std::filesystem::path n = getModuleNameA();
+    if (n.has_parent_path())
+    {
+      auto p = n.parent_path();
+      if (p.has_filename())
+      {
+        return p.filename().u8string();
+      }
+    }
 
-		return std::string();
-	}
+    return std::string();
+  }
 
-	std::string getBinaryName()
-	{
-		std::filesystem::path n = getModuleNameA();
-		if (n.has_filename())
-		{
-			return n.stem().u8string();
-		}
-		return std::string();
-	}
+  std::string getBinaryName()
+  {
+    std::filesystem::path n = getModuleNameA();
+    if (n.has_filename())
+    {
+      return n.stem().u8string();
+    }
+    return std::string();
+  }
 
+  LRESULT WindowsHelper::Wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+  {
+    switch (msg)
+    {
+    case WM_USER + 1:
+      return 1;
+      break;
+    case WM_TIMER:
+      gWindowsHelper.executeDefered();
+      return 1;
+      break;
+    default:
+      return ::DefWindowProc(hwnd, msg, wParam, lParam);
+    }
+  }
 
-	LRESULT WindowsHelper::Wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
-	{
-		switch (msg)
-		{
-		case WM_USER + 1:
-			return 1;
-			break;
-		case WM_TIMER:
-			gWindowsHelper.executeDefered();
-			return 1;
-			break;
-		default:
-			return ::DefWindowProc(hwnd, msg, wParam, lParam);
-		}
-	}
+  void WindowsHelper::init()
+  {
+    auto modulename = getModuleName();
+    WNDCLASSEX wc;
+    memset(&wc, 0, sizeof(wc));
+    wc.cbSize = sizeof(wc);
+    wc.hInstance = ghInst;
+    wc.lpfnWndProc = (WNDPROC)&Wndproc;
+    wc.lpszClassName = modulename;
+    auto a = RegisterClassEx(&wc);
 
-	void WindowsHelper::init()
-	{
-		auto modulename = getModuleName();
-		WNDCLASSEX wc;
-		memset(&wc, 0, sizeof(wc));
-		wc.cbSize = sizeof(wc);
-		wc.hInstance = ghInst;
-		wc.lpfnWndProc = (WNDPROC)&Wndproc;
-		wc.lpszClassName = modulename;
-		auto a = RegisterClassEx(&wc);
+    _msgWin = ::CreateWindowEx(0, modulename, NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, 0);
+    ::SetWindowLongW(_msgWin, GWLP_WNDPROC, (LONG_PTR)&Wndproc);
+    _timer = ::SetTimer(_msgWin, 0, 20, NULL);
+  }
 
-		_msgWin = ::CreateWindowEx(0, modulename, NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, 0);
-		::SetWindowLongW(_msgWin, GWLP_WNDPROC, (LONG_PTR)&Wndproc);
-		_timer = ::SetTimer(_msgWin, 0, 20, NULL);
-	}
+  void WindowsHelper::terminate()
+  {
+    ::KillTimer(_msgWin, _timer);
+    ::DestroyWindow(_msgWin);
+    ::UnregisterClass(getModuleName(), ghInst);
+  }
 
-	void WindowsHelper::terminate()
-	{
-		::KillTimer(_msgWin, _timer);
-		::DestroyWindow(_msgWin);
-		::UnregisterClass(getModuleName(), ghInst);
-	}
+  void WindowsHelper::executeDefered()
+  {
+    for (auto &&p : _plugs)
+      p->onIdle();
+  }
 
-	void WindowsHelper::executeDefered()
-	{
-		for (auto&&   p : _plugs) p->onIdle();
-	}
+  void WindowsHelper::attach(IPlugObject *plugobject) { _plugs.push_back(plugobject); }
 
-	void WindowsHelper::attach(IPlugObject* plugobject)
-	{
-		_plugs.push_back(plugobject);
-	}
+  void WindowsHelper::detach(IPlugObject *plugobject)
+  {
+    _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
+  }
 
-	void WindowsHelper::detach(IPlugObject * plugobject)
-	{
-		_plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
-	}
+  // [UI Thread]
+  void attach(IPlugObject *plugobject) { gWindowsHelper.attach(plugobject); }
 
-	// [UI Thread]
-	void attach(IPlugObject* plugobject)
-	{
-		gWindowsHelper.attach(plugobject);
-	}
+  // [UI Thread]
+  void detach(IPlugObject *plugobject) { gWindowsHelper.detach(plugobject); }
 
-	// [UI Thread]
-	void detach(IPlugObject* plugobject)
-	{
-		gWindowsHelper.detach(plugobject);
-	}
-
-	uint64_t getTickInMS()
-	{
-		return GetTickCount64();
-	}
-}
+  uint64_t getTickInMS() { return GetTickCount64(); }
+} // namespace os

--- a/src/detail/vst3/os/windows.cpp
+++ b/src/detail/vst3/os/windows.cpp
@@ -1,13 +1,13 @@
 #define NOMINMAX 1
 
 /**
- *		the windows helper
- *
- *		provides services for all plugin instances regarding Windows
- *		- global timer object
- *		- dispatch to UI thread
- *
- */
+*		the windows helper
+* 
+*		provides services for all plugin instances regarding Windows
+*		- global timer object
+*		- dispatch to UI thread
+* 
+*/
 
 #include <Windows.h>
 #include <tchar.h>
@@ -21,7 +21,7 @@ extern HINSTANCE ghInst;
 namespace os
 {
 
-  void log(const char *text)
+  void log(const char* text)
   {
     OutputDebugStringA(text);
     OutputDebugStringA("\n");
@@ -29,24 +29,24 @@ namespace os
 
   class WindowsHelper
   {
-  public:
+   public:
     void init();
     void terminate();
-    void attach(IPlugObject *plugobject);
-    void detach(IPlugObject *plugobject);
+    void attach(IPlugObject* plugobject);
+    void detach(IPlugObject* plugobject);
 
-  private:
+   private:
     void executeDefered();
     static LRESULT Wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
     HWND _msgWin = 0;
     UINT_PTR _timer = 0;
-    std::vector<IPlugObject *> _plugs;
+    std::vector<IPlugObject*> _plugs;
   } gWindowsHelper;
 
   static Steinberg::ModuleInitializer createMessageWindow([] { gWindowsHelper.init(); });
   static Steinberg::ModuleTerminator dropMessageWindow([] { gWindowsHelper.terminate(); });
 
-  static char *getModuleNameA()
+  static char* getModuleNameA()
   {
     static char modulename[2048];
     HMODULE selfmodule;
@@ -57,7 +57,7 @@ namespace os
     return modulename;
   }
 
-  static TCHAR *getModuleName()
+  static TCHAR* getModuleName()
   {
     static TCHAR modulename[2048];
     HMODULE selfmodule;
@@ -97,15 +97,15 @@ namespace os
   {
     switch (msg)
     {
-    case WM_USER + 1:
-      return 1;
-      break;
-    case WM_TIMER:
-      gWindowsHelper.executeDefered();
-      return 1;
-      break;
-    default:
-      return ::DefWindowProc(hwnd, msg, wParam, lParam);
+      case WM_USER + 1:
+        return 1;
+        break;
+      case WM_TIMER:
+        gWindowsHelper.executeDefered();
+        return 1;
+        break;
+      default:
+        return ::DefWindowProc(hwnd, msg, wParam, lParam);
     }
   }
 
@@ -134,22 +134,18 @@ namespace os
 
   void WindowsHelper::executeDefered()
   {
-    for (auto &&p : _plugs)
-      p->onIdle();
+    for (auto&& p : _plugs) p->onIdle();
   }
 
-  void WindowsHelper::attach(IPlugObject *plugobject) { _plugs.push_back(plugobject); }
+  void WindowsHelper::attach(IPlugObject* plugobject) { _plugs.push_back(plugobject); }
 
-  void WindowsHelper::detach(IPlugObject *plugobject)
-  {
-    _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
-  }
+  void WindowsHelper::detach(IPlugObject* plugobject) { _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end()); }
 
   // [UI Thread]
-  void attach(IPlugObject *plugobject) { gWindowsHelper.attach(plugobject); }
+  void attach(IPlugObject* plugobject) { gWindowsHelper.attach(plugobject); }
 
   // [UI Thread]
-  void detach(IPlugObject *plugobject) { gWindowsHelper.detach(plugobject); }
+  void detach(IPlugObject* plugobject) { gWindowsHelper.detach(plugobject); }
 
   uint64_t getTickInMS() { return GetTickCount64(); }
-} // namespace os
+}  // namespace os

--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -5,16 +5,14 @@
 
 using namespace Steinberg;
 
-Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo &vst3info, const clap_param_info_t *clapinfo)
-    : Steinberg::Vst::Parameter(vst3info), id(clapinfo->id), cookie(clapinfo->cookie), min_value(clapinfo->min_value),
-      max_value(clapinfo->max_value)
+Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, const clap_param_info_t* clapinfo)
+    : Steinberg::Vst::Parameter(vst3info), id(clapinfo->id), cookie(clapinfo->cookie), min_value(clapinfo->min_value), max_value(clapinfo->max_value)
 {
   //
 }
 
-Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo &vst3info, uint8_t bus, uint8_t channel, uint8_t cc)
-    : Steinberg::Vst::Parameter(vst3info), id(vst3info.id), cookie(nullptr), min_value(0), max_value(127), isMidi(true),
-      channel(channel), controller(cc)
+Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint8_t bus, uint8_t channel, uint8_t cc)
+    : Steinberg::Vst::Parameter(vst3info), id(vst3info.id), cookie(nullptr), min_value(0), max_value(127), isMidi(true), channel(channel), controller(cc)
 {
   if (cc == Vst::ControllerNumbers::kPitchBend)
   {
@@ -44,12 +42,11 @@ bool Vst3Parameter::fromString(const Steinberg::Vst::TChar* string, Steinberg::V
 }
 #endif
 
-Vst3Parameter *Vst3Parameter::create(const clap_param_info_t *info,
-                                     std::function<Steinberg::Vst::UnitID(const char *modulepath)> getUnitId)
+Vst3Parameter* Vst3Parameter::create(const clap_param_info_t* info, std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId)
 {
   Vst::ParameterInfo v;
 
-  v.id = info->id & 0x7FFFFFFF; // why ever SMTG does not want the highest bit to be set
+  v.id = info->id & 0x7FFFFFFF;  // why ever SMTG does not want the highest bit to be set
 
   // the long name might contain the module name
   // this will change when we split the module to units
@@ -78,24 +75,21 @@ Vst3Parameter *Vst3Parameter::create(const clap_param_info_t *info,
   str8ToStr16(v.title, fullname.c_str(), str16BufferSize(v.title));
   // TODO: string shrink algorithm shortening the string a bit
   str8ToStr16(v.shortTitle, info->name, str16BufferSize(v.shortTitle));
-  v.units[0] = 0; // unfortunately, CLAP has no unit for parameter values
+  v.units[0] = 0;  // unfortunately, CLAP has no unit for parameter values
   v.unitId = unit;
 
   /*
-                  In the VST3 SDK the normalized value [0, 1] to discrete value and its inverse function discrete value
-     to normalized value is defined like this:
+			In the VST3 SDK the normalized value [0, 1] to discrete value and its inverse function discrete value to normalized value is defined like this:
 
-                  Normalize:
-                  double normalized = discreteValue / (double) stepCount;
+			Normalize:
+			double normalized = discreteValue / (double) stepCount;
 
-                  Denormalize :
-                  int discreteValue = min (stepCount, normalized * (stepCount + 1));
-  */
+			Denormalize :
+			int discreteValue = min (stepCount, normalized * (stepCount + 1));
+	*/
 
-  v.flags = Vst::ParameterInfo::kNoFlags | ((info->flags & CLAP_PARAM_IS_HIDDEN) ? Vst::ParameterInfo::kIsHidden : 0) |
-            ((info->flags & CLAP_PARAM_IS_BYPASS) ? Vst::ParameterInfo::kIsBypass : 0) |
-            ((info->flags & CLAP_PARAM_IS_AUTOMATABLE) ? Vst::ParameterInfo::kCanAutomate : 0) |
-            ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
+  v.flags = Vst::ParameterInfo::kNoFlags | ((info->flags & CLAP_PARAM_IS_HIDDEN) ? Vst::ParameterInfo::kIsHidden : 0) | ((info->flags & CLAP_PARAM_IS_BYPASS) ? Vst::ParameterInfo::kIsBypass : 0) |
+            ((info->flags & CLAP_PARAM_IS_AUTOMATABLE) ? Vst::ParameterInfo::kCanAutomate : 0) | ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
       // | ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
       ;
 
@@ -111,11 +105,11 @@ Vst3Parameter *Vst3Parameter::create(const clap_param_info_t *info,
     v.stepCount = 0;
 
   auto result = new Vst3Parameter(v, info);
-  result->addRef(); // ParameterContainer doesn't add the ref -> but we don't have copies
+  result->addRef();  // ParameterContainer doesn't add the ref -> but we don't have copies
   return result;
 }
 
-Vst3Parameter *Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, Vst::ParamID id)
+Vst3Parameter* Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, Vst::ParamID id)
 {
   Vst::ParameterInfo v;
 
@@ -137,7 +131,7 @@ Vst3Parameter *Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, V
   str8ToStr16(v.title, fullname.c_str(), str16BufferSize(v.title));
   // TODO: string shrink algorithm shortening the string a bit
   str8ToStr16(v.shortTitle, name, str16BufferSize(v.shortTitle));
-  v.units[0] = 0; // unfortunately, CLAP has no unit for parameter values
+  v.units[0] = 0;  // unfortunately, CLAP has no unit for parameter values
   v.unitId = channel + 1;
 
   v.defaultNormalizedValue = 0;
@@ -157,6 +151,6 @@ Vst3Parameter *Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, V
   }
 
   auto result = new Vst3Parameter(v, bus, channel, cc);
-  result->addRef(); // ParameterContainer doesn't add the ref -> but we don't have copies
+  result->addRef();  // ParameterContainer doesn't add the ref -> but we don't have copies
   return result;
 }

--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -7,25 +7,25 @@ using namespace Steinberg;
 
 Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info,
                              const clap_param_info_t* clapinfo)
-    : Steinberg::Vst::Parameter(vst3info),
-      id(clapinfo->id),
-      cookie(clapinfo->cookie),
-      min_value(clapinfo->min_value),
-      max_value(clapinfo->max_value)
+    : Steinberg::Vst::Parameter(vst3info)
+    , id(clapinfo->id)
+    , cookie(clapinfo->cookie)
+    , min_value(clapinfo->min_value)
+    , max_value(clapinfo->max_value)
 {
   //
 }
 
 Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint8_t bus, uint8_t channel,
                              uint8_t cc)
-    : Steinberg::Vst::Parameter(vst3info),
-      id(vst3info.id),
-      cookie(nullptr),
-      min_value(0),
-      max_value(127),
-      isMidi(true),
-      channel(channel),
-      controller(cc)
+    : Steinberg::Vst::Parameter(vst3info)
+    , id(vst3info.id)
+    , cookie(nullptr)
+    , min_value(0)
+    , max_value(127)
+    , isMidi(true)
+    , channel(channel)
+    , controller(cc)
 {
   if (cc == Vst::ControllerNumbers::kPitchBend)
   {

--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -19,7 +19,9 @@ Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint
     max_value = 16383;
   }
 }
-Vst3Parameter::~Vst3Parameter() {}
+Vst3Parameter::~Vst3Parameter()
+{
+}
 
 bool Vst3Parameter::setNormalized(Steinberg::Vst::ParamValue v)
 {

--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -7,25 +7,25 @@ using namespace Steinberg;
 
 Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info,
                              const clap_param_info_t* clapinfo)
-    : Steinberg::Vst::Parameter(vst3info)
-    , id(clapinfo->id)
-    , cookie(clapinfo->cookie)
-    , min_value(clapinfo->min_value)
-    , max_value(clapinfo->max_value)
+  : Steinberg::Vst::Parameter(vst3info)
+  , id(clapinfo->id)
+  , cookie(clapinfo->cookie)
+  , min_value(clapinfo->min_value)
+  , max_value(clapinfo->max_value)
 {
   //
 }
 
 Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint8_t bus, uint8_t channel,
                              uint8_t cc)
-    : Steinberg::Vst::Parameter(vst3info)
-    , id(vst3info.id)
-    , cookie(nullptr)
-    , min_value(0)
-    , max_value(127)
-    , isMidi(true)
-    , channel(channel)
-    , controller(cc)
+  : Steinberg::Vst::Parameter(vst3info)
+  , id(vst3info.id)
+  , cookie(nullptr)
+  , min_value(0)
+  , max_value(127)
+  , isMidi(true)
+  , channel(channel)
+  , controller(cc)
 {
   if (cc == Vst::ControllerNumbers::kPitchBend)
   {

--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -5,42 +5,31 @@
 
 using namespace Steinberg;
 
-Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, const clap_param_info_t* clapinfo)
-: Steinberg::Vst::Parameter(vst3info)
-, id(clapinfo->id)
-, cookie(clapinfo->cookie)
-, min_value(clapinfo->min_value)
-, max_value(clapinfo->max_value)
+Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo &vst3info, const clap_param_info_t *clapinfo)
+    : Steinberg::Vst::Parameter(vst3info), id(clapinfo->id), cookie(clapinfo->cookie), min_value(clapinfo->min_value),
+      max_value(clapinfo->max_value)
 {
-  // 
+  //
 }
 
-Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint8_t bus, uint8_t channel, uint8_t cc)
-	: Steinberg::Vst::Parameter(vst3info)
-	, id(vst3info.id)
-	, cookie(nullptr)
-	, min_value(0)
-	, max_value(127)
-	, isMidi(true)
-	, channel(channel)
-	, controller(cc)
+Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo &vst3info, uint8_t bus, uint8_t channel, uint8_t cc)
+    : Steinberg::Vst::Parameter(vst3info), id(vst3info.id), cookie(nullptr), min_value(0), max_value(127), isMidi(true),
+      channel(channel), controller(cc)
 {
-	if (cc == Vst::ControllerNumbers::kPitchBend)
-	{
-		max_value = 16383;
-	}
+  if (cc == Vst::ControllerNumbers::kPitchBend)
+  {
+    max_value = 16383;
+  }
 }
-Vst3Parameter::~Vst3Parameter()
-{
-}
+Vst3Parameter::~Vst3Parameter() {}
 
 bool Vst3Parameter::setNormalized(Steinberg::Vst::ParamValue v)
 {
-	if (isMidi && info.flags & Steinberg::Vst::ParameterInfo::kIsProgramChange)
-	{
-		return true;
-	}
-	return super::setNormalized(v);
+  if (isMidi && info.flags & Steinberg::Vst::ParameterInfo::kIsProgramChange)
+  {
+    return true;
+  }
+  return super::setNormalized(v);
 }
 
 #if 0
@@ -55,118 +44,119 @@ bool Vst3Parameter::fromString(const Steinberg::Vst::TChar* string, Steinberg::V
 }
 #endif
 
-Vst3Parameter* Vst3Parameter::create(const clap_param_info_t* info, std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId)
+Vst3Parameter *Vst3Parameter::create(const clap_param_info_t *info,
+                                     std::function<Steinberg::Vst::UnitID(const char *modulepath)> getUnitId)
 {
-	Vst::ParameterInfo v;
+  Vst::ParameterInfo v;
 
-	v.id = info->id & 0x7FFFFFFF;	// why ever SMTG does not want the highest bit to be set
+  v.id = info->id & 0x7FFFFFFF; // why ever SMTG does not want the highest bit to be set
 
-	// the long name might contain the module name
-	// this will change when we split the module to units
-	std::string fullname;
-	Vst::UnitID unit = 0;
+  // the long name might contain the module name
+  // this will change when we split the module to units
+  std::string fullname;
+  Vst::UnitID unit = 0;
 
-	// if there is a module name and a lambda
-	if (info->module[0] != 0 && getUnitId)
-	{
-		unit = getUnitId(info->module);
-		fullname = info->name;
-	}
-	else
-	{
-		if (!fullname.empty())
-		{
-			fullname.append("/");
-		}
-		fullname.append(info->name);
-		if (fullname.size() >= str16BufferSize(v.title))
-		{
-			fullname = info->name;
-		}
-	}
-	
-	str8ToStr16(v.title, fullname.c_str(), str16BufferSize(v.title));
-	// TODO: string shrink algorithm shortening the string a bit
-	str8ToStr16(v.shortTitle, info->name, str16BufferSize(v.shortTitle));
-	v.units[0] = 0;  // unfortunately, CLAP has no unit for parameter values
-	v.unitId = unit;
+  // if there is a module name and a lambda
+  if (info->module[0] != 0 && getUnitId)
+  {
+    unit = getUnitId(info->module);
+    fullname = info->name;
+  }
+  else
+  {
+    if (!fullname.empty())
+    {
+      fullname.append("/");
+    }
+    fullname.append(info->name);
+    if (fullname.size() >= str16BufferSize(v.title))
+    {
+      fullname = info->name;
+    }
+  }
 
-	/*
-			In the VST3 SDK the normalized value [0, 1] to discrete value and its inverse function discrete value to normalized value is defined like this:
+  str8ToStr16(v.title, fullname.c_str(), str16BufferSize(v.title));
+  // TODO: string shrink algorithm shortening the string a bit
+  str8ToStr16(v.shortTitle, info->name, str16BufferSize(v.shortTitle));
+  v.units[0] = 0; // unfortunately, CLAP has no unit for parameter values
+  v.unitId = unit;
 
-			Normalize:
-			double normalized = discreteValue / (double) stepCount;
+  /*
+                  In the VST3 SDK the normalized value [0, 1] to discrete value and its inverse function discrete value
+     to normalized value is defined like this:
 
-			Denormalize :
-			int discreteValue = min (stepCount, normalized * (stepCount + 1));
-	*/	
+                  Normalize:
+                  double normalized = discreteValue / (double) stepCount;
 
-	v.flags = Vst::ParameterInfo::kNoFlags
-		| ((info->flags & CLAP_PARAM_IS_HIDDEN) ? Vst::ParameterInfo::kIsHidden : 0)
-		| ((info->flags & CLAP_PARAM_IS_BYPASS) ? Vst::ParameterInfo::kIsBypass : 0)
-		| ((info->flags & CLAP_PARAM_IS_AUTOMATABLE) ? Vst::ParameterInfo::kCanAutomate : 0)
-		| ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
-		// | ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
-		;
+                  Denormalize :
+                  int discreteValue = min (stepCount, normalized * (stepCount + 1));
+  */
 
-	auto param_range = (info->max_value - info->min_value);
+  v.flags = Vst::ParameterInfo::kNoFlags | ((info->flags & CLAP_PARAM_IS_HIDDEN) ? Vst::ParameterInfo::kIsHidden : 0) |
+            ((info->flags & CLAP_PARAM_IS_BYPASS) ? Vst::ParameterInfo::kIsBypass : 0) |
+            ((info->flags & CLAP_PARAM_IS_AUTOMATABLE) ? Vst::ParameterInfo::kCanAutomate : 0) |
+            ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
+      // | ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
+      ;
 
-	v.defaultNormalizedValue = (info->default_value-info->min_value) / param_range;
-	if (info->flags & CLAP_PARAM_IS_STEPPED)
-	{
-		auto steps = param_range + 1;
-		v.stepCount = steps;
-	}
-	else
-		v.stepCount = 0;
+  auto param_range = (info->max_value - info->min_value);
 
-	auto result = new Vst3Parameter(v, info);
-	result->addRef();	// ParameterContainer doesn't add the ref -> but we don't have copies
-	return result;
+  v.defaultNormalizedValue = (info->default_value - info->min_value) / param_range;
+  if (info->flags & CLAP_PARAM_IS_STEPPED)
+  {
+    auto steps = param_range + 1;
+    v.stepCount = steps;
+  }
+  else
+    v.stepCount = 0;
+
+  auto result = new Vst3Parameter(v, info);
+  result->addRef(); // ParameterContainer doesn't add the ref -> but we don't have copies
+  return result;
 }
 
-Vst3Parameter* Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, Vst::ParamID id)
+Vst3Parameter *Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, Vst::ParamID id)
 {
-	Vst::ParameterInfo v;
+  Vst::ParameterInfo v;
 
-	v.id = id;
+  v.id = id;
 
-	auto name = "controller";
-	// the long name might contain the module name
-	// this will change when we split the module to units
-	std::string fullname("MIDI");
-	if (!fullname.empty())
-	{
-		fullname.append("/");
-	}
-	fullname.append("controller");
-	if (fullname.size() >= str16BufferSize(v.title))
-	{
-		fullname = "controller";
-	}
-	str8ToStr16(v.title, fullname.c_str(), str16BufferSize(v.title));
-	// TODO: string shrink algorithm shortening the string a bit
-	str8ToStr16(v.shortTitle, name, str16BufferSize(v.shortTitle));
-	v.units[0] = 0;  // unfortunately, CLAP has no unit for parameter values
-	v.unitId = channel+1;
+  auto name = "controller";
+  // the long name might contain the module name
+  // this will change when we split the module to units
+  std::string fullname("MIDI");
+  if (!fullname.empty())
+  {
+    fullname.append("/");
+  }
+  fullname.append("controller");
+  if (fullname.size() >= str16BufferSize(v.title))
+  {
+    fullname = "controller";
+  }
+  str8ToStr16(v.title, fullname.c_str(), str16BufferSize(v.title));
+  // TODO: string shrink algorithm shortening the string a bit
+  str8ToStr16(v.shortTitle, name, str16BufferSize(v.shortTitle));
+  v.units[0] = 0; // unfortunately, CLAP has no unit for parameter values
+  v.unitId = channel + 1;
 
-	v.defaultNormalizedValue = 0;
-	v.flags = Vst::ParameterInfo::kNoFlags;
-	if (cc == Vst::ControllerNumbers::kCtrlProgramChange)
-	{
-		v.flags |= Vst::ParameterInfo::kIsProgramChange;
-		v.stepCount = 128;
-	}
+  v.defaultNormalizedValue = 0;
+  v.flags = Vst::ParameterInfo::kNoFlags;
+  if (cc == Vst::ControllerNumbers::kCtrlProgramChange)
+  {
+    v.flags |= Vst::ParameterInfo::kIsProgramChange;
+    v.stepCount = 128;
+  }
 
-	v.defaultNormalizedValue = 0;
-	v.stepCount = 128;
+  v.defaultNormalizedValue = 0;
+  v.stepCount = 128;
 
-	if (cc == Vst::ControllerNumbers::kPitchBend)
-	{
-		v.stepCount = 16384;
-	}
+  if (cc == Vst::ControllerNumbers::kPitchBend)
+  {
+    v.stepCount = 16384;
+  }
 
-	auto result = new Vst3Parameter(v,bus, channel, cc);
-	result->addRef();	// ParameterContainer doesn't add the ref -> but we don't have copies
-	return result;
+  auto result = new Vst3Parameter(v, bus, channel, cc);
+  result->addRef(); // ParameterContainer doesn't add the ref -> but we don't have copies
+  return result;
 }

--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -5,14 +5,27 @@
 
 using namespace Steinberg;
 
-Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, const clap_param_info_t* clapinfo)
-    : Steinberg::Vst::Parameter(vst3info), id(clapinfo->id), cookie(clapinfo->cookie), min_value(clapinfo->min_value), max_value(clapinfo->max_value)
+Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info,
+                             const clap_param_info_t* clapinfo)
+    : Steinberg::Vst::Parameter(vst3info),
+      id(clapinfo->id),
+      cookie(clapinfo->cookie),
+      min_value(clapinfo->min_value),
+      max_value(clapinfo->max_value)
 {
   //
 }
 
-Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint8_t bus, uint8_t channel, uint8_t cc)
-    : Steinberg::Vst::Parameter(vst3info), id(vst3info.id), cookie(nullptr), min_value(0), max_value(127), isMidi(true), channel(channel), controller(cc)
+Vst3Parameter::Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint8_t bus, uint8_t channel,
+                             uint8_t cc)
+    : Steinberg::Vst::Parameter(vst3info),
+      id(vst3info.id),
+      cookie(nullptr),
+      min_value(0),
+      max_value(127),
+      isMidi(true),
+      channel(channel),
+      controller(cc)
 {
   if (cc == Vst::ControllerNumbers::kPitchBend)
   {
@@ -44,7 +57,9 @@ bool Vst3Parameter::fromString(const Steinberg::Vst::TChar* string, Steinberg::V
 }
 #endif
 
-Vst3Parameter* Vst3Parameter::create(const clap_param_info_t* info, std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId)
+Vst3Parameter* Vst3Parameter::create(
+    const clap_param_info_t* info,
+    std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId)
 {
   Vst::ParameterInfo v;
 
@@ -90,8 +105,11 @@ Vst3Parameter* Vst3Parameter::create(const clap_param_info_t* info, std::functio
 			int discreteValue = min (stepCount, normalized * (stepCount + 1));
 	*/
 
-  v.flags = Vst::ParameterInfo::kNoFlags | ((info->flags & CLAP_PARAM_IS_HIDDEN) ? Vst::ParameterInfo::kIsHidden : 0) | ((info->flags & CLAP_PARAM_IS_BYPASS) ? Vst::ParameterInfo::kIsBypass : 0) |
-            ((info->flags & CLAP_PARAM_IS_AUTOMATABLE) ? Vst::ParameterInfo::kCanAutomate : 0) | ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
+  v.flags = Vst::ParameterInfo::kNoFlags |
+            ((info->flags & CLAP_PARAM_IS_HIDDEN) ? Vst::ParameterInfo::kIsHidden : 0) |
+            ((info->flags & CLAP_PARAM_IS_BYPASS) ? Vst::ParameterInfo::kIsBypass : 0) |
+            ((info->flags & CLAP_PARAM_IS_AUTOMATABLE) ? Vst::ParameterInfo::kCanAutomate : 0) |
+            ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
       // | ((info->flags & CLAP_PARAM_IS_READONLY) ? Vst::ParameterInfo::kIsReadOnly : 0)
       ;
 

--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -49,8 +49,14 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
   bool fromString(const Steinberg::Vst::TChar* string, Steinberg::Vst::ParamValue& valueNormalized) const override;
 #endif
 
-  inline double asClapValue(double vst3value) const { return vst3value * (max_value - min_value) + min_value; }
-  inline double asVst3Value(double clapvalue) const { return (clapvalue - min_value) / (max_value - min_value); }
+  inline double asClapValue(double vst3value) const
+  {
+    return vst3value * (max_value - min_value) + min_value;
+  }
+  inline double asVst3Value(double clapvalue) const
+  {
+    return (clapvalue - min_value) / (max_value - min_value);
+  }
   static Vst3Parameter* create(const clap_param_info_t* info, std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId);
   static Vst3Parameter* create(uint8_t bus, uint8_t channel, uint8_t cc, Steinberg::Vst::ParamID id);
   // copies from the clap_param_info_t

--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -30,11 +30,11 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
 {
   using super = Steinberg::Vst::Parameter;
 
-protected:
-  Vst3Parameter(const Steinberg::Vst::ParameterInfo &vst3info, const clap_param_info_t *clapinfo);
-  Vst3Parameter(const Steinberg::Vst::ParameterInfo &vst3info, uint8_t bus, uint8_t channel, uint8_t cc);
+ protected:
+  Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, const clap_param_info_t* clapinfo);
+  Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint8_t bus, uint8_t channel, uint8_t cc);
 
-public:
+ public:
   virtual ~Vst3Parameter();
   bool setNormalized(Steinberg::Vst::ParamValue v) override;
 
@@ -51,14 +51,13 @@ public:
 
   inline double asClapValue(double vst3value) const { return vst3value * (max_value - min_value) + min_value; }
   inline double asVst3Value(double clapvalue) const { return (clapvalue - min_value) / (max_value - min_value); }
-  static Vst3Parameter *create(const clap_param_info_t *info,
-                               std::function<Steinberg::Vst::UnitID(const char *modulepath)> getUnitId);
-  static Vst3Parameter *create(uint8_t bus, uint8_t channel, uint8_t cc, Steinberg::Vst::ParamID id);
+  static Vst3Parameter* create(const clap_param_info_t* info, std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId);
+  static Vst3Parameter* create(uint8_t bus, uint8_t channel, uint8_t cc, Steinberg::Vst::ParamID id);
   // copies from the clap_param_info_t
   clap_id id = 0;
-  void *cookie = nullptr;
-  double min_value; // minimum plain value
-  double max_value; // maximum plain value
+  void* cookie = nullptr;
+  double min_value;  // minimum plain value
+  double max_value;  // maximum plain value
   // or it was MIDI
   bool isMidi = false;
   uint8_t channel = 0;

--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -57,7 +57,8 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
   {
     return (clapvalue - min_value) / (max_value - min_value);
   }
-  static Vst3Parameter* create(const clap_param_info_t* info, std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId);
+  static Vst3Parameter* create(const clap_param_info_t* info,
+                               std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId);
   static Vst3Parameter* create(uint8_t bus, uint8_t channel, uint8_t cc, Steinberg::Vst::ParamID id);
   // copies from the clap_param_info_t
   clap_id id = 0;

--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -29,9 +29,11 @@
 class Vst3Parameter : public Steinberg::Vst::Parameter
 {
   using super = Steinberg::Vst::Parameter;
+
 protected:
-  Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, const clap_param_info_t* clapinfo);
-  Vst3Parameter(const Steinberg::Vst::ParameterInfo& vst3info, uint8_t bus, uint8_t channel, uint8_t cc);
+  Vst3Parameter(const Steinberg::Vst::ParameterInfo &vst3info, const clap_param_info_t *clapinfo);
+  Vst3Parameter(const Steinberg::Vst::ParameterInfo &vst3info, uint8_t bus, uint8_t channel, uint8_t cc);
+
 public:
   virtual ~Vst3Parameter();
   bool setNormalized(Steinberg::Vst::ParamValue v) override;
@@ -47,24 +49,18 @@ public:
   bool fromString(const Steinberg::Vst::TChar* string, Steinberg::Vst::ParamValue& valueNormalized) const override;
 #endif
 
-  inline double asClapValue(double vst3value) const
-  {
-    return vst3value * (max_value - min_value) + min_value;
-  }
-  inline double asVst3Value(double clapvalue) const
-  {
-    return (clapvalue - min_value) / (max_value - min_value);
-  }
-  static Vst3Parameter* create(const clap_param_info_t* info, std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId);
-  static Vst3Parameter* create(uint8_t bus, uint8_t channel, uint8_t cc, Steinberg::Vst::ParamID id);
+  inline double asClapValue(double vst3value) const { return vst3value * (max_value - min_value) + min_value; }
+  inline double asVst3Value(double clapvalue) const { return (clapvalue - min_value) / (max_value - min_value); }
+  static Vst3Parameter *create(const clap_param_info_t *info,
+                               std::function<Steinberg::Vst::UnitID(const char *modulepath)> getUnitId);
+  static Vst3Parameter *create(uint8_t bus, uint8_t channel, uint8_t cc, Steinberg::Vst::ParamID id);
   // copies from the clap_param_info_t
   clap_id id = 0;
-  void* cookie = nullptr;
-  double min_value;     // minimum plain value
-  double max_value;     // maximum plain value
+  void *cookie = nullptr;
+  double min_value; // minimum plain value
+  double max_value; // maximum plain value
   // or it was MIDI
   bool isMidi = false;
   uint8_t channel = 0;
   uint8_t controller = 0;
-
 };

--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -3,16 +3,11 @@
 // #include <crtdbg.h>
 #include <cassert>
 
-WrappedView::WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui, std::function<void()> onDestroy,
+WrappedView::WrappedView(const clap_plugin_t *plugin, const clap_plugin_gui_t *gui, std::function<void()> onDestroy,
                          std::function<void()> onRunLoopAvailable)
-  : IPlugView()
-  , FObject()
-  , _plugin(plugin)
-  , _extgui(gui)
-  , _onDestroy(onDestroy)
-  , _onRunLoopAvailable(onRunLoopAvailable)
+    : IPlugView(), FObject(), _plugin(plugin), _extgui(gui), _onDestroy(onDestroy),
+      _onRunLoopAvailable(onRunLoopAvailable)
 {
-  
 }
 
 WrappedView::~WrappedView()
@@ -28,18 +23,18 @@ void WrappedView::ensure_ui()
 {
   if (!_created)
   {
-     const char* api{nullptr};
+    const char *api{nullptr};
 #if MAC
-     api = CLAP_WINDOW_API_COCOA;
+    api = CLAP_WINDOW_API_COCOA;
 #endif
 #if WIN
-     api = CLAP_WINDOW_API_WIN32;
+    api = CLAP_WINDOW_API_WIN32;
 #endif
 #if LIN
-      api = CLAP_WINDOW_API_X11;
+    api = CLAP_WINDOW_API_X11;
 #endif
 
-     if (_extgui->is_api_supported(_plugin, api, false))
+    if (_extgui->is_api_supported(_plugin, api, false))
       _extgui->create(_plugin, api, false);
 
     _created = true;
@@ -58,17 +53,15 @@ void WrappedView::drop_ui()
 
 tresult PLUGIN_API WrappedView::isPlatformTypeSupported(FIDString type)
 {
-  static struct vst3_and_clap_match_types_t{
-    const char* VST3;
-    const char* CLAP;
-  } platformTypeMatches[] =
-    {
-      { kPlatformTypeHWND, CLAP_WINDOW_API_WIN32},
-      { kPlatformTypeNSView, CLAP_WINDOW_API_COCOA },
-      { kPlatformTypeX11EmbedWindowID, CLAP_WINDOW_API_X11},
-      { nullptr, nullptr }
-    };
-  auto* n = platformTypeMatches;
+  static struct vst3_and_clap_match_types_t
+  {
+    const char *VST3;
+    const char *CLAP;
+  } platformTypeMatches[] = {{kPlatformTypeHWND, CLAP_WINDOW_API_WIN32},
+                             {kPlatformTypeNSView, CLAP_WINDOW_API_COCOA},
+                             {kPlatformTypeX11EmbedWindowID, CLAP_WINDOW_API_X11},
+                             {nullptr, nullptr}};
+  auto *n = platformTypeMatches;
   while (n->VST3 && n->CLAP)
   {
     if (!strcmp(type, n->VST3))
@@ -84,19 +77,18 @@ tresult PLUGIN_API WrappedView::isPlatformTypeSupported(FIDString type)
   return kResultFalse;
 }
 
-tresult PLUGIN_API WrappedView::attached(void* parent, FIDString type)
+tresult PLUGIN_API WrappedView::attached(void *parent, FIDString type)
 {
 #if WIN
-  _window = { CLAP_WINDOW_API_WIN32, { parent } };
+  _window = {CLAP_WINDOW_API_WIN32, {parent}};
 #endif
 
 #if MAC
-   _window = { CLAP_WINDOW_API_COCOA, { parent } };
+  _window = {CLAP_WINDOW_API_COCOA, {parent}};
 #endif
 
-
 #if LIN
-    _window = { CLAP_WINDOW_API_X11, { parent } };
+  _window = {CLAP_WINDOW_API_X11, {parent}};
 #endif
 
   ensure_ui();
@@ -108,10 +100,10 @@ tresult PLUGIN_API WrappedView::attached(void* parent, FIDString type)
     uint32_t h = _rect.getHeight();
     if (_extgui->adjust_size(_plugin, &w, &h))
     {
-      _rect.right = _rect.left + w +1;
-      _rect.bottom = _rect.top + h +1;
+      _rect.right = _rect.left + w + 1;
+      _rect.bottom = _rect.top + h + 1;
     }
-    _extgui->set_size(_plugin, w , h);
+    _extgui->set_size(_plugin, w, h);
   }
   _extgui->show(_plugin);
   return kResultOk;
@@ -124,22 +116,13 @@ tresult PLUGIN_API WrappedView::removed()
   return kResultOk;
 }
 
-tresult PLUGIN_API WrappedView::onWheel(float distance)
-{
-  return kResultOk;
-}
+tresult PLUGIN_API WrappedView::onWheel(float distance) { return kResultOk; }
 
-tresult PLUGIN_API WrappedView::onKeyDown(char16 key, int16 keyCode, int16 modifiers)
-{
-  return kResultOk;
-}
+tresult PLUGIN_API WrappedView::onKeyDown(char16 key, int16 keyCode, int16 modifiers) { return kResultOk; }
 
-tresult PLUGIN_API WrappedView::onKeyUp(char16 key, int16 keyCode, int16 modifiers)
-{  
-  return kResultOk;
-}
+tresult PLUGIN_API WrappedView::onKeyUp(char16 key, int16 keyCode, int16 modifiers) { return kResultOk; }
 
-tresult PLUGIN_API WrappedView::getSize(ViewRect* size)
+tresult PLUGIN_API WrappedView::getSize(ViewRect *size)
 {
   ensure_ui();
   if (size)
@@ -157,7 +140,7 @@ tresult PLUGIN_API WrappedView::getSize(ViewRect* size)
   return kInvalidArgument;
 }
 
-tresult PLUGIN_API WrappedView::onSize(ViewRect* newSize)
+tresult PLUGIN_API WrappedView::onSize(ViewRect *newSize)
 {
   // TODO: discussion took place if this call should be ignored completely
   // since it seems not to match the CLAP UI scheme.
@@ -185,11 +168,10 @@ tresult PLUGIN_API WrappedView::onSize(ViewRect* newSize)
       {
         return kResultFalse;
       }
-
     }
     return kResultOk;
   }
-  
+
   return kResultFalse;
 }
 
@@ -200,13 +182,12 @@ tresult PLUGIN_API WrappedView::onFocus(TBool state)
   return kResultOk;
 }
 
-tresult PLUGIN_API WrappedView::setFrame(IPlugFrame* frame)
+tresult PLUGIN_API WrappedView::setFrame(IPlugFrame *frame)
 {
   _plugFrame = frame;
 
 #if LIN
-  if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid,
-                                 (void **)&_runLoop) == Steinberg::kResultOk &&
+  if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void **)&_runLoop) == Steinberg::kResultOk &&
       _onRunLoopAvailable)
   {
     _onRunLoopAvailable();
@@ -222,7 +203,7 @@ tresult PLUGIN_API WrappedView::canResize()
   return _extgui->can_resize(_plugin) ? kResultOk : kResultFalse;
 }
 
-tresult PLUGIN_API WrappedView::checkSizeConstraint(ViewRect* rect)
+tresult PLUGIN_API WrappedView::checkSizeConstraint(ViewRect *rect)
 {
   ensure_ui();
   uint32_t w = rect->getWidth();

--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -110,11 +110,20 @@ tresult PLUGIN_API WrappedView::removed()
   return kResultOk;
 }
 
-tresult PLUGIN_API WrappedView::onWheel(float distance) { return kResultOk; }
+tresult PLUGIN_API WrappedView::onWheel(float distance)
+{
+  return kResultOk;
+}
 
-tresult PLUGIN_API WrappedView::onKeyDown(char16 key, int16 keyCode, int16 modifiers) { return kResultOk; }
+tresult PLUGIN_API WrappedView::onKeyDown(char16 key, int16 keyCode, int16 modifiers)
+{
+  return kResultOk;
+}
 
-tresult PLUGIN_API WrappedView::onKeyUp(char16 key, int16 keyCode, int16 modifiers) { return kResultOk; }
+tresult PLUGIN_API WrappedView::onKeyUp(char16 key, int16 keyCode, int16 modifiers)
+{
+  return kResultOk;
+}
 
 tresult PLUGIN_API WrappedView::getSize(ViewRect* size)
 {

--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -3,10 +3,8 @@
 // #include <crtdbg.h>
 #include <cassert>
 
-WrappedView::WrappedView(const clap_plugin_t *plugin, const clap_plugin_gui_t *gui, std::function<void()> onDestroy,
-                         std::function<void()> onRunLoopAvailable)
-    : IPlugView(), FObject(), _plugin(plugin), _extgui(gui), _onDestroy(onDestroy),
-      _onRunLoopAvailable(onRunLoopAvailable)
+WrappedView::WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui, std::function<void()> onDestroy, std::function<void()> onRunLoopAvailable)
+    : IPlugView(), FObject(), _plugin(plugin), _extgui(gui), _onDestroy(onDestroy), _onRunLoopAvailable(onRunLoopAvailable)
 {
 }
 
@@ -23,7 +21,7 @@ void WrappedView::ensure_ui()
 {
   if (!_created)
   {
-    const char *api{nullptr};
+    const char* api{nullptr};
 #if MAC
     api = CLAP_WINDOW_API_COCOA;
 #endif
@@ -34,8 +32,7 @@ void WrappedView::ensure_ui()
     api = CLAP_WINDOW_API_X11;
 #endif
 
-    if (_extgui->is_api_supported(_plugin, api, false))
-      _extgui->create(_plugin, api, false);
+    if (_extgui->is_api_supported(_plugin, api, false)) _extgui->create(_plugin, api, false);
 
     _created = true;
   }
@@ -55,13 +52,10 @@ tresult PLUGIN_API WrappedView::isPlatformTypeSupported(FIDString type)
 {
   static struct vst3_and_clap_match_types_t
   {
-    const char *VST3;
-    const char *CLAP;
-  } platformTypeMatches[] = {{kPlatformTypeHWND, CLAP_WINDOW_API_WIN32},
-                             {kPlatformTypeNSView, CLAP_WINDOW_API_COCOA},
-                             {kPlatformTypeX11EmbedWindowID, CLAP_WINDOW_API_X11},
-                             {nullptr, nullptr}};
-  auto *n = platformTypeMatches;
+    const char* VST3;
+    const char* CLAP;
+  } platformTypeMatches[] = {{kPlatformTypeHWND, CLAP_WINDOW_API_WIN32}, {kPlatformTypeNSView, CLAP_WINDOW_API_COCOA}, {kPlatformTypeX11EmbedWindowID, CLAP_WINDOW_API_X11}, {nullptr, nullptr}};
+  auto* n = platformTypeMatches;
   while (n->VST3 && n->CLAP)
   {
     if (!strcmp(type, n->VST3))
@@ -77,7 +71,7 @@ tresult PLUGIN_API WrappedView::isPlatformTypeSupported(FIDString type)
   return kResultFalse;
 }
 
-tresult PLUGIN_API WrappedView::attached(void *parent, FIDString type)
+tresult PLUGIN_API WrappedView::attached(void* parent, FIDString type)
 {
 #if WIN
   _window = {CLAP_WINDOW_API_WIN32, {parent}};
@@ -122,7 +116,7 @@ tresult PLUGIN_API WrappedView::onKeyDown(char16 key, int16 keyCode, int16 modif
 
 tresult PLUGIN_API WrappedView::onKeyUp(char16 key, int16 keyCode, int16 modifiers) { return kResultOk; }
 
-tresult PLUGIN_API WrappedView::getSize(ViewRect *size)
+tresult PLUGIN_API WrappedView::getSize(ViewRect* size)
 {
   ensure_ui();
   if (size)
@@ -140,7 +134,7 @@ tresult PLUGIN_API WrappedView::getSize(ViewRect *size)
   return kInvalidArgument;
 }
 
-tresult PLUGIN_API WrappedView::onSize(ViewRect *newSize)
+tresult PLUGIN_API WrappedView::onSize(ViewRect* newSize)
 {
   // TODO: discussion took place if this call should be ignored completely
   // since it seems not to match the CLAP UI scheme.
@@ -182,13 +176,12 @@ tresult PLUGIN_API WrappedView::onFocus(TBool state)
   return kResultOk;
 }
 
-tresult PLUGIN_API WrappedView::setFrame(IPlugFrame *frame)
+tresult PLUGIN_API WrappedView::setFrame(IPlugFrame* frame)
 {
   _plugFrame = frame;
 
 #if LIN
-  if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void **)&_runLoop) == Steinberg::kResultOk &&
-      _onRunLoopAvailable)
+  if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void**)&_runLoop) == Steinberg::kResultOk && _onRunLoopAvailable)
   {
     _onRunLoopAvailable();
   }
@@ -203,7 +196,7 @@ tresult PLUGIN_API WrappedView::canResize()
   return _extgui->can_resize(_plugin) ? kResultOk : kResultFalse;
 }
 
-tresult PLUGIN_API WrappedView::checkSizeConstraint(ViewRect *rect)
+tresult PLUGIN_API WrappedView::checkSizeConstraint(ViewRect* rect)
 {
   ensure_ui();
   uint32_t w = rect->getWidth();

--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -3,8 +3,14 @@
 // #include <crtdbg.h>
 #include <cassert>
 
-WrappedView::WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui, std::function<void()> onDestroy, std::function<void()> onRunLoopAvailable)
-    : IPlugView(), FObject(), _plugin(plugin), _extgui(gui), _onDestroy(onDestroy), _onRunLoopAvailable(onRunLoopAvailable)
+WrappedView::WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui,
+                         std::function<void()> onDestroy, std::function<void()> onRunLoopAvailable)
+    : IPlugView(),
+      FObject(),
+      _plugin(plugin),
+      _extgui(gui),
+      _onDestroy(onDestroy),
+      _onRunLoopAvailable(onRunLoopAvailable)
 {
 }
 
@@ -54,7 +60,10 @@ tresult PLUGIN_API WrappedView::isPlatformTypeSupported(FIDString type)
   {
     const char* VST3;
     const char* CLAP;
-  } platformTypeMatches[] = {{kPlatformTypeHWND, CLAP_WINDOW_API_WIN32}, {kPlatformTypeNSView, CLAP_WINDOW_API_COCOA}, {kPlatformTypeX11EmbedWindowID, CLAP_WINDOW_API_X11}, {nullptr, nullptr}};
+  } platformTypeMatches[] = {{kPlatformTypeHWND, CLAP_WINDOW_API_WIN32},
+                             {kPlatformTypeNSView, CLAP_WINDOW_API_COCOA},
+                             {kPlatformTypeX11EmbedWindowID, CLAP_WINDOW_API_X11},
+                             {nullptr, nullptr}};
   auto* n = platformTypeMatches;
   while (n->VST3 && n->CLAP)
   {
@@ -190,7 +199,9 @@ tresult PLUGIN_API WrappedView::setFrame(IPlugFrame* frame)
   _plugFrame = frame;
 
 #if LIN
-  if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void**)&_runLoop) == Steinberg::kResultOk && _onRunLoopAvailable)
+  if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void**)&_runLoop) ==
+          Steinberg::kResultOk &&
+      _onRunLoopAvailable)
   {
     _onRunLoopAvailable();
   }

--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -5,12 +5,12 @@
 
 WrappedView::WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui,
                          std::function<void()> onDestroy, std::function<void()> onRunLoopAvailable)
-    : IPlugView()
-    , FObject()
-    , _plugin(plugin)
-    , _extgui(gui)
-    , _onDestroy(onDestroy)
-    , _onRunLoopAvailable(onRunLoopAvailable)
+  : IPlugView()
+  , FObject()
+  , _plugin(plugin)
+  , _extgui(gui)
+  , _onDestroy(onDestroy)
+  , _onRunLoopAvailable(onRunLoopAvailable)
 {
 }
 

--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -5,12 +5,12 @@
 
 WrappedView::WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui,
                          std::function<void()> onDestroy, std::function<void()> onRunLoopAvailable)
-    : IPlugView(),
-      FObject(),
-      _plugin(plugin),
-      _extgui(gui),
-      _onDestroy(onDestroy),
-      _onRunLoopAvailable(onRunLoopAvailable)
+    : IPlugView()
+    , FObject()
+    , _plugin(plugin)
+    , _extgui(gui)
+    , _onDestroy(onDestroy)
+    , _onRunLoopAvailable(onRunLoopAvailable)
 {
 }
 

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -99,7 +99,10 @@ class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
 
 #if LIN
  public:
-  Steinberg::Linux::IRunLoop* getRunLoop() { return _runLoop; }
+  Steinberg::Linux::IRunLoop* getRunLoop()
+  {
+    return _runLoop;
+  }
 
  private:
   Steinberg::Linux::IRunLoop* _runLoop = nullptr;

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -1,9 +1,9 @@
 /*
 
-                Copyright (c) 2022 Timo Kaluza (defiantnerd)
+		Copyright (c) 2022 Timo Kaluza (defiantnerd)
 
-                This file is part of the clap-wrappers project which is released under MIT License.
-                See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+		This file is part of the clap-wrappers project which is released under MIT License.
+		See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
 
 */
 
@@ -16,66 +16,64 @@ using namespace Steinberg;
 
 class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
 {
-
-public:
-  WrappedView(const clap_plugin_t *plugin, const clap_plugin_gui_t *gui, std::function<void()> onDestroy,
-              std::function<void()> onRunLoopAvailable);
+ public:
+  WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui, std::function<void()> onDestroy, std::function<void()> onRunLoopAvailable);
   ~WrappedView();
 
   // IPlugView interface
   tresult PLUGIN_API isPlatformTypeSupported(FIDString type) override;
 
   /** The parent window of the view has been created, the (platform) representation of the view
-          should now be created as well.
-                  Note that the parent is owned by the caller and you are not allowed to alter it in any way
-          other than adding your own views.
-                  Note that in this call the plug-in could call a IPlugFrame::resizeView ()!
-                  \param parent : platform handle of the parent window or view
-                  \param type : \ref platformUIType which should be created */
-  tresult PLUGIN_API attached(void *parent, FIDString type) override;
+		should now be created as well.
+			Note that the parent is owned by the caller and you are not allowed to alter it in any way
+		other than adding your own views.
+			Note that in this call the plug-in could call a IPlugFrame::resizeView ()!
+			\param parent : platform handle of the parent window or view
+			\param type : \ref platformUIType which should be created */
+  tresult PLUGIN_API attached(void* parent, FIDString type) override;
 
   /** The parent window of the view is about to be destroyed.
-                  You have to remove all your own views from the parent window or view. */
+			You have to remove all your own views from the parent window or view. */
   tresult PLUGIN_API removed() override;
 
   /** Handling of mouse wheel. */
   tresult PLUGIN_API onWheel(float distance) override;
 
   /** Handling of keyboard events : Key Down.
-                  \param key : unicode code of key
-                  \param keyCode : virtual keycode for non ascii keys - see \ref VirtualKeyCodes in keycodes.h
-                  \param modifiers : any combination of modifiers - see \ref KeyModifier in keycodes.h
-                  \return kResultTrue if the key is handled, otherwise kResultFalse. \n
-                                                  <b> Please note that kResultTrue must only be returned if the key has
-     really been handled. </b> Otherwise key command handling of the host might be blocked! */
+			\param key : unicode code of key
+			\param keyCode : virtual keycode for non ascii keys - see \ref VirtualKeyCodes in keycodes.h
+			\param modifiers : any combination of modifiers - see \ref KeyModifier in keycodes.h
+			\return kResultTrue if the key is handled, otherwise kResultFalse. \n
+							<b> Please note that kResultTrue must only be returned if the key has really been
+		 handled. </b> Otherwise key command handling of the host might be blocked! */
   tresult PLUGIN_API onKeyDown(char16 key, int16 keyCode, int16 modifiers) override;
 
   /** Handling of keyboard events : Key Up.
-                  \param key : unicode code of key
-                  \param keyCode : virtual keycode for non ascii keys - see \ref VirtualKeyCodes in keycodes.h
-                  \param modifiers : any combination of KeyModifier - see \ref KeyModifier in keycodes.h
-                  \return kResultTrue if the key is handled, otherwise return kResultFalse. */
+			\param key : unicode code of key
+			\param keyCode : virtual keycode for non ascii keys - see \ref VirtualKeyCodes in keycodes.h
+			\param modifiers : any combination of KeyModifier - see \ref KeyModifier in keycodes.h
+			\return kResultTrue if the key is handled, otherwise return kResultFalse. */
   tresult PLUGIN_API onKeyUp(char16 key, int16 keyCode, int16 modifiers) override;
 
   /** Returns the size of the platform representation of the view. */
-  tresult PLUGIN_API getSize(ViewRect *size) override;
+  tresult PLUGIN_API getSize(ViewRect* size) override;
 
   /** Resizes the platform representation of the view to the given rect. Note that if the plug-in
-   *	requests a resize (IPlugFrame::resizeView ()) onSize has to be called afterward. */
-  tresult PLUGIN_API onSize(ViewRect *newSize) override;
+	 *	requests a resize (IPlugFrame::resizeView ()) onSize has to be called afterward. */
+  tresult PLUGIN_API onSize(ViewRect* newSize) override;
 
   /** Focus changed message. */
   tresult PLUGIN_API onFocus(TBool state) override;
 
   /** Sets IPlugFrame object to allow the plug-in to inform the host about resizing. */
-  tresult PLUGIN_API setFrame(IPlugFrame *frame) override;
+  tresult PLUGIN_API setFrame(IPlugFrame* frame) override;
 
   /** Is view sizable by user. */
   tresult PLUGIN_API canResize() override;
 
   /** On live resize this is called to check if the view can be resized to the given rect, if not
-   *	adjust the rect to the allowed size. */
-  tresult PLUGIN_API checkSizeConstraint(ViewRect *rect) override;
+	 *	adjust the rect to the allowed size. */
+  tresult PLUGIN_API checkSizeConstraint(ViewRect* rect) override;
 
   //---Interface------
   OBJ_METHODS(WrappedView, FObject)
@@ -87,23 +85,23 @@ public:
   // wrapper needed interfaces
   bool request_resize(uint32_t width, uint32_t height);
 
-private:
+ private:
   void ensure_ui();
   void drop_ui();
-  const clap_plugin_t *_plugin = nullptr;
-  const clap_plugin_gui_t *_extgui = nullptr;
+  const clap_plugin_t* _plugin = nullptr;
+  const clap_plugin_gui_t* _extgui = nullptr;
   std::function<void()> _onDestroy = nullptr, _onRunLoopAvailable = nullptr;
   clap_window_t _window = {nullptr, {nullptr}};
-  IPlugFrame *_plugFrame = nullptr;
+  IPlugFrame* _plugFrame = nullptr;
   ViewRect _rect = {0, 0, 0, 0};
   bool _created = false;
   bool _attached = false;
 
 #if LIN
-public:
-  Steinberg::Linux::IRunLoop *getRunLoop() { return _runLoop; }
+ public:
+  Steinberg::Linux::IRunLoop* getRunLoop() { return _runLoop; }
 
-private:
-  Steinberg::Linux::IRunLoop *_runLoop = nullptr;
+ private:
+  Steinberg::Linux::IRunLoop* _runLoop = nullptr;
 #endif
 };

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -17,7 +17,8 @@ using namespace Steinberg;
 class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
 {
  public:
-  WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui, std::function<void()> onDestroy, std::function<void()> onRunLoopAvailable);
+  WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui, std::function<void()> onDestroy,
+              std::function<void()> onRunLoopAvailable);
   ~WrappedView();
 
   // IPlugView interface

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -1,9 +1,9 @@
 /*
 
-		Copyright (c) 2022 Timo Kaluza (defiantnerd)
+                Copyright (c) 2022 Timo Kaluza (defiantnerd)
 
-		This file is part of the clap-wrappers project which is released under MIT License.
-		See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+                This file is part of the clap-wrappers project which is released under MIT License.
+                See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
 
 */
 
@@ -18,93 +18,92 @@ class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
 {
 
 public:
+  WrappedView(const clap_plugin_t *plugin, const clap_plugin_gui_t *gui, std::function<void()> onDestroy,
+              std::function<void()> onRunLoopAvailable);
+  ~WrappedView();
 
-	WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui, std::function<void()> onDestroy, std::function<void()> onRunLoopAvailable);
-	~WrappedView();
+  // IPlugView interface
+  tresult PLUGIN_API isPlatformTypeSupported(FIDString type) override;
 
+  /** The parent window of the view has been created, the (platform) representation of the view
+          should now be created as well.
+                  Note that the parent is owned by the caller and you are not allowed to alter it in any way
+          other than adding your own views.
+                  Note that in this call the plug-in could call a IPlugFrame::resizeView ()!
+                  \param parent : platform handle of the parent window or view
+                  \param type : \ref platformUIType which should be created */
+  tresult PLUGIN_API attached(void *parent, FIDString type) override;
 
-	// IPlugView interface
-	tresult PLUGIN_API isPlatformTypeSupported(FIDString type) override;
+  /** The parent window of the view is about to be destroyed.
+                  You have to remove all your own views from the parent window or view. */
+  tresult PLUGIN_API removed() override;
 
-	/** The parent window of the view has been created, the (platform) representation of the view
-		should now be created as well.
-			Note that the parent is owned by the caller and you are not allowed to alter it in any way
-		other than adding your own views.
-			Note that in this call the plug-in could call a IPlugFrame::resizeView ()!
-			\param parent : platform handle of the parent window or view
-			\param type : \ref platformUIType which should be created */
-	tresult PLUGIN_API attached(void* parent, FIDString type) override;
+  /** Handling of mouse wheel. */
+  tresult PLUGIN_API onWheel(float distance) override;
 
-	/** The parent window of the view is about to be destroyed.
-			You have to remove all your own views from the parent window or view. */
-	tresult PLUGIN_API removed() override;
+  /** Handling of keyboard events : Key Down.
+                  \param key : unicode code of key
+                  \param keyCode : virtual keycode for non ascii keys - see \ref VirtualKeyCodes in keycodes.h
+                  \param modifiers : any combination of modifiers - see \ref KeyModifier in keycodes.h
+                  \return kResultTrue if the key is handled, otherwise kResultFalse. \n
+                                                  <b> Please note that kResultTrue must only be returned if the key has
+     really been handled. </b> Otherwise key command handling of the host might be blocked! */
+  tresult PLUGIN_API onKeyDown(char16 key, int16 keyCode, int16 modifiers) override;
 
-	/** Handling of mouse wheel. */
-	tresult PLUGIN_API onWheel(float distance) override;
+  /** Handling of keyboard events : Key Up.
+                  \param key : unicode code of key
+                  \param keyCode : virtual keycode for non ascii keys - see \ref VirtualKeyCodes in keycodes.h
+                  \param modifiers : any combination of KeyModifier - see \ref KeyModifier in keycodes.h
+                  \return kResultTrue if the key is handled, otherwise return kResultFalse. */
+  tresult PLUGIN_API onKeyUp(char16 key, int16 keyCode, int16 modifiers) override;
 
-	/** Handling of keyboard events : Key Down.
-			\param key : unicode code of key
-			\param keyCode : virtual keycode for non ascii keys - see \ref VirtualKeyCodes in keycodes.h
-			\param modifiers : any combination of modifiers - see \ref KeyModifier in keycodes.h
-			\return kResultTrue if the key is handled, otherwise kResultFalse. \n
-							<b> Please note that kResultTrue must only be returned if the key has really been
-		 handled. </b> Otherwise key command handling of the host might be blocked! */
-	tresult PLUGIN_API onKeyDown(char16 key, int16 keyCode, int16 modifiers) override;
+  /** Returns the size of the platform representation of the view. */
+  tresult PLUGIN_API getSize(ViewRect *size) override;
 
-	/** Handling of keyboard events : Key Up.
-			\param key : unicode code of key
-			\param keyCode : virtual keycode for non ascii keys - see \ref VirtualKeyCodes in keycodes.h
-			\param modifiers : any combination of KeyModifier - see \ref KeyModifier in keycodes.h
-			\return kResultTrue if the key is handled, otherwise return kResultFalse. */
-	tresult PLUGIN_API onKeyUp(char16 key, int16 keyCode, int16 modifiers) override;
+  /** Resizes the platform representation of the view to the given rect. Note that if the plug-in
+   *	requests a resize (IPlugFrame::resizeView ()) onSize has to be called afterward. */
+  tresult PLUGIN_API onSize(ViewRect *newSize) override;
 
-	/** Returns the size of the platform representation of the view. */
-	tresult PLUGIN_API getSize(ViewRect* size) override;
+  /** Focus changed message. */
+  tresult PLUGIN_API onFocus(TBool state) override;
 
-	/** Resizes the platform representation of the view to the given rect. Note that if the plug-in
-	 *	requests a resize (IPlugFrame::resizeView ()) onSize has to be called afterward. */
-	tresult PLUGIN_API onSize(ViewRect* newSize) override;
+  /** Sets IPlugFrame object to allow the plug-in to inform the host about resizing. */
+  tresult PLUGIN_API setFrame(IPlugFrame *frame) override;
 
-	/** Focus changed message. */
-	tresult PLUGIN_API onFocus(TBool state) override;
+  /** Is view sizable by user. */
+  tresult PLUGIN_API canResize() override;
 
-	/** Sets IPlugFrame object to allow the plug-in to inform the host about resizing. */
-	tresult PLUGIN_API setFrame(IPlugFrame* frame) override;
+  /** On live resize this is called to check if the view can be resized to the given rect, if not
+   *	adjust the rect to the allowed size. */
+  tresult PLUGIN_API checkSizeConstraint(ViewRect *rect) override;
 
-	/** Is view sizable by user. */
-	tresult PLUGIN_API canResize() override;
-
-	/** On live resize this is called to check if the view can be resized to the given rect, if not
-	 *	adjust the rect to the allowed size. */
-	tresult PLUGIN_API checkSizeConstraint(ViewRect* rect) override;
-
-	//---Interface------
-	OBJ_METHODS(WrappedView, FObject)
-		DEFINE_INTERFACES
-		DEF_INTERFACE(IPlugView)
-		END_DEFINE_INTERFACES(FObject)
-		REFCOUNT_METHODS(FObject)
+  //---Interface------
+  OBJ_METHODS(WrappedView, FObject)
+  DEFINE_INTERFACES
+  DEF_INTERFACE(IPlugView)
+  END_DEFINE_INTERFACES(FObject)
+  REFCOUNT_METHODS(FObject)
 
   // wrapper needed interfaces
-	bool request_resize(uint32_t width, uint32_t height);
+  bool request_resize(uint32_t width, uint32_t height);
 
 private:
-	void ensure_ui();
-	void drop_ui();
-	const clap_plugin_t* _plugin = nullptr;
-	const clap_plugin_gui_t* _extgui = nullptr;	
-	std::function<void()> _onDestroy = nullptr, _onRunLoopAvailable = nullptr;
-  clap_window_t _window = { nullptr, { nullptr } };
-	IPlugFrame* _plugFrame = nullptr;
-    ViewRect _rect = {0,0,0,0};
-	bool _created = false;
-	bool _attached = false;
+  void ensure_ui();
+  void drop_ui();
+  const clap_plugin_t *_plugin = nullptr;
+  const clap_plugin_gui_t *_extgui = nullptr;
+  std::function<void()> _onDestroy = nullptr, _onRunLoopAvailable = nullptr;
+  clap_window_t _window = {nullptr, {nullptr}};
+  IPlugFrame *_plugFrame = nullptr;
+  ViewRect _rect = {0, 0, 0, 0};
+  bool _created = false;
+  bool _attached = false;
 
 #if LIN
 public:
-    Steinberg::Linux::IRunLoop *getRunLoop() { return _runLoop; }
-private:
-    Steinberg::Linux::IRunLoop *_runLoop = nullptr;
-#endif
+  Steinberg::Linux::IRunLoop *getRunLoop() { return _runLoop; }
 
+private:
+  Steinberg::Linux::IRunLoop *_runLoop = nullptr;
+#endif
 };

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -141,9 +141,15 @@ namespace Clap
     */
   }
 
-  inline clap_beattime doubleToBeatTime(double t) { return std::round(t * CLAP_BEATTIME_FACTOR); }
+  inline clap_beattime doubleToBeatTime(double t)
+  {
+    return std::round(t * CLAP_BEATTIME_FACTOR);
+  }
 
-  inline clap_sectime doubleToSecTime(double t) { return round(t * CLAP_SECTIME_FACTOR); }
+  inline clap_sectime doubleToSecTime(double t)
+  {
+    return round(t * CLAP_SECTIME_FACTOR);
+  }
 
   void ProcessAdapter::flush()
   {
@@ -382,7 +388,9 @@ namespace Clap
     _vstdata = nullptr;
   }
 
-  void ProcessAdapter::processOutputParams(Steinberg::Vst::ProcessData& data) {}
+  void ProcessAdapter::processOutputParams(Steinberg::Vst::ProcessData& data)
+  {
+  }
 
   uint32_t ProcessAdapter::input_events_size(const struct clap_input_events* list)
   {

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -10,16 +10,16 @@
 #include <cmath>
 #include "../clap/automation.h"
 
-
 namespace Clap
 {
   using namespace Steinberg;
 
-  void ProcessAdapter::setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params,
-    Vst::BusList& audioinputs, Vst::BusList& audiooutputs,
-    uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
-    Steinberg::Vst::ParameterContainer& params, Steinberg::Vst::IComponentHandler* componenthandler,
-    IAutomation* automation, bool enablePolyPressure, bool supportsTuningNoteExpression)
+  void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
+                                       Vst::BusList &audioinputs, Vst::BusList &audiooutputs, uint32_t numSamples,
+                                       size_t numEventInputs, size_t numEventOutputs,
+                                       Steinberg::Vst::ParameterContainer &params,
+                                       Steinberg::Vst::IComponentHandler *componenthandler, IAutomation *automation,
+                                       bool enablePolyPressure, bool supportsTuningNoteExpression)
   {
     _plugin = plugin;
     _ext_params = ext_params;
@@ -46,12 +46,12 @@ namespace Clap
     delete[] _input_ports;
     _input_ports = nullptr;
 
-    if ( numInputs > 0)
+    if (numInputs > 0)
     {
       _input_ports = new clap_audio_buffer_t[numInputs];
       for (auto i = 0U; i < numInputs; ++i)
       {
-        clap_audio_buffer_t& bus = _input_ports[i];
+        clap_audio_buffer_t &bus = _input_ports[i];
         Vst::BusInfo info;
         if (_audioinputs->at(i)->getInfo(info))
         {
@@ -73,13 +73,12 @@ namespace Clap
     delete[] _output_ports;
     _output_ports = nullptr;
 
-
     if (numOutputs > 0)
     {
       _output_ports = new clap_audio_buffer_t[numOutputs];
       for (auto i = 0U; i < numOutputs; ++i)
       {
-        clap_audio_buffer_t& bus = _output_ports[i];
+        clap_audio_buffer_t &bus = _output_ports[i];
         Vst::BusInfo info;
         if (_audiooutputs->at(i)->getInfo(info))
         {
@@ -122,7 +121,6 @@ namespace Clap
 
     _supportsPolyPressure = enablePolyPressure;
     _supportsTuningNoteExpression = supportsTuningNoteExpression;
-
   }
 
   void ProcessAdapter::activateAudioBus(Steinberg::Vst::BusDirection dir, int32 index, TBool state)
@@ -147,16 +145,9 @@ namespace Clap
     */
   }
 
-  inline clap_beattime doubleToBeatTime(double t)
-  {
-    return std::round(t * CLAP_BEATTIME_FACTOR);
-  }
+  inline clap_beattime doubleToBeatTime(double t) { return std::round(t * CLAP_BEATTIME_FACTOR); }
 
-  inline clap_sectime doubleToSecTime(double t)
-  {
-    return round(t * CLAP_SECTIME_FACTOR);
-  }
-
+  inline clap_sectime doubleToSecTime(double t) { return round(t * CLAP_SECTIME_FACTOR); }
 
   void ProcessAdapter::flush()
   {
@@ -172,51 +163,49 @@ namespace Clap
   }
 
   // this converts the ProcessContext data from VST to CLAP
-  void ProcessAdapter::process(Steinberg::Vst::ProcessData& data)
+  void ProcessAdapter::process(Steinberg::Vst::ProcessData &data)
   {
     // remember the ProcessData pointer during process
     _vstdata = &data;
 
     /// convert timing
-    _transport.header = {
-      sizeof(_transport),
-      0,
-      CLAP_CORE_EVENT_SPACE_ID,
-      CLAP_EVENT_TRANSPORT,
-      0
-    };
+    _transport.header = {sizeof(_transport), 0, CLAP_CORE_EVENT_SPACE_ID, CLAP_EVENT_TRANSPORT, 0};
 
     _transport.flags = 0;
     if (_vstdata->processContext)
     {
       // converting the flags
-      _transport.flags |= 0
-        // kPlaying = 1 << 1,		///< currently playing
-        | ((_vstdata->processContext->state & Vst::ProcessContext::kPlaying) ? CLAP_TRANSPORT_IS_PLAYING : 0)
-        // kRecording = 1 << 3,		///< currently recording
-        | ((_vstdata->processContext->state & Vst::ProcessContext::kRecording) ? CLAP_TRANSPORT_IS_RECORDING : 0)
-        // kCycleActive = 1 << 2,		///< cycle is active
-        | ((_vstdata->processContext->state & Vst::ProcessContext::kCycleActive) ? CLAP_TRANSPORT_IS_LOOP_ACTIVE : 0)
-        // kTempoValid = 1 << 10,	///< tempo contains valid information
-        | ((_vstdata->processContext->state & Vst::ProcessContext::kTempoValid) ? CLAP_TRANSPORT_HAS_TEMPO : 0)
-        | ((_vstdata->processContext->state & Vst::ProcessContext::kBarPositionValid) ? CLAP_TRANSPORT_HAS_BEATS_TIMELINE : 0)
-        | ((_vstdata->processContext->state & Vst::ProcessContext::kTimeSigValid) ? CLAP_TRANSPORT_HAS_TIME_SIGNATURE : 0)
+      _transport.flags |=
+          0
+          // kPlaying = 1 << 1,		///< currently playing
+          | ((_vstdata->processContext->state & Vst::ProcessContext::kPlaying) ? CLAP_TRANSPORT_IS_PLAYING : 0)
+          // kRecording = 1 << 3,		///< currently recording
+          | ((_vstdata->processContext->state & Vst::ProcessContext::kRecording) ? CLAP_TRANSPORT_IS_RECORDING : 0)
+          // kCycleActive = 1 << 2,		///< cycle is active
+          | ((_vstdata->processContext->state & Vst::ProcessContext::kCycleActive) ? CLAP_TRANSPORT_IS_LOOP_ACTIVE : 0)
+          // kTempoValid = 1 << 10,	///< tempo contains valid information
+          | ((_vstdata->processContext->state & Vst::ProcessContext::kTempoValid) ? CLAP_TRANSPORT_HAS_TEMPO : 0) |
+          ((_vstdata->processContext->state & Vst::ProcessContext::kBarPositionValid)
+               ? CLAP_TRANSPORT_HAS_BEATS_TIMELINE
+               : 0) |
+          ((_vstdata->processContext->state & Vst::ProcessContext::kTimeSigValid) ? CLAP_TRANSPORT_HAS_TIME_SIGNATURE
+                                                                                  : 0)
 
-        // the rest of the flags has no meaning to CLAP
-        // kSystemTimeValid = 1 << 8,		///< systemTime contains valid information
-        // kContTimeValid = 1 << 17,	///< continousTimeSamples contains valid information
-        //
-        // kProjectTimeMusicValid = 1 << 9,///< projectTimeMusic contains valid information
-        // kBarPositionValid = 1 << 11,	///< barPositionMusic contains valid information
-        // kCycleValid = 1 << 12,	///< cycleStartMusic and barPositionMusic contain valid information
-        //
-        // kClockValid = 1 << 15		///< samplesToNextClock valid
-        // kTimeSigValid = 1 << 13,	///< timeSigNumerator and timeSigDenominator contain valid information
-        // kChordValid = 1 << 18,	///< chord contains valid information
-        //
-        // kSmpteValid = 1 << 14,	///< smpteOffset and frameRate contain valid information
+          // the rest of the flags has no meaning to CLAP
+          // kSystemTimeValid = 1 << 8,		///< systemTime contains valid information
+          // kContTimeValid = 1 << 17,	///< continousTimeSamples contains valid information
+          //
+          // kProjectTimeMusicValid = 1 << 9,///< projectTimeMusic contains valid information
+          // kBarPositionValid = 1 << 11,	///< barPositionMusic contains valid information
+          // kCycleValid = 1 << 12,	///< cycleStartMusic and barPositionMusic contain valid information
+          //
+          // kClockValid = 1 << 15		///< samplesToNextClock valid
+          // kTimeSigValid = 1 << 13,	///< timeSigNumerator and timeSigDenominator contain valid information
+          // kChordValid = 1 << 18,	///< chord contains valid information
+          //
+          // kSmpteValid = 1 << 14,	///< smpteOffset and frameRate contain valid information
 
-        ;
+          ;
 
       _transport.song_pos_beats = doubleToBeatTime(_vstdata->processContext->projectTimeMusic);
       _transport.song_pos_seconds = 0;
@@ -273,7 +262,7 @@ namespace Clap
           continue;
         }
 
-        auto param = (Vst3Parameter*)parameters->getParameter(paramid);
+        auto param = (Vst3Parameter *)parameters->getParameter(paramid);
         if (param)
         {
           if (param->isMidi)
@@ -338,7 +327,7 @@ namespace Clap
               n.param.cookie = param->cookie;
 
               // nothing note specific
-              n.param.note_id = -1;   // always global
+              n.param.note_id = -1; // always global
               n.param.port_index = -1;
               n.param.channel = -1;
               n.param.key = -1;
@@ -349,7 +338,6 @@ namespace Clap
             }
           }
         }
-
       }
     }
 
@@ -357,7 +345,7 @@ namespace Clap
 
     bool doProcess = true;
 
-    if (_vstdata->numSamples > 0 )
+    if (_vstdata->numSamples > 0)
     {
       // setting the buffers
       auto inbusses = _audioinputs->size();
@@ -404,23 +392,20 @@ namespace Clap
     _vstdata = nullptr;
   }
 
-  void ProcessAdapter::processOutputParams(Steinberg::Vst::ProcessData& data)
-  {
+  void ProcessAdapter::processOutputParams(Steinberg::Vst::ProcessData &data) {}
 
-  }
-
-  uint32_t ProcessAdapter::input_events_size(const struct clap_input_events* list)
+  uint32_t ProcessAdapter::input_events_size(const struct clap_input_events *list)
   {
-    auto self = static_cast<ProcessAdapter*>(list->ctx);
+    auto self = static_cast<ProcessAdapter *>(list->ctx);
     return (uint32_t)self->_events.size();
     // return self->_vstdata->inputEvents->getEventCount();
   }
 
   // returns the pointer to an event in the list. The index accessed is not the position in the event list itself
   // since all events indices were sorted by timestamp
-  const clap_event_header_t* ProcessAdapter::input_events_get(const struct clap_input_events* list, uint32_t index)
+  const clap_event_header_t *ProcessAdapter::input_events_get(const struct clap_input_events *list, uint32_t index)
   {
-    auto self = static_cast<ProcessAdapter*>(list->ctx);
+    auto self = static_cast<ProcessAdapter *>(list->ctx);
     if (self->_events.size() > index)
     {
       // we can safely return the note.header also for other event types
@@ -431,9 +416,9 @@ namespace Clap
     return nullptr;
   }
 
-  bool ProcessAdapter::output_events_try_push(const struct clap_output_events* list, const clap_event_header_t* event)
+  bool ProcessAdapter::output_events_try_push(const struct clap_output_events *list, const clap_event_header_t *event)
   {
-    auto self = static_cast<ProcessAdapter*>(list->ctx);
+    auto self = static_cast<ProcessAdapter *>(list->ctx);
     // mainly used for CLAP_EVENT_NOTE_CHOKE and CLAP_EVENT_NOTE_END
     // but also for parameter changes
     return self->enqueueOutputEvent(event);
@@ -442,14 +427,11 @@ namespace Clap
   void ProcessAdapter::sortEventIndices()
   {
     // just sorting the index
-    std::sort(_eventindices.begin(), _eventindices.end(), [&](size_t const& a, size_t const& b)
-      {
-        return _events[a].header.time < _events[b].header.time;
-      }
-    );
+    std::sort(_eventindices.begin(), _eventindices.end(),
+              [&](size_t const &a, size_t const &b) { return _events[a].header.time < _events[b].header.time; });
   }
 
-  void ProcessAdapter::processInputEvents(Steinberg::Vst::IEventList* eventlist)
+  void ProcessAdapter::processInputEvents(Steinberg::Vst::IEventList *eventlist)
   {
     if (eventlist)
     {
@@ -480,24 +462,24 @@ namespace Clap
             // convert but only if your target clap supports note expressions
             if (_supportsTuningNoteExpression && vstevent.noteOn.tuning != 0)
             {
-               clap_multi_event_t n;
-               n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
-               n.noteexpression.header.flags = (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
-               n.noteexpression.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-               n.noteexpression.header.time = vstevent.sampleOffset;
-               n.noteexpression.header.size = sizeof(clap_event_note_expression);
-               n.noteexpression.note_id = vstevent.noteExpressionValue.noteId;
-               n.noteexpression.port_index = 0;
-               n.noteexpression.key = vstevent.noteOn.pitch;
-               n.noteexpression.channel = vstevent.noteOn.channel;
-               n.noteexpression.note_id = vstevent.noteOn.noteId;
-               n.noteexpression.value = vstevent.noteExpressionValue.value;
+              clap_multi_event_t n;
+              n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+              n.noteexpression.header.flags = (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
+              n.noteexpression.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+              n.noteexpression.header.time = vstevent.sampleOffset;
+              n.noteexpression.header.size = sizeof(clap_event_note_expression);
+              n.noteexpression.note_id = vstevent.noteExpressionValue.noteId;
+              n.noteexpression.port_index = 0;
+              n.noteexpression.key = vstevent.noteOn.pitch;
+              n.noteexpression.channel = vstevent.noteOn.channel;
+              n.noteexpression.note_id = vstevent.noteOn.noteId;
+              n.noteexpression.value = vstevent.noteExpressionValue.value;
 
-               // VST3 Tuning is float in cents. We are in semitones. So
-               n.noteexpression.value = vstevent.noteOn.tuning * 0.01;
-               n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;
-               _eventindices.push_back(_events.size());
-               _events.push_back(n);
+              // VST3 Tuning is float in cents. We are in semitones. So
+              n.noteexpression.value = vstevent.noteOn.tuning * 0.01;
+              n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;
+              _eventindices.push_back(_events.size());
+              _events.push_back(n);
             }
           }
           if (vstevent.type == Vst::Event::kNoteOffEvent)
@@ -546,13 +528,13 @@ namespace Clap
             n.noteexpression.header.time = vstevent.sampleOffset;
             n.noteexpression.header.size = sizeof(clap_event_note_expression);
             n.noteexpression.note_id = vstevent.polyPressure.noteId;
-            for (auto& i : _activeNotes)
+            for (auto &i : _activeNotes)
             {
               if (i.used && i.note_id == vstevent.polyPressure.noteId)
               {
                 n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
                 n.noteexpression.port_index = i.port_index;
-                n.noteexpression.key = i.key;   // should be the same as vstevent.polyPressure.pitch
+                n.noteexpression.key = i.key; // should be the same as vstevent.polyPressure.pitch
                 n.noteexpression.channel = i.channel;
                 n.noteexpression.value = vstevent.polyPressure.pressure;
               }
@@ -569,7 +551,7 @@ namespace Clap
             n.noteexpression.header.time = vstevent.sampleOffset;
             n.noteexpression.header.size = sizeof(clap_event_note_expression);
             n.noteexpression.note_id = vstevent.noteExpressionValue.noteId;
-            for (auto& i : _activeNotes)
+            for (auto &i : _activeNotes)
             {
               if (i.used && i.note_id == vstevent.noteExpressionValue.noteId)
               {
@@ -612,7 +594,7 @@ namespace Clap
     }
   }
 
-  bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t* event)
+  bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
   {
     switch (event->type)
     {
@@ -650,14 +632,13 @@ namespace Clap
       oe.busIndex = 0; // FIXME - multi-out midi still needs work
       oe.sampleOffset = nevt->header.time;
 
-
       if (_vstdata && _vstdata->outputEvents)
         _vstdata->outputEvents->addEvent(oe);
     }
       return true;
     case CLAP_EVENT_NOTE_END:
     case CLAP_EVENT_NOTE_CHOKE:
-      removeFromActiveNotes((const clap_event_note*)(event));
+      removeFromActiveNotes((const clap_event_note *)(event));
       return true;
       break;
     case CLAP_EVENT_NOTE_EXPRESSION:
@@ -665,8 +646,8 @@ namespace Clap
       break;
     case CLAP_EVENT_PARAM_VALUE:
     {
-      auto ev = (clap_event_param_value*)event;
-      auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
+      auto ev = (clap_event_param_value *)event;
+      auto param = (Vst3Parameter *)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
       if (param)
       {
         auto param_id = param->getInfo().id;
@@ -684,45 +665,44 @@ namespace Clap
         // actually, it should be called getParameterQueue()
         auto list = _vstdata->outputParameterChanges->addParameterData(param_id, index);
 
-        // the implementation of addParameterData() in the SDK always returns a queue, but Cubase 12 (perhaps others, too)
-        // sometimes don't return a queue object during the first bunch of process calls. I (df) haven't figured out, why.
-        // therefore we have to check if there is an output queue at all
+        // the implementation of addParameterData() in the SDK always returns a queue, but Cubase 12 (perhaps others,
+        // too) sometimes don't return a queue object during the first bunch of process calls. I (df) haven't figured
+        // out, why. therefore we have to check if there is an output queue at all
         if (list)
         {
           Steinberg::int32 index2 = 0;
           list->addPoint(ev->header.time, param->asVst3Value(ev->value), index2);
         }
-
       }
     }
 
-    return true;
-    break;
+      return true;
+      break;
     case CLAP_EVENT_PARAM_MOD:
       return true;
       break;
     case CLAP_EVENT_PARAM_GESTURE_BEGIN:
-      {
-         auto ev = (clap_event_param_gesture*)event;
-         auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
-         _gesturedParameters.push_back(param->getInfo().id);
-        _automation->onBeginEdit(param->getInfo().id);
-      }
+    {
+      auto ev = (clap_event_param_gesture *)event;
+      auto param = (Vst3Parameter *)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
+      _gesturedParameters.push_back(param->getInfo().id);
+      _automation->onBeginEdit(param->getInfo().id);
+    }
       return true;
 
       break;
     case CLAP_EVENT_PARAM_GESTURE_END:
-      {
-        auto ev = (clap_event_param_gesture*)event;
-        auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
+    {
+      auto ev = (clap_event_param_gesture *)event;
+      auto param = (Vst3Parameter *)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
 
-        auto n = std::remove(_gesturedParameters.begin(), _gesturedParameters.end(), param->getInfo().id);
-        if (n != _gesturedParameters.end())
-        {
-          _gesturedParameters.erase(n, _gesturedParameters.end());
-          _automation->onEndEdit(param->getInfo().id);
-        }
+      auto n = std::remove(_gesturedParameters.begin(), _gesturedParameters.end(), param->getInfo().id);
+      if (n != _gesturedParameters.end())
+      {
+        _gesturedParameters.erase(n, _gesturedParameters.end());
+        _automation->onEndEdit(param->getInfo().id);
       }
+    }
       return true;
       break;
 
@@ -737,9 +717,9 @@ namespace Clap
     return false;
   }
 
-  void ProcessAdapter::addToActiveNotes(const clap_event_note* note)
+  void ProcessAdapter::addToActiveNotes(const clap_event_note *note)
   {
-    for (auto& i : _activeNotes)
+    for (auto &i : _activeNotes)
     {
       if (!i.used)
       {
@@ -751,22 +731,18 @@ namespace Clap
         return;
       }
     }
-    _activeNotes.push_back({true,note->note_id, note->port_index, note->channel, note->key});
+    _activeNotes.push_back({true, note->note_id, note->port_index, note->channel, note->key});
   }
 
-  void ProcessAdapter::removeFromActiveNotes(const clap_event_note * note)
+  void ProcessAdapter::removeFromActiveNotes(const clap_event_note *note)
   {
-    for (auto& i : _activeNotes)
+    for (auto &i : _activeNotes)
     {
-      if (i.used
-        && i.port_index == note->port_index
-        && i.channel == note->channel
-        && i.note_id == note->note_id)
+      if (i.used && i.port_index == note->port_index && i.channel == note->channel && i.note_id == note->note_id)
       {
         i.used = false;
       }
     }
   }
 
-
-}
+} // namespace Clap

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -14,8 +14,11 @@ namespace Clap
 {
   using namespace Steinberg;
 
-  void ProcessAdapter::setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params, Vst::BusList& audioinputs, Vst::BusList& audiooutputs, uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
-                                       Steinberg::Vst::ParameterContainer& params, Steinberg::Vst::IComponentHandler* componenthandler, IAutomation* automation, bool enablePolyPressure, bool supportsTuningNoteExpression)
+  void ProcessAdapter::setupProcessing(
+      const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params, Vst::BusList& audioinputs,
+      Vst::BusList& audiooutputs, uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
+      Steinberg::Vst::ParameterContainer& params, Steinberg::Vst::IComponentHandler* componenthandler,
+      IAutomation* automation, bool enablePolyPressure, bool supportsTuningNoteExpression)
   {
     _plugin = plugin;
     _ext_params = ext_params;
@@ -179,14 +182,27 @@ namespace Clap
       // converting the flags
       _transport.flags |= 0
                           // kPlaying = 1 << 1,		///< currently playing
-                          | ((_vstdata->processContext->state & Vst::ProcessContext::kPlaying) ? CLAP_TRANSPORT_IS_PLAYING : 0)
+                          | ((_vstdata->processContext->state & Vst::ProcessContext::kPlaying)
+                                 ? CLAP_TRANSPORT_IS_PLAYING
+                                 : 0)
                           // kRecording = 1 << 3,		///< currently recording
-                          | ((_vstdata->processContext->state & Vst::ProcessContext::kRecording) ? CLAP_TRANSPORT_IS_RECORDING : 0)
+                          | ((_vstdata->processContext->state & Vst::ProcessContext::kRecording)
+                                 ? CLAP_TRANSPORT_IS_RECORDING
+                                 : 0)
                           // kCycleActive = 1 << 2,		///< cycle is active
-                          | ((_vstdata->processContext->state & Vst::ProcessContext::kCycleActive) ? CLAP_TRANSPORT_IS_LOOP_ACTIVE : 0)
+                          | ((_vstdata->processContext->state & Vst::ProcessContext::kCycleActive)
+                                 ? CLAP_TRANSPORT_IS_LOOP_ACTIVE
+                                 : 0)
                           // kTempoValid = 1 << 10,	///< tempo contains valid information
-                          | ((_vstdata->processContext->state & Vst::ProcessContext::kTempoValid) ? CLAP_TRANSPORT_HAS_TEMPO : 0) | ((_vstdata->processContext->state & Vst::ProcessContext::kBarPositionValid) ? CLAP_TRANSPORT_HAS_BEATS_TIMELINE : 0) |
-                          ((_vstdata->processContext->state & Vst::ProcessContext::kTimeSigValid) ? CLAP_TRANSPORT_HAS_TIME_SIGNATURE : 0)
+                          | ((_vstdata->processContext->state & Vst::ProcessContext::kTempoValid)
+                                 ? CLAP_TRANSPORT_HAS_TEMPO
+                                 : 0) |
+                          ((_vstdata->processContext->state & Vst::ProcessContext::kBarPositionValid)
+                               ? CLAP_TRANSPORT_HAS_BEATS_TIMELINE
+                               : 0) |
+                          ((_vstdata->processContext->state & Vst::ProcessContext::kTimeSigValid)
+                               ? CLAP_TRANSPORT_HAS_TIME_SIGNATURE
+                               : 0)
 
           // the rest of the flags has no meaning to CLAP
           // kSystemTimeValid = 1 << 8,		///< systemTime contains valid information
@@ -254,7 +270,8 @@ namespace Clap
 
         // if a parameter is currently edited by a user, we are not allowed to send this back to the CLAP.
         // this is a fundamental difference between VST3 and CLAP
-        if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), paramid) != _gesturedParameters.end())
+        if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), paramid) !=
+            _gesturedParameters.end())
         {
           continue;
         }
@@ -401,7 +418,8 @@ namespace Clap
 
   // returns the pointer to an event in the list. The index accessed is not the position in the event list itself
   // since all events indices were sorted by timestamp
-  const clap_event_header_t* ProcessAdapter::input_events_get(const struct clap_input_events* list, uint32_t index)
+  const clap_event_header_t* ProcessAdapter::input_events_get(const struct clap_input_events* list,
+                                                              uint32_t index)
   {
     auto self = static_cast<ProcessAdapter*>(list->ctx);
     if (self->_events.size() > index)
@@ -414,7 +432,8 @@ namespace Clap
     return nullptr;
   }
 
-  bool ProcessAdapter::output_events_try_push(const struct clap_output_events* list, const clap_event_header_t* event)
+  bool ProcessAdapter::output_events_try_push(const struct clap_output_events* list,
+                                              const clap_event_header_t* event)
   {
     auto self = static_cast<ProcessAdapter*>(list->ctx);
     // mainly used for CLAP_EVENT_NOTE_CHOKE and CLAP_EVENT_NOTE_END
@@ -425,7 +444,9 @@ namespace Clap
   void ProcessAdapter::sortEventIndices()
   {
     // just sorting the index
-    std::sort(_eventindices.begin(), _eventindices.end(), [&](size_t const& a, size_t const& b) { return _events[a].header.time < _events[b].header.time; });
+    std::sort(_eventindices.begin(), _eventindices.end(),
+              [&](size_t const& a, size_t const& b)
+              { return _events[a].header.time < _events[b].header.time; });
   }
 
   void ProcessAdapter::processInputEvents(Steinberg::Vst::IEventList* eventlist)
@@ -461,7 +482,8 @@ namespace Clap
             {
               clap_multi_event_t n;
               n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
-              n.noteexpression.header.flags = (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
+              n.noteexpression.header.flags =
+                  (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
               n.noteexpression.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
               n.noteexpression.header.time = vstevent.sampleOffset;
               n.noteexpression.header.size = sizeof(clap_event_note_expression);
@@ -520,7 +542,8 @@ namespace Clap
           {
             clap_multi_event_t n;
             n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
-            n.noteexpression.header.flags = (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
+            n.noteexpression.header.flags =
+                (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
             n.noteexpression.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
             n.noteexpression.header.time = vstevent.sampleOffset;
             n.noteexpression.header.size = sizeof(clap_event_note_expression);
@@ -543,7 +566,8 @@ namespace Clap
           {
             clap_multi_event_t n;
             n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
-            n.noteexpression.header.flags = (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
+            n.noteexpression.header.flags =
+                (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
             n.noteexpression.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
             n.noteexpression.header.time = vstevent.sampleOffset;
             n.noteexpression.header.size = sizeof(clap_event_note_expression);
@@ -649,7 +673,8 @@ namespace Clap
 
           // if the parameter is marked as being edited in the UI, pass the value
           // to the queue so it can be given to the IComponentHandler
-          if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), param_id) != _gesturedParameters.end())
+          if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), param_id) !=
+              _gesturedParameters.end())
           {
             _automation->onPerformEdit(ev);
           }
@@ -691,7 +716,8 @@ namespace Clap
         auto ev = (clap_event_param_gesture*)event;
         auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
 
-        auto n = std::remove(_gesturedParameters.begin(), _gesturedParameters.end(), param->getInfo().id);
+        auto n =
+            std::remove(_gesturedParameters.begin(), _gesturedParameters.end(), param->getInfo().id);
         if (n != _gesturedParameters.end())
         {
           _gesturedParameters.erase(n, _gesturedParameters.end());
@@ -733,7 +759,8 @@ namespace Clap
   {
     for (auto& i : _activeNotes)
     {
-      if (i.used && i.port_index == note->port_index && i.channel == note->channel && i.note_id == note->note_id)
+      if (i.used && i.port_index == note->port_index && i.channel == note->channel &&
+          i.note_id == note->note_id)
       {
         i.used = false;
       }

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -12,119 +12,121 @@
 
 namespace Clap
 {
-  using namespace Steinberg;
+using namespace Steinberg;
 
-  void ProcessAdapter::setupProcessing(
-      const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params, Vst::BusList& audioinputs,
-      Vst::BusList& audiooutputs, uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
-      Steinberg::Vst::ParameterContainer& params, Steinberg::Vst::IComponentHandler* componenthandler,
-      IAutomation* automation, bool enablePolyPressure, bool supportsTuningNoteExpression)
+void ProcessAdapter::setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params,
+                                     Vst::BusList& audioinputs, Vst::BusList& audiooutputs,
+                                     uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
+                                     Steinberg::Vst::ParameterContainer& params,
+                                     Steinberg::Vst::IComponentHandler* componenthandler,
+                                     IAutomation* automation, bool enablePolyPressure,
+                                     bool supportsTuningNoteExpression)
+{
+  _plugin = plugin;
+  _ext_params = ext_params;
+  _audioinputs = &audioinputs;
+  _audiooutputs = &audiooutputs;
+
+  parameters = &params;
+  _componentHandler = componenthandler;
+  _automation = automation;
+
+  if (numSamples > 0)
   {
-    _plugin = plugin;
-    _ext_params = ext_params;
-    _audioinputs = &audioinputs;
-    _audiooutputs = &audiooutputs;
+    delete[] _silent_input;
+    _silent_input = new float[numSamples];
 
-    parameters = &params;
-    _componentHandler = componenthandler;
-    _automation = automation;
-
-    if (numSamples > 0)
-    {
-      delete[] _silent_input;
-      _silent_input = new float[numSamples];
-
-      delete[] _silent_output;
-      _silent_output = new float[numSamples];
-    }
-
-    auto numInputs = (uint32_t)_audioinputs->size();
-    auto numOutputs = (uint32_t)_audiooutputs->size();
-
-    _processData.audio_inputs_count = numInputs;
-    delete[] _input_ports;
-    _input_ports = nullptr;
-
-    if (numInputs > 0)
-    {
-      _input_ports = new clap_audio_buffer_t[numInputs];
-      for (auto i = 0U; i < numInputs; ++i)
-      {
-        clap_audio_buffer_t& bus = _input_ports[i];
-        Vst::BusInfo info;
-        if (_audioinputs->at(i)->getInfo(info))
-        {
-          bus.channel_count = info.channelCount;
-          bus.constant_mask = 0;
-          bus.latency = 0;
-          bus.data64 = 0;
-          bus.data32 = 0;
-        }
-      }
-      _processData.audio_inputs = _input_ports;
-    }
-    else
-    {
-      _processData.audio_inputs = nullptr;
-    }
-
-    _processData.audio_outputs_count = numOutputs;
-    delete[] _output_ports;
-    _output_ports = nullptr;
-
-    if (numOutputs > 0)
-    {
-      _output_ports = new clap_audio_buffer_t[numOutputs];
-      for (auto i = 0U; i < numOutputs; ++i)
-      {
-        clap_audio_buffer_t& bus = _output_ports[i];
-        Vst::BusInfo info;
-        if (_audiooutputs->at(i)->getInfo(info))
-        {
-          bus.channel_count = info.channelCount;
-          bus.constant_mask = 0;
-          bus.latency = 0;
-          bus.data64 = 0;
-          bus.data32 = 0;
-        }
-      }
-      _processData.audio_outputs = _output_ports;
-    }
-    else
-    {
-      _processData.audio_outputs = nullptr;
-    }
-
-    _processData.in_events = &_in_events;
-    _processData.out_events = &_out_events;
-
-    _processData.transport = &_transport;
-
-    _in_events.ctx = this;
-    _in_events.size = input_events_size;
-    _in_events.get = input_events_get;
-
-    _out_events.ctx = this;
-    _out_events.try_push = output_events_try_push;
-
-    _events.clear();
-    _events.reserve(256);
-    _eventindices.clear();
-    _eventindices.reserve(_events.capacity());
-
-    _out_events.ctx = this;
-
-    _gesturedParameters.reserve(32);
-
-    _activeNotes.reserve(64);
-
-    _supportsPolyPressure = enablePolyPressure;
-    _supportsTuningNoteExpression = supportsTuningNoteExpression;
+    delete[] _silent_output;
+    _silent_output = new float[numSamples];
   }
 
-  void ProcessAdapter::activateAudioBus(Steinberg::Vst::BusDirection dir, int32 index, TBool state)
+  auto numInputs = (uint32_t)_audioinputs->size();
+  auto numOutputs = (uint32_t)_audiooutputs->size();
+
+  _processData.audio_inputs_count = numInputs;
+  delete[] _input_ports;
+  _input_ports = nullptr;
+
+  if (numInputs > 0)
   {
-    /*
+    _input_ports = new clap_audio_buffer_t[numInputs];
+    for (auto i = 0U; i < numInputs; ++i)
+    {
+      clap_audio_buffer_t& bus = _input_ports[i];
+      Vst::BusInfo info;
+      if (_audioinputs->at(i)->getInfo(info))
+      {
+        bus.channel_count = info.channelCount;
+        bus.constant_mask = 0;
+        bus.latency = 0;
+        bus.data64 = 0;
+        bus.data32 = 0;
+      }
+    }
+    _processData.audio_inputs = _input_ports;
+  }
+  else
+  {
+    _processData.audio_inputs = nullptr;
+  }
+
+  _processData.audio_outputs_count = numOutputs;
+  delete[] _output_ports;
+  _output_ports = nullptr;
+
+  if (numOutputs > 0)
+  {
+    _output_ports = new clap_audio_buffer_t[numOutputs];
+    for (auto i = 0U; i < numOutputs; ++i)
+    {
+      clap_audio_buffer_t& bus = _output_ports[i];
+      Vst::BusInfo info;
+      if (_audiooutputs->at(i)->getInfo(info))
+      {
+        bus.channel_count = info.channelCount;
+        bus.constant_mask = 0;
+        bus.latency = 0;
+        bus.data64 = 0;
+        bus.data32 = 0;
+      }
+    }
+    _processData.audio_outputs = _output_ports;
+  }
+  else
+  {
+    _processData.audio_outputs = nullptr;
+  }
+
+  _processData.in_events = &_in_events;
+  _processData.out_events = &_out_events;
+
+  _processData.transport = &_transport;
+
+  _in_events.ctx = this;
+  _in_events.size = input_events_size;
+  _in_events.get = input_events_get;
+
+  _out_events.ctx = this;
+  _out_events.try_push = output_events_try_push;
+
+  _events.clear();
+  _events.reserve(256);
+  _eventindices.clear();
+  _eventindices.reserve(_events.capacity());
+
+  _out_events.ctx = this;
+
+  _gesturedParameters.reserve(32);
+
+  _activeNotes.reserve(64);
+
+  _supportsPolyPressure = enablePolyPressure;
+  _supportsTuningNoteExpression = supportsTuningNoteExpression;
+}
+
+void ProcessAdapter::activateAudioBus(Steinberg::Vst::BusDirection dir, int32 index, TBool state)
+{
+  /*
     if (dir == Vst::kInput)
     {
       auto& map = _bogus_buffers->_in_channelmap[index];
@@ -142,427 +144,343 @@ namespace Clap
         _bogus_buffers->_active_mask_out &= ~map._bitmap;
     }
     */
-  }
+}
 
-  inline clap_beattime doubleToBeatTime(double t)
+inline clap_beattime doubleToBeatTime(double t)
+{
+  return std::round(t * CLAP_BEATTIME_FACTOR);
+}
+
+inline clap_sectime doubleToSecTime(double t)
+{
+  return round(t * CLAP_SECTIME_FACTOR);
+}
+
+void ProcessAdapter::flush()
+{
+  // minimal processing if _ext_params is existent
+  if (_ext_params)
   {
-    return std::round(t * CLAP_BEATTIME_FACTOR);
-  }
-
-  inline clap_sectime doubleToSecTime(double t)
-  {
-    return round(t * CLAP_SECTIME_FACTOR);
-  }
-
-  void ProcessAdapter::flush()
-  {
-    // minimal processing if _ext_params is existent
-    if (_ext_params)
-    {
-      _events.clear();
-      _eventindices.clear();
-
-      // sortEventIndices(); call only if there would be any input event
-      _ext_params->flush(_plugin, _processData.in_events, _processData.out_events);
-    }
-  }
-
-  // this converts the ProcessContext data from VST to CLAP
-  void ProcessAdapter::process(Steinberg::Vst::ProcessData& data)
-  {
-    // remember the ProcessData pointer during process
-    _vstdata = &data;
-
-    /// convert timing
-    _transport.header = {sizeof(_transport), 0, CLAP_CORE_EVENT_SPACE_ID, CLAP_EVENT_TRANSPORT, 0};
-
-    _transport.flags = 0;
-    if (_vstdata->processContext)
-    {
-      // converting the flags
-      _transport.flags |= 0
-                          // kPlaying = 1 << 1,		///< currently playing
-                          | ((_vstdata->processContext->state & Vst::ProcessContext::kPlaying)
-                                 ? CLAP_TRANSPORT_IS_PLAYING
-                                 : 0)
-                          // kRecording = 1 << 3,		///< currently recording
-                          | ((_vstdata->processContext->state & Vst::ProcessContext::kRecording)
-                                 ? CLAP_TRANSPORT_IS_RECORDING
-                                 : 0)
-                          // kCycleActive = 1 << 2,		///< cycle is active
-                          | ((_vstdata->processContext->state & Vst::ProcessContext::kCycleActive)
-                                 ? CLAP_TRANSPORT_IS_LOOP_ACTIVE
-                                 : 0)
-                          // kTempoValid = 1 << 10,	///< tempo contains valid information
-                          | ((_vstdata->processContext->state & Vst::ProcessContext::kTempoValid)
-                                 ? CLAP_TRANSPORT_HAS_TEMPO
-                                 : 0) |
-                          ((_vstdata->processContext->state & Vst::ProcessContext::kBarPositionValid)
-                               ? CLAP_TRANSPORT_HAS_BEATS_TIMELINE
-                               : 0) |
-                          ((_vstdata->processContext->state & Vst::ProcessContext::kTimeSigValid)
-                               ? CLAP_TRANSPORT_HAS_TIME_SIGNATURE
-                               : 0)
-
-          // the rest of the flags has no meaning to CLAP
-          // kSystemTimeValid = 1 << 8,		///< systemTime contains valid information
-          // kContTimeValid = 1 << 17,	///< continousTimeSamples contains valid information
-          //
-          // kProjectTimeMusicValid = 1 << 9,///< projectTimeMusic contains valid information
-          // kBarPositionValid = 1 << 11,	///< barPositionMusic contains valid information
-          // kCycleValid = 1 << 12,	///< cycleStartMusic and barPositionMusic contain valid information
-          //
-          // kClockValid = 1 << 15		///< samplesToNextClock valid
-          // kTimeSigValid = 1 << 13,	///< timeSigNumerator and timeSigDenominator contain valid information
-          // kChordValid = 1 << 18,	///< chord contains valid information
-          //
-          // kSmpteValid = 1 << 14,	///< smpteOffset and frameRate contain valid information
-
-          ;
-
-      _transport.song_pos_beats = doubleToBeatTime(_vstdata->processContext->projectTimeMusic);
-      _transport.song_pos_seconds = 0;
-
-      _transport.tempo = _vstdata->processContext->tempo;
-      _transport.tempo_inc = 0;
-
-      _transport.loop_start_beats = doubleToBeatTime(_vstdata->processContext->cycleStartMusic);
-      _transport.loop_end_beats = doubleToBeatTime(_vstdata->processContext->cycleEndMusic);
-      _transport.loop_start_seconds = 0;
-      _transport.loop_end_seconds = 0;
-
-      _transport.bar_start = 0;
-      _transport.bar_number = 0;
-
-      if ((_vstdata->processContext->state & Vst::ProcessContext::kTimeSigValid))
-      {
-        _transport.tsig_num = _vstdata->processContext->timeSigNumerator;
-        _transport.tsig_denom = _vstdata->processContext->timeSigDenominator;
-      }
-      else
-      {
-        _transport.tsig_num = 4;
-        _transport.tsig_denom = 4;
-      }
-
-      _transport.bar_number = _vstdata->processContext->barPositionMusic;
-      _processData.steady_time = _vstdata->processContext->projectTimeSamples;
-    }
-
-    // setting up transport
-    _processData.frames_count = _vstdata->numSamples;
-
-    // always clear
     _events.clear();
     _eventindices.clear();
 
-    processInputEvents(_vstdata->inputEvents);
+    // sortEventIndices(); call only if there would be any input event
+    _ext_params->flush(_plugin, _processData.in_events, _processData.out_events);
+  }
+}
 
-    if (_vstdata->inputParameterChanges)
+// this converts the ProcessContext data from VST to CLAP
+void ProcessAdapter::process(Steinberg::Vst::ProcessData& data)
+{
+  // remember the ProcessData pointer during process
+  _vstdata = &data;
+
+  /// convert timing
+  _transport.header = {sizeof(_transport), 0, CLAP_CORE_EVENT_SPACE_ID, CLAP_EVENT_TRANSPORT, 0};
+
+  _transport.flags = 0;
+  if (_vstdata->processContext)
+  {
+    // converting the flags
+    _transport.flags |=
+        0
+        // kPlaying = 1 << 1,		///< currently playing
+        | ((_vstdata->processContext->state & Vst::ProcessContext::kPlaying) ? CLAP_TRANSPORT_IS_PLAYING
+                                                                             : 0)
+        // kRecording = 1 << 3,		///< currently recording
+        | ((_vstdata->processContext->state & Vst::ProcessContext::kRecording)
+               ? CLAP_TRANSPORT_IS_RECORDING
+               : 0)
+        // kCycleActive = 1 << 2,		///< cycle is active
+        | ((_vstdata->processContext->state & Vst::ProcessContext::kCycleActive)
+               ? CLAP_TRANSPORT_IS_LOOP_ACTIVE
+               : 0)
+        // kTempoValid = 1 << 10,	///< tempo contains valid information
+        |
+        ((_vstdata->processContext->state & Vst::ProcessContext::kTempoValid) ? CLAP_TRANSPORT_HAS_TEMPO
+                                                                              : 0) |
+        ((_vstdata->processContext->state & Vst::ProcessContext::kBarPositionValid)
+             ? CLAP_TRANSPORT_HAS_BEATS_TIMELINE
+             : 0) |
+        ((_vstdata->processContext->state & Vst::ProcessContext::kTimeSigValid)
+             ? CLAP_TRANSPORT_HAS_TIME_SIGNATURE
+             : 0)
+
+        // the rest of the flags has no meaning to CLAP
+        // kSystemTimeValid = 1 << 8,		///< systemTime contains valid information
+        // kContTimeValid = 1 << 17,	///< continousTimeSamples contains valid information
+        //
+        // kProjectTimeMusicValid = 1 << 9,///< projectTimeMusic contains valid information
+        // kBarPositionValid = 1 << 11,	///< barPositionMusic contains valid information
+        // kCycleValid = 1 << 12,	///< cycleStartMusic and barPositionMusic contain valid information
+        //
+        // kClockValid = 1 << 15		///< samplesToNextClock valid
+        // kTimeSigValid = 1 << 13,	///< timeSigNumerator and timeSigDenominator contain valid information
+        // kChordValid = 1 << 18,	///< chord contains valid information
+        //
+        // kSmpteValid = 1 << 14,	///< smpteOffset and frameRate contain valid information
+
+        ;
+
+    _transport.song_pos_beats = doubleToBeatTime(_vstdata->processContext->projectTimeMusic);
+    _transport.song_pos_seconds = 0;
+
+    _transport.tempo = _vstdata->processContext->tempo;
+    _transport.tempo_inc = 0;
+
+    _transport.loop_start_beats = doubleToBeatTime(_vstdata->processContext->cycleStartMusic);
+    _transport.loop_end_beats = doubleToBeatTime(_vstdata->processContext->cycleEndMusic);
+    _transport.loop_start_seconds = 0;
+    _transport.loop_end_seconds = 0;
+
+    _transport.bar_start = 0;
+    _transport.bar_number = 0;
+
+    if ((_vstdata->processContext->state & Vst::ProcessContext::kTimeSigValid))
     {
-      auto numPevent = _vstdata->inputParameterChanges->getParameterCount();
-      for (decltype(numPevent) i = 0; i < numPevent; ++i)
+      _transport.tsig_num = _vstdata->processContext->timeSigNumerator;
+      _transport.tsig_denom = _vstdata->processContext->timeSigDenominator;
+    }
+    else
+    {
+      _transport.tsig_num = 4;
+      _transport.tsig_denom = 4;
+    }
+
+    _transport.bar_number = _vstdata->processContext->barPositionMusic;
+    _processData.steady_time = _vstdata->processContext->projectTimeSamples;
+  }
+
+  // setting up transport
+  _processData.frames_count = _vstdata->numSamples;
+
+  // always clear
+  _events.clear();
+  _eventindices.clear();
+
+  processInputEvents(_vstdata->inputEvents);
+
+  if (_vstdata->inputParameterChanges)
+  {
+    auto numPevent = _vstdata->inputParameterChanges->getParameterCount();
+    for (decltype(numPevent) i = 0; i < numPevent; ++i)
+    {
+      auto k = _vstdata->inputParameterChanges->getParameterData(i);
+
+      // get the Vst3Parameter
+      auto paramid = k->getParameterId();
+
+      // if a parameter is currently edited by a user, we are not allowed to send this back to the CLAP.
+      // this is a fundamental difference between VST3 and CLAP
+      if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), paramid) !=
+          _gesturedParameters.end())
       {
-        auto k = _vstdata->inputParameterChanges->getParameterData(i);
+        continue;
+      }
 
-        // get the Vst3Parameter
-        auto paramid = k->getParameterId();
-
-        // if a parameter is currently edited by a user, we are not allowed to send this back to the CLAP.
-        // this is a fundamental difference between VST3 and CLAP
-        if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), paramid) !=
-            _gesturedParameters.end())
+      auto param = (Vst3Parameter*)parameters->getParameter(paramid);
+      if (param)
+      {
+        if (param->isMidi)
         {
-          continue;
-        }
+          auto nums = k->getPointCount();
 
-        auto param = (Vst3Parameter*)parameters->getParameter(paramid);
-        if (param)
-        {
-          if (param->isMidi)
+          Vst::ParamValue value;
+          int32 offset;
+          if (k->getPoint(nums - 1, offset, value) == kResultOk)
           {
-            auto nums = k->getPointCount();
+            // create MIDI event
+            clap_multi_event_t n;
+            n.param.header.type = CLAP_EVENT_MIDI;
+            n.param.header.flags = 0;
+            n.param.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+            n.param.header.time = offset;
+            n.param.header.size = sizeof(clap_event_midi_t);
+            n.midi.port_index = 0;
 
-            Vst::ParamValue value;
-            int32 offset;
-            if (k->getPoint(nums - 1, offset, value) == kResultOk)
+            switch (param->controller)
             {
-              // create MIDI event
-              clap_multi_event_t n;
-              n.param.header.type = CLAP_EVENT_MIDI;
-              n.param.header.flags = 0;
-              n.param.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-              n.param.header.time = offset;
-              n.param.header.size = sizeof(clap_event_midi_t);
-              n.midi.port_index = 0;
-
-              switch (param->controller)
-              {
-                case Vst::ControllerNumbers::kAfterTouch:
-                  n.midi.data[0] = 0xD0 | param->channel;
-                  n.midi.data[1] = param->asClapValue(value);
-                  n.midi.data[2] = 0;
-                  break;
-                case Vst::ControllerNumbers::kPitchBend:
-                {
-                  auto val = (uint16_t)param->asClapValue(value);
-                  n.midi.data[0] = 0xE0 | param->channel;  // $Ec
-                  n.midi.data[1] = (val & 0x7F);           // LSB
-                  n.midi.data[2] = (val >> 7) & 0x7F;      // MSB
-                }
+              case Vst::ControllerNumbers::kAfterTouch:
+                n.midi.data[0] = 0xD0 | param->channel;
+                n.midi.data[1] = param->asClapValue(value);
+                n.midi.data[2] = 0;
                 break;
-                default:
-                  n.midi.data[0] = 0xB0 | param->channel;
-                  n.midi.data[1] = param->controller;
-                  n.midi.data[2] = param->asClapValue(value);
-                  break;
+              case Vst::ControllerNumbers::kPitchBend:
+              {
+                auto val = (uint16_t)param->asClapValue(value);
+                n.midi.data[0] = 0xE0 | param->channel;  // $Ec
+                n.midi.data[1] = (val & 0x7F);           // LSB
+                n.midi.data[2] = (val >> 7) & 0x7F;      // MSB
               }
-
-              _eventindices.push_back(_events.size());
-              _events.push_back(n);
+              break;
+              default:
+                n.midi.data[0] = 0xB0 | param->channel;
+                n.midi.data[1] = param->controller;
+                n.midi.data[2] = param->asClapValue(value);
+                break;
             }
-          }
-          else
-          {
-            auto nums = k->getPointCount();
 
-            Vst::ParamValue value;
-            int32 offset;
-            if (k->getPoint(nums - 1, offset, value) == kResultOk)
-            {
-              clap_multi_event_t n;
-              n.param.header.type = CLAP_EVENT_PARAM_VALUE;
-              n.param.header.flags = 0;
-              n.param.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-              n.param.header.time = offset;
-              n.param.header.size = sizeof(clap_event_param_value);
-              n.param.param_id = param->id;
-              n.param.cookie = param->cookie;
-
-              // nothing note specific
-              n.param.note_id = -1;  // always global
-              n.param.port_index = -1;
-              n.param.channel = -1;
-              n.param.key = -1;
-
-              n.param.value = param->asClapValue(value);
-              _eventindices.push_back(_events.size());
-              _events.push_back(n);
-            }
+            _eventindices.push_back(_events.size());
+            _events.push_back(n);
           }
         }
-      }
-    }
-
-    sortEventIndices();
-
-    bool doProcess = true;
-
-    if (_vstdata->numSamples > 0)
-    {
-      // setting the buffers
-      auto inbusses = _audioinputs->size();
-      for (auto i = 0U; i < inbusses; ++i)
-      {
-        if (_vstdata->inputs[i].numChannels > 0)
-          _input_ports[i].data32 = _vstdata->inputs[i].channelBuffers32;
         else
-          doProcess = false;
-      }
-
-      auto outbusses = _audiooutputs->size();
-      for (auto i = 0U; i < outbusses; ++i)
-      {
-        if (_vstdata->outputs[i].numChannels > 0)
-          _output_ports[i].data32 = _vstdata->outputs[i].channelBuffers32;
-        else
-          doProcess = false;
-      }
-      if (doProcess)
-        _plugin->process(_plugin, &_processData);
-      else
-      {
-        if (_ext_params)
         {
-          _ext_params->flush(_plugin, _processData.in_events, _processData.out_events);
+          auto nums = k->getPointCount();
+
+          Vst::ParamValue value;
+          int32 offset;
+          if (k->getPoint(nums - 1, offset, value) == kResultOk)
+          {
+            clap_multi_event_t n;
+            n.param.header.type = CLAP_EVENT_PARAM_VALUE;
+            n.param.header.flags = 0;
+            n.param.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+            n.param.header.time = offset;
+            n.param.header.size = sizeof(clap_event_param_value);
+            n.param.param_id = param->id;
+            n.param.cookie = param->cookie;
+
+            // nothing note specific
+            n.param.note_id = -1;  // always global
+            n.param.port_index = -1;
+            n.param.channel = -1;
+            n.param.key = -1;
+
+            n.param.value = param->asClapValue(value);
+            _eventindices.push_back(_events.size());
+            _events.push_back(n);
+          }
         }
       }
     }
+  }
+
+  sortEventIndices();
+
+  bool doProcess = true;
+
+  if (_vstdata->numSamples > 0)
+  {
+    // setting the buffers
+    auto inbusses = _audioinputs->size();
+    for (auto i = 0U; i < inbusses; ++i)
+    {
+      if (_vstdata->inputs[i].numChannels > 0)
+        _input_ports[i].data32 = _vstdata->inputs[i].channelBuffers32;
+      else
+        doProcess = false;
+    }
+
+    auto outbusses = _audiooutputs->size();
+    for (auto i = 0U; i < outbusses; ++i)
+    {
+      if (_vstdata->outputs[i].numChannels > 0)
+        _output_ports[i].data32 = _vstdata->outputs[i].channelBuffers32;
+      else
+        doProcess = false;
+    }
+    if (doProcess)
+      _plugin->process(_plugin, &_processData);
     else
     {
       if (_ext_params)
       {
         _ext_params->flush(_plugin, _processData.in_events, _processData.out_events);
       }
-      else
-      {
-        // something was now very very wrong here..
-      }
     }
-
-    processOutputParams(data);
-
-    _vstdata = nullptr;
   }
-
-  void ProcessAdapter::processOutputParams(Steinberg::Vst::ProcessData& data)
+  else
   {
-  }
-
-  uint32_t ProcessAdapter::input_events_size(const struct clap_input_events* list)
-  {
-    auto self = static_cast<ProcessAdapter*>(list->ctx);
-    return (uint32_t)self->_events.size();
-    // return self->_vstdata->inputEvents->getEventCount();
-  }
-
-  // returns the pointer to an event in the list. The index accessed is not the position in the event list itself
-  // since all events indices were sorted by timestamp
-  const clap_event_header_t* ProcessAdapter::input_events_get(const struct clap_input_events* list,
-                                                              uint32_t index)
-  {
-    auto self = static_cast<ProcessAdapter*>(list->ctx);
-    if (self->_events.size() > index)
+    if (_ext_params)
     {
-      // we can safely return the note.header also for other event types
-      // since they are at the same memory address
-      auto realindex = self->_eventindices[index];
-      return &(self->_events[realindex].header);
+      _ext_params->flush(_plugin, _processData.in_events, _processData.out_events);
     }
-    return nullptr;
-  }
-
-  bool ProcessAdapter::output_events_try_push(const struct clap_output_events* list,
-                                              const clap_event_header_t* event)
-  {
-    auto self = static_cast<ProcessAdapter*>(list->ctx);
-    // mainly used for CLAP_EVENT_NOTE_CHOKE and CLAP_EVENT_NOTE_END
-    // but also for parameter changes
-    return self->enqueueOutputEvent(event);
-  }
-
-  void ProcessAdapter::sortEventIndices()
-  {
-    // just sorting the index
-    std::sort(_eventindices.begin(), _eventindices.end(),
-              [&](size_t const& a, size_t const& b)
-              { return _events[a].header.time < _events[b].header.time; });
-  }
-
-  void ProcessAdapter::processInputEvents(Steinberg::Vst::IEventList* eventlist)
-  {
-    if (eventlist)
+    else
     {
-      Vst::Event vstevent;
-      auto numev = eventlist->getEventCount();
-      for (decltype(numev) i = 0; i < numev; ++i)
+      // something was now very very wrong here..
+    }
+  }
+
+  processOutputParams(data);
+
+  _vstdata = nullptr;
+}
+
+void ProcessAdapter::processOutputParams(Steinberg::Vst::ProcessData& data)
+{
+}
+
+uint32_t ProcessAdapter::input_events_size(const struct clap_input_events* list)
+{
+  auto self = static_cast<ProcessAdapter*>(list->ctx);
+  return (uint32_t)self->_events.size();
+  // return self->_vstdata->inputEvents->getEventCount();
+}
+
+// returns the pointer to an event in the list. The index accessed is not the position in the event list itself
+// since all events indices were sorted by timestamp
+const clap_event_header_t* ProcessAdapter::input_events_get(const struct clap_input_events* list,
+                                                            uint32_t index)
+{
+  auto self = static_cast<ProcessAdapter*>(list->ctx);
+  if (self->_events.size() > index)
+  {
+    // we can safely return the note.header also for other event types
+    // since they are at the same memory address
+    auto realindex = self->_eventindices[index];
+    return &(self->_events[realindex].header);
+  }
+  return nullptr;
+}
+
+bool ProcessAdapter::output_events_try_push(const struct clap_output_events* list,
+                                            const clap_event_header_t* event)
+{
+  auto self = static_cast<ProcessAdapter*>(list->ctx);
+  // mainly used for CLAP_EVENT_NOTE_CHOKE and CLAP_EVENT_NOTE_END
+  // but also for parameter changes
+  return self->enqueueOutputEvent(event);
+}
+
+void ProcessAdapter::sortEventIndices()
+{
+  // just sorting the index
+  std::sort(_eventindices.begin(), _eventindices.end(),
+            [&](size_t const& a, size_t const& b)
+            { return _events[a].header.time < _events[b].header.time; });
+}
+
+void ProcessAdapter::processInputEvents(Steinberg::Vst::IEventList* eventlist)
+{
+  if (eventlist)
+  {
+    Vst::Event vstevent;
+    auto numev = eventlist->getEventCount();
+    for (decltype(numev) i = 0; i < numev; ++i)
+    {
+      if (eventlist->getEvent(i, vstevent) == kResultOk)
       {
-        if (eventlist->getEvent(i, vstevent) == kResultOk)
+        if (vstevent.type == Vst::Event::kNoteOnEvent)
         {
-          if (vstevent.type == Vst::Event::kNoteOnEvent)
-          {
-            clap_multi_event_t n;
-            n.note.header.type = CLAP_EVENT_NOTE_ON;
-            n.note.header.flags = (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
-            n.note.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-            n.note.header.time = vstevent.sampleOffset;
-            n.note.header.size = sizeof(clap_event_note);
-            n.note.channel = vstevent.noteOn.channel;
-            n.note.note_id = vstevent.noteOn.noteId;
-            n.note.port_index = 0;
-            n.note.velocity = vstevent.noteOn.velocity;
-            n.note.key = vstevent.noteOn.pitch;
-            _eventindices.push_back(_events.size());
-            _events.push_back(n);
-            addToActiveNotes(&n.note);
+          clap_multi_event_t n;
+          n.note.header.type = CLAP_EVENT_NOTE_ON;
+          n.note.header.flags = (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
+          n.note.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+          n.note.header.time = vstevent.sampleOffset;
+          n.note.header.size = sizeof(clap_event_note);
+          n.note.channel = vstevent.noteOn.channel;
+          n.note.note_id = vstevent.noteOn.noteId;
+          n.note.port_index = 0;
+          n.note.velocity = vstevent.noteOn.velocity;
+          n.note.key = vstevent.noteOn.pitch;
+          _eventindices.push_back(_events.size());
+          _events.push_back(n);
+          addToActiveNotes(&n.note);
 
-            // CLAP doesn't support note-on retuning but does support note expressions so
-            // convert but only if your target clap supports note expressions
-            if (_supportsTuningNoteExpression && vstevent.noteOn.tuning != 0)
-            {
-              clap_multi_event_t n;
-              n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
-              n.noteexpression.header.flags =
-                  (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
-              n.noteexpression.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-              n.noteexpression.header.time = vstevent.sampleOffset;
-              n.noteexpression.header.size = sizeof(clap_event_note_expression);
-              n.noteexpression.note_id = vstevent.noteExpressionValue.noteId;
-              n.noteexpression.port_index = 0;
-              n.noteexpression.key = vstevent.noteOn.pitch;
-              n.noteexpression.channel = vstevent.noteOn.channel;
-              n.noteexpression.note_id = vstevent.noteOn.noteId;
-              n.noteexpression.value = vstevent.noteExpressionValue.value;
-
-              // VST3 Tuning is float in cents. We are in semitones. So
-              n.noteexpression.value = vstevent.noteOn.tuning * 0.01;
-              n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;
-              _eventindices.push_back(_events.size());
-              _events.push_back(n);
-            }
-          }
-          if (vstevent.type == Vst::Event::kNoteOffEvent)
-          {
-            clap_multi_event_t n;
-            n.note.header.type = CLAP_EVENT_NOTE_OFF;
-            n.note.header.flags = (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
-            n.note.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-            n.note.header.time = vstevent.sampleOffset;
-            n.note.header.size = sizeof(clap_event_note);
-            n.note.channel = vstevent.noteOff.channel;
-            n.note.note_id = vstevent.noteOff.noteId;
-            n.note.port_index = 0;
-            n.note.velocity = vstevent.noteOff.velocity;
-            n.note.key = vstevent.noteOff.pitch;
-            _eventindices.push_back(_events.size());
-            _events.push_back(n);
-          }
-          if (vstevent.type == Vst::Event::kDataEvent)
-          {
-            clap_multi_event_t n;
-            if (vstevent.data.type == Vst::DataEvent::DataTypes::kMidiSysEx)
-            {
-              n.sysex.buffer = vstevent.data.bytes;
-              n.sysex.size = vstevent.data.size;
-              n.sysex.port_index = 0;
-              n.sysex.header.type = CLAP_EVENT_MIDI_SYSEX;
-              n.sysex.header.flags = vstevent.flags & Vst::Event::kIsLive ? CLAP_EVENT_IS_LIVE : 0;
-              n.sysex.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-              n.sysex.header.time = vstevent.sampleOffset;
-              n.sysex.header.size = sizeof(n.sysex);
-              _eventindices.push_back(_events.size());
-              _events.push_back(n);
-            }
-            else
-            {
-              // there are no other event types yet
-            }
-          }
-          if (_supportsPolyPressure && vstevent.type == Vst::Event::kPolyPressureEvent)
-          {
-            clap_multi_event_t n;
-            n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
-            n.noteexpression.header.flags =
-                (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
-            n.noteexpression.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-            n.noteexpression.header.time = vstevent.sampleOffset;
-            n.noteexpression.header.size = sizeof(clap_event_note_expression);
-            n.noteexpression.note_id = vstevent.polyPressure.noteId;
-            for (auto& i : _activeNotes)
-            {
-              if (i.used && i.note_id == vstevent.polyPressure.noteId)
-              {
-                n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
-                n.noteexpression.port_index = i.port_index;
-                n.noteexpression.key = i.key;  // should be the same as vstevent.polyPressure.pitch
-                n.noteexpression.channel = i.channel;
-                n.noteexpression.value = vstevent.polyPressure.pressure;
-              }
-            }
-            _eventindices.push_back(_events.size());
-            _events.push_back(n);
-          }
-          if (vstevent.type == Vst::Event::kNoteExpressionValueEvent)
+          // CLAP doesn't support note-on retuning but does support note expressions so
+          // convert but only if your target clap supports note expressions
+          if (_supportsTuningNoteExpression && vstevent.noteOn.tuning != 0)
           {
             clap_multi_event_t n;
             n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
@@ -572,199 +490,282 @@ namespace Clap
             n.noteexpression.header.time = vstevent.sampleOffset;
             n.noteexpression.header.size = sizeof(clap_event_note_expression);
             n.noteexpression.note_id = vstevent.noteExpressionValue.noteId;
-            for (auto& i : _activeNotes)
+            n.noteexpression.port_index = 0;
+            n.noteexpression.key = vstevent.noteOn.pitch;
+            n.noteexpression.channel = vstevent.noteOn.channel;
+            n.noteexpression.note_id = vstevent.noteOn.noteId;
+            n.noteexpression.value = vstevent.noteExpressionValue.value;
+
+            // VST3 Tuning is float in cents. We are in semitones. So
+            n.noteexpression.value = vstevent.noteOn.tuning * 0.01;
+            n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;
+            _eventindices.push_back(_events.size());
+            _events.push_back(n);
+          }
+        }
+        if (vstevent.type == Vst::Event::kNoteOffEvent)
+        {
+          clap_multi_event_t n;
+          n.note.header.type = CLAP_EVENT_NOTE_OFF;
+          n.note.header.flags = (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
+          n.note.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+          n.note.header.time = vstevent.sampleOffset;
+          n.note.header.size = sizeof(clap_event_note);
+          n.note.channel = vstevent.noteOff.channel;
+          n.note.note_id = vstevent.noteOff.noteId;
+          n.note.port_index = 0;
+          n.note.velocity = vstevent.noteOff.velocity;
+          n.note.key = vstevent.noteOff.pitch;
+          _eventindices.push_back(_events.size());
+          _events.push_back(n);
+        }
+        if (vstevent.type == Vst::Event::kDataEvent)
+        {
+          clap_multi_event_t n;
+          if (vstevent.data.type == Vst::DataEvent::DataTypes::kMidiSysEx)
+          {
+            n.sysex.buffer = vstevent.data.bytes;
+            n.sysex.size = vstevent.data.size;
+            n.sysex.port_index = 0;
+            n.sysex.header.type = CLAP_EVENT_MIDI_SYSEX;
+            n.sysex.header.flags = vstevent.flags & Vst::Event::kIsLive ? CLAP_EVENT_IS_LIVE : 0;
+            n.sysex.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+            n.sysex.header.time = vstevent.sampleOffset;
+            n.sysex.header.size = sizeof(n.sysex);
+            _eventindices.push_back(_events.size());
+            _events.push_back(n);
+          }
+          else
+          {
+            // there are no other event types yet
+          }
+        }
+        if (_supportsPolyPressure && vstevent.type == Vst::Event::kPolyPressureEvent)
+        {
+          clap_multi_event_t n;
+          n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+          n.noteexpression.header.flags =
+              (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
+          n.noteexpression.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+          n.noteexpression.header.time = vstevent.sampleOffset;
+          n.noteexpression.header.size = sizeof(clap_event_note_expression);
+          n.noteexpression.note_id = vstevent.polyPressure.noteId;
+          for (auto& i : _activeNotes)
+          {
+            if (i.used && i.note_id == vstevent.polyPressure.noteId)
             {
-              if (i.used && i.note_id == vstevent.noteExpressionValue.noteId)
+              n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
+              n.noteexpression.port_index = i.port_index;
+              n.noteexpression.key = i.key;  // should be the same as vstevent.polyPressure.pitch
+              n.noteexpression.channel = i.channel;
+              n.noteexpression.value = vstevent.polyPressure.pressure;
+            }
+          }
+          _eventindices.push_back(_events.size());
+          _events.push_back(n);
+        }
+        if (vstevent.type == Vst::Event::kNoteExpressionValueEvent)
+        {
+          clap_multi_event_t n;
+          n.noteexpression.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+          n.noteexpression.header.flags =
+              (vstevent.flags & Vst::Event::kIsLive) ? CLAP_EVENT_IS_LIVE : 0;
+          n.noteexpression.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+          n.noteexpression.header.time = vstevent.sampleOffset;
+          n.noteexpression.header.size = sizeof(clap_event_note_expression);
+          n.noteexpression.note_id = vstevent.noteExpressionValue.noteId;
+          for (auto& i : _activeNotes)
+          {
+            if (i.used && i.note_id == vstevent.noteExpressionValue.noteId)
+            {
+              n.noteexpression.port_index = i.port_index;
+              n.noteexpression.key = i.key;
+              n.noteexpression.channel = i.channel;
+              n.noteexpression.value = vstevent.noteExpressionValue.value;
+              switch (vstevent.noteExpressionValue.typeId)
               {
-                n.noteexpression.port_index = i.port_index;
-                n.noteexpression.key = i.key;
-                n.noteexpression.channel = i.channel;
-                n.noteexpression.value = vstevent.noteExpressionValue.value;
-                switch (vstevent.noteExpressionValue.typeId)
-                {
-                  case Vst::NoteExpressionTypeIDs::kVolumeTypeID:
-                    n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_VOLUME;
-                    break;
-                  case Vst::NoteExpressionTypeIDs::kPanTypeID:
-                    n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PAN;
-                    break;
-                  case Vst::NoteExpressionTypeIDs::kTuningTypeID:
-                    // VST3 has a 0...1 range; clap has a -120 ... 120 range
-                    n.noteexpression.value = (n.noteexpression.value - 0.5) * 2 * 120;
-                    n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;
-                    break;
-                  case Vst::NoteExpressionTypeIDs::kVibratoTypeID:
-                    n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_VIBRATO;
-                    break;
-                  case Vst::NoteExpressionTypeIDs::kExpressionTypeID:
-                    n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_EXPRESSION;
-                    break;
-                  case Vst::NoteExpressionTypeIDs::kBrightnessTypeID:
-                    n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_BRIGHTNESS;
-                    break;
-                  default:
-                    continue;
-                }
-                _eventindices.push_back(_events.size());
-                _events.push_back(n);
+                case Vst::NoteExpressionTypeIDs::kVolumeTypeID:
+                  n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_VOLUME;
+                  break;
+                case Vst::NoteExpressionTypeIDs::kPanTypeID:
+                  n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PAN;
+                  break;
+                case Vst::NoteExpressionTypeIDs::kTuningTypeID:
+                  // VST3 has a 0...1 range; clap has a -120 ... 120 range
+                  n.noteexpression.value = (n.noteexpression.value - 0.5) * 2 * 120;
+                  n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;
+                  break;
+                case Vst::NoteExpressionTypeIDs::kVibratoTypeID:
+                  n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_VIBRATO;
+                  break;
+                case Vst::NoteExpressionTypeIDs::kExpressionTypeID:
+                  n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_EXPRESSION;
+                  break;
+                case Vst::NoteExpressionTypeIDs::kBrightnessTypeID:
+                  n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_BRIGHTNESS;
+                  break;
+                default:
+                  continue;
               }
+              _eventindices.push_back(_events.size());
+              _events.push_back(n);
             }
           }
         }
       }
     }
   }
+}
 
-  bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t* event)
+bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t* event)
+{
+  switch (event->type)
   {
-    switch (event->type)
+    case CLAP_EVENT_NOTE_ON:
     {
-      case CLAP_EVENT_NOTE_ON:
+      auto nevt = reinterpret_cast<const clap_event_note*>(event);
+
+      Steinberg::Vst::Event oe{};
+      oe.type = Steinberg::Vst::Event::kNoteOnEvent;
+      oe.noteOn.channel = nevt->channel;
+      oe.noteOn.pitch = nevt->key;
+      oe.noteOn.velocity = nevt->velocity;
+      oe.noteOn.length = 0;
+      oe.noteOn.tuning = 0.0f;
+      oe.noteOn.noteId = nevt->note_id;
+      oe.busIndex = 0;  // FIXME - multi-out midi still needs work
+      oe.sampleOffset = nevt->header.time;
+
+      if (_vstdata && _vstdata->outputEvents) _vstdata->outputEvents->addEvent(oe);
+    }
+      return true;
+    case CLAP_EVENT_NOTE_OFF:
+    {
+      auto nevt = reinterpret_cast<const clap_event_note*>(event);
+
+      Steinberg::Vst::Event oe{};
+      oe.type = Steinberg::Vst::Event::kNoteOffEvent;
+      oe.noteOff.channel = nevt->channel;
+      oe.noteOff.pitch = nevt->key;
+      oe.noteOff.velocity = nevt->velocity;
+      oe.noteOn.length = 0;
+      oe.noteOff.tuning = 0.0f;
+      oe.noteOff.noteId = nevt->note_id;
+      oe.busIndex = 0;  // FIXME - multi-out midi still needs work
+      oe.sampleOffset = nevt->header.time;
+
+      if (_vstdata && _vstdata->outputEvents) _vstdata->outputEvents->addEvent(oe);
+    }
+      return true;
+    case CLAP_EVENT_NOTE_END:
+    case CLAP_EVENT_NOTE_CHOKE:
+      removeFromActiveNotes((const clap_event_note*)(event));
+      return true;
+      break;
+    case CLAP_EVENT_NOTE_EXPRESSION:
+      return true;
+      break;
+    case CLAP_EVENT_PARAM_VALUE:
+    {
+      auto ev = (clap_event_param_value*)event;
+      auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
+      if (param)
       {
-        auto nevt = reinterpret_cast<const clap_event_note*>(event);
+        auto param_id = param->getInfo().id;
 
-        Steinberg::Vst::Event oe{};
-        oe.type = Steinberg::Vst::Event::kNoteOnEvent;
-        oe.noteOn.channel = nevt->channel;
-        oe.noteOn.pitch = nevt->key;
-        oe.noteOn.velocity = nevt->velocity;
-        oe.noteOn.length = 0;
-        oe.noteOn.tuning = 0.0f;
-        oe.noteOn.noteId = nevt->note_id;
-        oe.busIndex = 0;  // FIXME - multi-out midi still needs work
-        oe.sampleOffset = nevt->header.time;
-
-        if (_vstdata && _vstdata->outputEvents) _vstdata->outputEvents->addEvent(oe);
-      }
-        return true;
-      case CLAP_EVENT_NOTE_OFF:
-      {
-        auto nevt = reinterpret_cast<const clap_event_note*>(event);
-
-        Steinberg::Vst::Event oe{};
-        oe.type = Steinberg::Vst::Event::kNoteOffEvent;
-        oe.noteOff.channel = nevt->channel;
-        oe.noteOff.pitch = nevt->key;
-        oe.noteOff.velocity = nevt->velocity;
-        oe.noteOn.length = 0;
-        oe.noteOff.tuning = 0.0f;
-        oe.noteOff.noteId = nevt->note_id;
-        oe.busIndex = 0;  // FIXME - multi-out midi still needs work
-        oe.sampleOffset = nevt->header.time;
-
-        if (_vstdata && _vstdata->outputEvents) _vstdata->outputEvents->addEvent(oe);
-      }
-        return true;
-      case CLAP_EVENT_NOTE_END:
-      case CLAP_EVENT_NOTE_CHOKE:
-        removeFromActiveNotes((const clap_event_note*)(event));
-        return true;
-        break;
-      case CLAP_EVENT_NOTE_EXPRESSION:
-        return true;
-        break;
-      case CLAP_EVENT_PARAM_VALUE:
-      {
-        auto ev = (clap_event_param_value*)event;
-        auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
-        if (param)
+        // if the parameter is marked as being edited in the UI, pass the value
+        // to the queue so it can be given to the IComponentHandler
+        if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), param_id) !=
+            _gesturedParameters.end())
         {
-          auto param_id = param->getInfo().id;
+          _automation->onPerformEdit(ev);
+        }
 
-          // if the parameter is marked as being edited in the UI, pass the value
-          // to the queue so it can be given to the IComponentHandler
-          if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), param_id) !=
-              _gesturedParameters.end())
-          {
-            _automation->onPerformEdit(ev);
-          }
+        // it also needs to be communicated to the audio thread,otherwise the parameter jumps back to the original value
+        Steinberg::int32 index = 0;
+        // addParameterData() does check if there is already a queue and returns it,
+        // actually, it should be called getParameterQueue()
+        auto list = _vstdata->outputParameterChanges->addParameterData(param_id, index);
 
-          // it also needs to be communicated to the audio thread,otherwise the parameter jumps back to the original value
-          Steinberg::int32 index = 0;
-          // addParameterData() does check if there is already a queue and returns it,
-          // actually, it should be called getParameterQueue()
-          auto list = _vstdata->outputParameterChanges->addParameterData(param_id, index);
-
-          // the implementation of addParameterData() in the SDK always returns a queue, but Cubase 12 (perhaps others, too)
-          // sometimes don't return a queue object during the first bunch of process calls. I (df) haven't figured out, why.
-          // therefore we have to check if there is an output queue at all
-          if (list)
-          {
-            Steinberg::int32 index2 = 0;
-            list->addPoint(ev->header.time, param->asVst3Value(ev->value), index2);
-          }
+        // the implementation of addParameterData() in the SDK always returns a queue, but Cubase 12 (perhaps others, too)
+        // sometimes don't return a queue object during the first bunch of process calls. I (df) haven't figured out, why.
+        // therefore we have to check if there is an output queue at all
+        if (list)
+        {
+          Steinberg::int32 index2 = 0;
+          list->addPoint(ev->header.time, param->asVst3Value(ev->value), index2);
         }
       }
-
-        return true;
-        break;
-      case CLAP_EVENT_PARAM_MOD:
-        return true;
-        break;
-      case CLAP_EVENT_PARAM_GESTURE_BEGIN:
-      {
-        auto ev = (clap_event_param_gesture*)event;
-        auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
-        _gesturedParameters.push_back(param->getInfo().id);
-        _automation->onBeginEdit(param->getInfo().id);
-      }
-        return true;
-
-        break;
-      case CLAP_EVENT_PARAM_GESTURE_END:
-      {
-        auto ev = (clap_event_param_gesture*)event;
-        auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
-
-        auto n =
-            std::remove(_gesturedParameters.begin(), _gesturedParameters.end(), param->getInfo().id);
-        if (n != _gesturedParameters.end())
-        {
-          _gesturedParameters.erase(n, _gesturedParameters.end());
-          _automation->onEndEdit(param->getInfo().id);
-        }
-      }
-        return true;
-        break;
-
-      case CLAP_EVENT_MIDI:
-      case CLAP_EVENT_MIDI_SYSEX:
-      case CLAP_EVENT_MIDI2:
-        return true;
-        break;
-      default:
-        break;
     }
-    return false;
-  }
 
-  void ProcessAdapter::addToActiveNotes(const clap_event_note* note)
-  {
-    for (auto& i : _activeNotes)
+      return true;
+      break;
+    case CLAP_EVENT_PARAM_MOD:
+      return true;
+      break;
+    case CLAP_EVENT_PARAM_GESTURE_BEGIN:
     {
-      if (!i.used)
-      {
-        i.note_id = note->note_id;
-        i.port_index = note->port_index;
-        i.channel = note->channel;
-        i.key = note->key;
-        i.used = true;
-        return;
-      }
+      auto ev = (clap_event_param_gesture*)event;
+      auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
+      _gesturedParameters.push_back(param->getInfo().id);
+      _automation->onBeginEdit(param->getInfo().id);
     }
-    _activeNotes.push_back({true, note->note_id, note->port_index, note->channel, note->key});
-  }
+      return true;
 
-  void ProcessAdapter::removeFromActiveNotes(const clap_event_note* note)
-  {
-    for (auto& i : _activeNotes)
+      break;
+    case CLAP_EVENT_PARAM_GESTURE_END:
     {
-      if (i.used && i.port_index == note->port_index && i.channel == note->channel &&
-          i.note_id == note->note_id)
+      auto ev = (clap_event_param_gesture*)event;
+      auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
+
+      auto n = std::remove(_gesturedParameters.begin(), _gesturedParameters.end(), param->getInfo().id);
+      if (n != _gesturedParameters.end())
       {
-        i.used = false;
+        _gesturedParameters.erase(n, _gesturedParameters.end());
+        _automation->onEndEdit(param->getInfo().id);
       }
     }
+      return true;
+      break;
+
+    case CLAP_EVENT_MIDI:
+    case CLAP_EVENT_MIDI_SYSEX:
+    case CLAP_EVENT_MIDI2:
+      return true;
+      break;
+    default:
+      break;
   }
+  return false;
+}
+
+void ProcessAdapter::addToActiveNotes(const clap_event_note* note)
+{
+  for (auto& i : _activeNotes)
+  {
+    if (!i.used)
+    {
+      i.note_id = note->note_id;
+      i.port_index = note->port_index;
+      i.channel = note->channel;
+      i.key = note->key;
+      i.used = true;
+      return;
+    }
+  }
+  _activeNotes.push_back({true, note->note_id, note->port_index, note->channel, note->key});
+}
+
+void ProcessAdapter::removeFromActiveNotes(const clap_event_note* note)
+{
+  for (auto& i : _activeNotes)
+  {
+    if (i.used && i.port_index == note->port_index && i.channel == note->channel &&
+        i.note_id == note->note_id)
+    {
+      i.used = false;
+    }
+  }
+}
 
 }  // namespace Clap

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -63,18 +63,25 @@ namespace Clap
 		}
 #endif
 
-    void setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params, Steinberg::Vst::BusList& numInputs, Steinberg::Vst::BusList& numOutputs, uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
-                         Steinberg::Vst::ParameterContainer& params, Steinberg::Vst::IComponentHandler* componenthandler, IAutomation* automation, bool enablePolyPressure, bool supportsTuningNoteExpression);
+    void setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params,
+                         Steinberg::Vst::BusList& numInputs, Steinberg::Vst::BusList& numOutputs,
+                         uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
+                         Steinberg::Vst::ParameterContainer& params,
+                         Steinberg::Vst::IComponentHandler* componenthandler, IAutomation* automation,
+                         bool enablePolyPressure, bool supportsTuningNoteExpression);
     void process(Steinberg::Vst::ProcessData& data);
     void flush();
     void processOutputParams(Steinberg::Vst::ProcessData& data);
-    void activateAudioBus(Steinberg::Vst::BusDirection dir, Steinberg::int32 index, Steinberg::TBool state);
+    void activateAudioBus(Steinberg::Vst::BusDirection dir, Steinberg::int32 index,
+                          Steinberg::TBool state);
 
     // C callbacks
     static uint32_t input_events_size(const struct clap_input_events* list);
-    static const clap_event_header_t* input_events_get(const struct clap_input_events* list, uint32_t index);
+    static const clap_event_header_t* input_events_get(const struct clap_input_events* list,
+                                                       uint32_t index);
 
-    static bool output_events_try_push(const struct clap_output_events* list, const clap_event_header_t* event);
+    static bool output_events_try_push(const struct clap_output_events* list,
+                                       const clap_event_header_t* event);
 
    private:
     void sortEventIndices();
@@ -117,7 +124,8 @@ namespace Clap
     float* _silent_input = nullptr;
     float* _silent_output = nullptr;
 
-    clap_process_t _processData = {-1, 0, &_transport, nullptr, nullptr, 0, 0, &_in_events, &_out_events};
+    clap_process_t _processData = {-1, 0, &_transport, nullptr,     nullptr,
+                                   0,  0, &_in_events, &_out_events};
 
     Steinberg::Vst::ProcessData* _vstdata = nullptr;
 

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -35,18 +35,18 @@
 
 namespace Clap
 {
-  class ProcessAdapter
+class ProcessAdapter
+{
+ public:
+  typedef union clap_multi_event
   {
-   public:
-    typedef union clap_multi_event
-    {
-      clap_event_header_t header;
-      clap_event_note_t note;
-      clap_event_midi_t midi;
-      clap_event_midi_sysex_t sysex;
-      clap_event_param_value_t param;
-      clap_event_note_expression_t noteexpression;
-    } clap_multi_event_t;
+    clap_event_header_t header;
+    clap_event_note_t note;
+    clap_event_midi_t midi;
+    clap_event_midi_sysex_t sysex;
+    clap_event_param_value_t param;
+    clap_event_note_expression_t noteexpression;
+  } clap_multi_event_t;
 
 #if 0
 		// the bitly helpers. These names conflict with macOS params.h but are
@@ -63,77 +63,76 @@ namespace Clap
 		}
 #endif
 
-    void setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params,
-                         Steinberg::Vst::BusList& numInputs, Steinberg::Vst::BusList& numOutputs,
-                         uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
-                         Steinberg::Vst::ParameterContainer& params,
-                         Steinberg::Vst::IComponentHandler* componenthandler, IAutomation* automation,
-                         bool enablePolyPressure, bool supportsTuningNoteExpression);
-    void process(Steinberg::Vst::ProcessData& data);
-    void flush();
-    void processOutputParams(Steinberg::Vst::ProcessData& data);
-    void activateAudioBus(Steinberg::Vst::BusDirection dir, Steinberg::int32 index,
-                          Steinberg::TBool state);
+  void setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params,
+                       Steinberg::Vst::BusList& numInputs, Steinberg::Vst::BusList& numOutputs,
+                       uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
+                       Steinberg::Vst::ParameterContainer& params,
+                       Steinberg::Vst::IComponentHandler* componenthandler, IAutomation* automation,
+                       bool enablePolyPressure, bool supportsTuningNoteExpression);
+  void process(Steinberg::Vst::ProcessData& data);
+  void flush();
+  void processOutputParams(Steinberg::Vst::ProcessData& data);
+  void activateAudioBus(Steinberg::Vst::BusDirection dir, Steinberg::int32 index,
+                        Steinberg::TBool state);
 
-    // C callbacks
-    static uint32_t input_events_size(const struct clap_input_events* list);
-    static const clap_event_header_t* input_events_get(const struct clap_input_events* list,
-                                                       uint32_t index);
+  // C callbacks
+  static uint32_t input_events_size(const struct clap_input_events* list);
+  static const clap_event_header_t* input_events_get(const struct clap_input_events* list,
+                                                     uint32_t index);
 
-    static bool output_events_try_push(const struct clap_output_events* list,
-                                       const clap_event_header_t* event);
+  static bool output_events_try_push(const struct clap_output_events* list,
+                                     const clap_event_header_t* event);
 
-   private:
-    void sortEventIndices();
-    void processInputEvents(Steinberg::Vst::IEventList* eventlist);
+ private:
+  void sortEventIndices();
+  void processInputEvents(Steinberg::Vst::IEventList* eventlist);
 
-    bool enqueueOutputEvent(const clap_event_header_t* event);
-    void addToActiveNotes(const clap_event_note* note);
-    void removeFromActiveNotes(const clap_event_note* note);
+  bool enqueueOutputEvent(const clap_event_header_t* event);
+  void addToActiveNotes(const clap_event_note* note);
+  void removeFromActiveNotes(const clap_event_note* note);
 
-    // the plugin
-    const clap_plugin_t* _plugin = nullptr;
-    const clap_plugin_params_t* _ext_params = nullptr;
+  // the plugin
+  const clap_plugin_t* _plugin = nullptr;
+  const clap_plugin_params_t* _ext_params = nullptr;
 
-    Steinberg::Vst::ParameterContainer* parameters = nullptr;
-    Steinberg::Vst::IComponentHandler* _componentHandler = nullptr;
-    IAutomation* _automation = nullptr;
-    Steinberg::Vst::BusList* _audioinputs = nullptr;
-    Steinberg::Vst::BusList* _audiooutputs = nullptr;
+  Steinberg::Vst::ParameterContainer* parameters = nullptr;
+  Steinberg::Vst::IComponentHandler* _componentHandler = nullptr;
+  IAutomation* _automation = nullptr;
+  Steinberg::Vst::BusList* _audioinputs = nullptr;
+  Steinberg::Vst::BusList* _audiooutputs = nullptr;
 
-    // for automation gestures
-    std::vector<clap_id> _gesturedParameters;
+  // for automation gestures
+  std::vector<clap_id> _gesturedParameters;
 
-    // for INoteExpression
-    struct ActiveNote
-    {
-      bool used = false;
-      int32_t note_id;  // -1 if unspecified, otherwise >=0
-      int16_t port_index;
-      int16_t channel;  // 0..15
-      int16_t key;      // 0..127
-    };
-    std::vector<ActiveNote> _activeNotes;
-
-    clap_audio_buffer_t* _input_ports = nullptr;
-    clap_audio_buffer_t* _output_ports = nullptr;
-    clap_event_transport_t _transport = {};
-    clap_input_events_t _in_events = {};
-    clap_output_events_t _out_events = {};
-
-    float* _silent_input = nullptr;
-    float* _silent_output = nullptr;
-
-    clap_process_t _processData = {-1, 0, &_transport, nullptr,     nullptr,
-                                   0,  0, &_in_events, &_out_events};
-
-    Steinberg::Vst::ProcessData* _vstdata = nullptr;
-
-    std::vector<clap_multi_event_t> _events;
-    std::vector<size_t> _eventindices;
-
-    bool _supportsPolyPressure = false;
-    bool _supportsTuningNoteExpression = false;
+  // for INoteExpression
+  struct ActiveNote
+  {
+    bool used = false;
+    int32_t note_id;  // -1 if unspecified, otherwise >=0
+    int16_t port_index;
+    int16_t channel;  // 0..15
+    int16_t key;      // 0..127
   };
+  std::vector<ActiveNote> _activeNotes;
+
+  clap_audio_buffer_t* _input_ports = nullptr;
+  clap_audio_buffer_t* _output_ports = nullptr;
+  clap_event_transport_t _transport = {};
+  clap_input_events_t _in_events = {};
+  clap_output_events_t _out_events = {};
+
+  float* _silent_input = nullptr;
+  float* _silent_output = nullptr;
+
+  clap_process_t _processData = {-1, 0, &_transport, nullptr, nullptr, 0, 0, &_in_events, &_out_events};
+
+  Steinberg::Vst::ProcessData* _vstdata = nullptr;
+
+  std::vector<clap_multi_event_t> _events;
+  std::vector<size_t> _eventindices;
+
+  bool _supportsPolyPressure = false;
+  bool _supportsTuningNoteExpression = false;
+};
 
 }  // namespace Clap

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -1,15 +1,15 @@
 #pragma once
 
 /*
-          VST3 process adapter
+	  VST3 process adapter
 
-                Copyright (c) 2022 Timo Kaluza (defiantnerd)
+		Copyright (c) 2022 Timo Kaluza (defiantnerd)
 
-                This file is part of the clap-wrappers project which is released under MIT License.
-                See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+		This file is part of the clap-wrappers project which is released under MIT License.
+		See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
 
 
-                The process adapter is responible to translate events, timing information
+		The process adapter is responible to translate events, timing information 
 
 */
 #include <clap/clap.h>
@@ -37,7 +37,7 @@ namespace Clap
 {
   class ProcessAdapter
   {
-  public:
+   public:
     typedef union clap_multi_event
     {
       clap_event_header_t header;
@@ -63,39 +63,36 @@ namespace Clap
 		}
 #endif
 
-    void setupProcessing(const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
-                         Steinberg::Vst::BusList &numInputs, Steinberg::Vst::BusList &numOutputs, uint32_t numSamples,
-                         size_t numEventInputs, size_t numEventOutputs, Steinberg::Vst::ParameterContainer &params,
-                         Steinberg::Vst::IComponentHandler *componenthandler, IAutomation *automation,
-                         bool enablePolyPressure, bool supportsTuningNoteExpression);
-    void process(Steinberg::Vst::ProcessData &data);
+    void setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params, Steinberg::Vst::BusList& numInputs, Steinberg::Vst::BusList& numOutputs, uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
+                         Steinberg::Vst::ParameterContainer& params, Steinberg::Vst::IComponentHandler* componenthandler, IAutomation* automation, bool enablePolyPressure, bool supportsTuningNoteExpression);
+    void process(Steinberg::Vst::ProcessData& data);
     void flush();
-    void processOutputParams(Steinberg::Vst::ProcessData &data);
+    void processOutputParams(Steinberg::Vst::ProcessData& data);
     void activateAudioBus(Steinberg::Vst::BusDirection dir, Steinberg::int32 index, Steinberg::TBool state);
 
     // C callbacks
-    static uint32_t input_events_size(const struct clap_input_events *list);
-    static const clap_event_header_t *input_events_get(const struct clap_input_events *list, uint32_t index);
+    static uint32_t input_events_size(const struct clap_input_events* list);
+    static const clap_event_header_t* input_events_get(const struct clap_input_events* list, uint32_t index);
 
-    static bool output_events_try_push(const struct clap_output_events *list, const clap_event_header_t *event);
+    static bool output_events_try_push(const struct clap_output_events* list, const clap_event_header_t* event);
 
-  private:
+   private:
     void sortEventIndices();
-    void processInputEvents(Steinberg::Vst::IEventList *eventlist);
+    void processInputEvents(Steinberg::Vst::IEventList* eventlist);
 
-    bool enqueueOutputEvent(const clap_event_header_t *event);
-    void addToActiveNotes(const clap_event_note *note);
-    void removeFromActiveNotes(const clap_event_note *note);
+    bool enqueueOutputEvent(const clap_event_header_t* event);
+    void addToActiveNotes(const clap_event_note* note);
+    void removeFromActiveNotes(const clap_event_note* note);
 
     // the plugin
-    const clap_plugin_t *_plugin = nullptr;
-    const clap_plugin_params_t *_ext_params = nullptr;
+    const clap_plugin_t* _plugin = nullptr;
+    const clap_plugin_params_t* _ext_params = nullptr;
 
-    Steinberg::Vst::ParameterContainer *parameters = nullptr;
-    Steinberg::Vst::IComponentHandler *_componentHandler = nullptr;
-    IAutomation *_automation = nullptr;
-    Steinberg::Vst::BusList *_audioinputs = nullptr;
-    Steinberg::Vst::BusList *_audiooutputs = nullptr;
+    Steinberg::Vst::ParameterContainer* parameters = nullptr;
+    Steinberg::Vst::IComponentHandler* _componentHandler = nullptr;
+    IAutomation* _automation = nullptr;
+    Steinberg::Vst::BusList* _audioinputs = nullptr;
+    Steinberg::Vst::BusList* _audiooutputs = nullptr;
 
     // for automation gestures
     std::vector<clap_id> _gesturedParameters;
@@ -104,25 +101,25 @@ namespace Clap
     struct ActiveNote
     {
       bool used = false;
-      int32_t note_id; // -1 if unspecified, otherwise >=0
+      int32_t note_id;  // -1 if unspecified, otherwise >=0
       int16_t port_index;
-      int16_t channel; // 0..15
-      int16_t key;     // 0..127
+      int16_t channel;  // 0..15
+      int16_t key;      // 0..127
     };
     std::vector<ActiveNote> _activeNotes;
 
-    clap_audio_buffer_t *_input_ports = nullptr;
-    clap_audio_buffer_t *_output_ports = nullptr;
+    clap_audio_buffer_t* _input_ports = nullptr;
+    clap_audio_buffer_t* _output_ports = nullptr;
     clap_event_transport_t _transport = {};
     clap_input_events_t _in_events = {};
     clap_output_events_t _out_events = {};
 
-    float *_silent_input = nullptr;
-    float *_silent_output = nullptr;
+    float* _silent_input = nullptr;
+    float* _silent_output = nullptr;
 
     clap_process_t _processData = {-1, 0, &_transport, nullptr, nullptr, 0, 0, &_in_events, &_out_events};
 
-    Steinberg::Vst::ProcessData *_vstdata = nullptr;
+    Steinberg::Vst::ProcessData* _vstdata = nullptr;
 
     std::vector<clap_multi_event_t> _events;
     std::vector<size_t> _eventindices;
@@ -131,4 +128,4 @@ namespace Clap
     bool _supportsTuningNoteExpression = false;
   };
 
-} // namespace Clap
+}  // namespace Clap

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -1,15 +1,15 @@
 #pragma once
 
 /*
-	  VST3 process adapter
+          VST3 process adapter
 
-		Copyright (c) 2022 Timo Kaluza (defiantnerd)
+                Copyright (c) 2022 Timo Kaluza (defiantnerd)
 
-		This file is part of the clap-wrappers project which is released under MIT License.
-		See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+                This file is part of the clap-wrappers project which is released under MIT License.
+                See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
 
 
-		The process adapter is responible to translate events, timing information 
+                The process adapter is responible to translate events, timing information
 
 */
 #include <clap/clap.h>
@@ -35,18 +35,18 @@
 
 namespace Clap
 {
-	class ProcessAdapter
-	{
-	public:
-		typedef union clap_multi_event
-		{
-			clap_event_header_t header;
-			clap_event_note_t note;
-			clap_event_midi_t midi;
-			clap_event_midi_sysex_t sysex;
-			clap_event_param_value_t param;
-			clap_event_note_expression_t noteexpression;
-		} clap_multi_event_t;
+  class ProcessAdapter
+  {
+  public:
+    typedef union clap_multi_event
+    {
+      clap_event_header_t header;
+      clap_event_note_t note;
+      clap_event_midi_t midi;
+      clap_event_midi_sysex_t sysex;
+      clap_event_param_value_t param;
+      clap_event_note_expression_t noteexpression;
+    } clap_multi_event_t;
 
 #if 0
 		// the bitly helpers. These names conflict with macOS params.h but are
@@ -63,73 +63,72 @@ namespace Clap
 		}
 #endif
 
-		void setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params, 
-			Steinberg::Vst::BusList& numInputs, Steinberg::Vst::BusList& numOutputs,
-			uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
-         Steinberg::Vst::ParameterContainer& params, Steinberg::Vst::IComponentHandler* componenthandler,
-         IAutomation* automation, bool enablePolyPressure, bool supportsTuningNoteExpression);
-		void process(Steinberg::Vst::ProcessData& data);
-		void flush();
-		void processOutputParams(Steinberg::Vst::ProcessData& data);
-		void activateAudioBus(Steinberg::Vst::BusDirection dir, Steinberg::int32 index, Steinberg::TBool state);
+    void setupProcessing(const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
+                         Steinberg::Vst::BusList &numInputs, Steinberg::Vst::BusList &numOutputs, uint32_t numSamples,
+                         size_t numEventInputs, size_t numEventOutputs, Steinberg::Vst::ParameterContainer &params,
+                         Steinberg::Vst::IComponentHandler *componenthandler, IAutomation *automation,
+                         bool enablePolyPressure, bool supportsTuningNoteExpression);
+    void process(Steinberg::Vst::ProcessData &data);
+    void flush();
+    void processOutputParams(Steinberg::Vst::ProcessData &data);
+    void activateAudioBus(Steinberg::Vst::BusDirection dir, Steinberg::int32 index, Steinberg::TBool state);
 
-		// C callbacks
-		static uint32_t input_events_size(const struct clap_input_events* list);
-		static const clap_event_header_t* input_events_get(const struct clap_input_events* list, uint32_t index);
+    // C callbacks
+    static uint32_t input_events_size(const struct clap_input_events *list);
+    static const clap_event_header_t *input_events_get(const struct clap_input_events *list, uint32_t index);
 
-		static bool output_events_try_push(const struct clap_output_events* list, const clap_event_header_t* event);		
-	private:
-		void sortEventIndices();
-		void processInputEvents(Steinberg::Vst::IEventList* eventlist);
+    static bool output_events_try_push(const struct clap_output_events *list, const clap_event_header_t *event);
 
-		bool enqueueOutputEvent(const clap_event_header_t* event);
-		void addToActiveNotes(const clap_event_note* note);
-		void removeFromActiveNotes(const clap_event_note* note);
+  private:
+    void sortEventIndices();
+    void processInputEvents(Steinberg::Vst::IEventList *eventlist);
 
-		// the plugin
-		const clap_plugin_t* _plugin = nullptr;
-		const clap_plugin_params_t* _ext_params = nullptr;
+    bool enqueueOutputEvent(const clap_event_header_t *event);
+    void addToActiveNotes(const clap_event_note *note);
+    void removeFromActiveNotes(const clap_event_note *note);
 
-		Steinberg::Vst::ParameterContainer* parameters = nullptr;
-		Steinberg::Vst::IComponentHandler* _componentHandler = nullptr;
-		IAutomation* _automation = nullptr;
-		Steinberg::Vst::BusList* _audioinputs = nullptr;
-		Steinberg::Vst::BusList* _audiooutputs = nullptr;
+    // the plugin
+    const clap_plugin_t *_plugin = nullptr;
+    const clap_plugin_params_t *_ext_params = nullptr;
 
-		// for automation gestures
-		std::vector<clap_id> _gesturedParameters;
+    Steinberg::Vst::ParameterContainer *parameters = nullptr;
+    Steinberg::Vst::IComponentHandler *_componentHandler = nullptr;
+    IAutomation *_automation = nullptr;
+    Steinberg::Vst::BusList *_audioinputs = nullptr;
+    Steinberg::Vst::BusList *_audiooutputs = nullptr;
 
-		// for INoteExpression
-		struct ActiveNote
-		{
-			bool used = false;
-			int32_t note_id; // -1 if unspecified, otherwise >=0
-			int16_t port_index;
-			int16_t channel;  // 0..15
-			int16_t key;      // 0..127
-		};
-		std::vector<ActiveNote> _activeNotes;
+    // for automation gestures
+    std::vector<clap_id> _gesturedParameters;
 
-		clap_audio_buffer_t* _input_ports = nullptr;
-		clap_audio_buffer_t* _output_ports = nullptr;
-		clap_event_transport_t _transport = {};
-		clap_input_events_t _in_events = {};
-		clap_output_events_t _out_events = {};
+    // for INoteExpression
+    struct ActiveNote
+    {
+      bool used = false;
+      int32_t note_id; // -1 if unspecified, otherwise >=0
+      int16_t port_index;
+      int16_t channel; // 0..15
+      int16_t key;     // 0..127
+    };
+    std::vector<ActiveNote> _activeNotes;
 
-		float* _silent_input = nullptr;
-		float* _silent_output = nullptr;
+    clap_audio_buffer_t *_input_ports = nullptr;
+    clap_audio_buffer_t *_output_ports = nullptr;
+    clap_event_transport_t _transport = {};
+    clap_input_events_t _in_events = {};
+    clap_output_events_t _out_events = {};
 
-		clap_process_t _processData = { -1, 0, &_transport, nullptr, nullptr, 0, 0, &_in_events, &_out_events };
+    float *_silent_input = nullptr;
+    float *_silent_output = nullptr;
 
+    clap_process_t _processData = {-1, 0, &_transport, nullptr, nullptr, 0, 0, &_in_events, &_out_events};
 
-		Steinberg::Vst::ProcessData* _vstdata = nullptr;
+    Steinberg::Vst::ProcessData *_vstdata = nullptr;
 
-		std::vector<clap_multi_event_t> _events;
-		std::vector<size_t> _eventindices;
+    std::vector<clap_multi_event_t> _events;
+    std::vector<size_t> _eventindices;
 
-		bool _supportsPolyPressure = false;
-      bool _supportsTuningNoteExpression = false;
+    bool _supportsPolyPressure = false;
+    bool _supportsTuningNoteExpression = false;
+  };
 
-	};
-
-}
+} // namespace Clap

--- a/src/detail/vst3/state.h
+++ b/src/detail/vst3/state.h
@@ -12,31 +12,29 @@
 class CLAPVST3StreamAdapter
 {
 public:
-  CLAPVST3StreamAdapter(Steinberg::IBStream* stream)
-    : vst_stream(stream)
-  {
-  }
-  operator const clap_istream_t* () const { return &in; }
-  operator const clap_ostream_t* () const { return &out; }
+  CLAPVST3StreamAdapter(Steinberg::IBStream *stream) : vst_stream(stream) {}
+  operator const clap_istream_t *() const { return &in; }
+  operator const clap_ostream_t *() const { return &out; }
 
-  static int64_t read(const struct clap_istream* stream, void* buffer, uint64_t size)
+  static int64_t read(const struct clap_istream *stream, void *buffer, uint64_t size)
   {
-    auto self = static_cast<CLAPVST3StreamAdapter*>(stream->ctx);
+    auto self = static_cast<CLAPVST3StreamAdapter *>(stream->ctx);
     Steinberg::int32 bytesRead = 0;
     if (kResultOk == self->vst_stream->read(buffer, (int32)size, &bytesRead))
       return bytesRead;
     return -1;
   }
-  static int64_t write(const struct clap_ostream* stream, const void* buffer, uint64_t size)
+  static int64_t write(const struct clap_ostream *stream, const void *buffer, uint64_t size)
   {
-    auto self = static_cast<CLAPVST3StreamAdapter*>(stream->ctx);
+    auto self = static_cast<CLAPVST3StreamAdapter *>(stream->ctx);
     Steinberg::int32 bytesWritten = 0;
-    if (kResultOk == self->vst_stream->write(const_cast<void*>(buffer), (int32)size, &bytesWritten))
+    if (kResultOk == self->vst_stream->write(const_cast<void *>(buffer), (int32)size, &bytesWritten))
       return bytesWritten;
     return -1;
   }
+
 private:
-  Steinberg::IBStream* vst_stream = nullptr;
-  clap_istream_t in = { this, read };
-  clap_ostream_t out = { this, write };
+  Steinberg::IBStream *vst_stream = nullptr;
+  clap_istream_t in = {this, read};
+  clap_ostream_t out = {this, write};
 };

--- a/src/detail/vst3/state.h
+++ b/src/detail/vst3/state.h
@@ -11,30 +11,28 @@
 
 class CLAPVST3StreamAdapter
 {
-public:
-  CLAPVST3StreamAdapter(Steinberg::IBStream *stream) : vst_stream(stream) {}
-  operator const clap_istream_t *() const { return &in; }
-  operator const clap_ostream_t *() const { return &out; }
+ public:
+  CLAPVST3StreamAdapter(Steinberg::IBStream* stream) : vst_stream(stream) {}
+  operator const clap_istream_t*() const { return &in; }
+  operator const clap_ostream_t*() const { return &out; }
 
-  static int64_t read(const struct clap_istream *stream, void *buffer, uint64_t size)
+  static int64_t read(const struct clap_istream* stream, void* buffer, uint64_t size)
   {
-    auto self = static_cast<CLAPVST3StreamAdapter *>(stream->ctx);
+    auto self = static_cast<CLAPVST3StreamAdapter*>(stream->ctx);
     Steinberg::int32 bytesRead = 0;
-    if (kResultOk == self->vst_stream->read(buffer, (int32)size, &bytesRead))
-      return bytesRead;
+    if (kResultOk == self->vst_stream->read(buffer, (int32)size, &bytesRead)) return bytesRead;
     return -1;
   }
-  static int64_t write(const struct clap_ostream *stream, const void *buffer, uint64_t size)
+  static int64_t write(const struct clap_ostream* stream, const void* buffer, uint64_t size)
   {
-    auto self = static_cast<CLAPVST3StreamAdapter *>(stream->ctx);
+    auto self = static_cast<CLAPVST3StreamAdapter*>(stream->ctx);
     Steinberg::int32 bytesWritten = 0;
-    if (kResultOk == self->vst_stream->write(const_cast<void *>(buffer), (int32)size, &bytesWritten))
-      return bytesWritten;
+    if (kResultOk == self->vst_stream->write(const_cast<void*>(buffer), (int32)size, &bytesWritten)) return bytesWritten;
     return -1;
   }
 
-private:
-  Steinberg::IBStream *vst_stream = nullptr;
+ private:
+  Steinberg::IBStream* vst_stream = nullptr;
   clap_istream_t in = {this, read};
   clap_ostream_t out = {this, write};
 };

--- a/src/detail/vst3/state.h
+++ b/src/detail/vst3/state.h
@@ -35,7 +35,8 @@ class CLAPVST3StreamAdapter
   {
     auto self = static_cast<CLAPVST3StreamAdapter*>(stream->ctx);
     Steinberg::int32 bytesWritten = 0;
-    if (kResultOk == self->vst_stream->write(const_cast<void*>(buffer), (int32)size, &bytesWritten)) return bytesWritten;
+    if (kResultOk == self->vst_stream->write(const_cast<void*>(buffer), (int32)size, &bytesWritten))
+      return bytesWritten;
     return -1;
   }
 

--- a/src/detail/vst3/state.h
+++ b/src/detail/vst3/state.h
@@ -12,9 +12,17 @@
 class CLAPVST3StreamAdapter
 {
  public:
-  CLAPVST3StreamAdapter(Steinberg::IBStream* stream) : vst_stream(stream) {}
-  operator const clap_istream_t*() const { return &in; }
-  operator const clap_ostream_t*() const { return &out; }
+  CLAPVST3StreamAdapter(Steinberg::IBStream* stream) : vst_stream(stream)
+  {
+  }
+  operator const clap_istream_t*() const
+  {
+    return &in;
+  }
+  operator const clap_ostream_t*() const
+  {
+    return &out;
+  }
 
   static int64_t read(const struct clap_istream* stream, void* buffer, uint64_t size)
   {

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -1036,7 +1036,7 @@ struct FDHandler : Steinberg::Linux::IEventHandler, public Steinberg::FObject
   int _fd{0};
   clap_posix_fd_flags_t _flags{};
   FDHandler(ClapAsVst3* parent, int fd, clap_posix_fd_flags_t flags)
-      : _parent(parent), _fd(fd), _flags(flags)
+    : _parent(parent), _fd(fd), _flags(flags)
   {
   }
   void PLUGIN_API onFDIsSet(Steinberg::Linux::FileDescriptor) override

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -75,12 +75,16 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
     _active = true;
     _processAdapter = new Clap::ProcessAdapter();
 
-    auto supportsnoteexpression = (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PRESSURE);
+    auto supportsnoteexpression =
+        (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PRESSURE);
 
     // the processAdapter needs to know a few things to intercommunicate between VST3 host and CLAP plugin.
 
-    _processAdapter->setupProcessing(_plugin->_plugin, _plugin->_ext._params, this->audioInputs, this->audioOutputs, this->_largestBlocksize, this->eventInputs.size(), this->eventOutputs.size(), parameters, componentHandler, this,
-                                     supportsnoteexpression, _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
+    _processAdapter->setupProcessing(
+        _plugin->_plugin, _plugin->_ext._params, this->audioInputs, this->audioOutputs,
+        this->_largestBlocksize, this->eventInputs.size(), this->eventOutputs.size(), parameters,
+        componentHandler, this, supportsnoteexpression,
+        _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
     updateAudioBusses();
 
     os::attach(this);
@@ -186,12 +190,14 @@ tresult PLUGIN_API ClapAsVst3::setProcessing(TBool state)
   return result;
 }
 
-tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns, Vst::SpeakerArrangement* outputs, int32 numOuts)
+tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns,
+                                                  Vst::SpeakerArrangement* outputs, int32 numOuts)
 {
   return super::setBusArrangements(inputs, numIns, outputs, numOuts);
 };
 
-tresult PLUGIN_API ClapAsVst3::getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement& arr)
+tresult PLUGIN_API ClapAsVst3::getBusArrangement(Vst::BusDirection dir, int32 index,
+                                                 Vst::SpeakerArrangement& arr)
 {
   return super::getBusArrangement(dir, index, arr);
 }
@@ -226,7 +232,8 @@ IPlugView* PLUGIN_API ClapAsVst3::createView(FIDString name)
   return nullptr;
 }
 
-tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized, Vst::String128 string)
+tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized,
+                                                     Vst::String128 string)
 {
   auto param = (Vst3Parameter*)this->getParameterObject(id);
   auto val = param->asClapValue(valueNormalized);
@@ -243,7 +250,8 @@ tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::Param
   return super::getParamStringByValue(id, valueNormalized, string);
 }
 
-tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar* string, Vst::ParamValue& valueNormalized)
+tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar* string,
+                                                     Vst::ParamValue& valueNormalized)
 {
   auto param = (Vst3Parameter*)this->getParameterObject(id);
   Steinberg::String m(string);
@@ -258,14 +266,17 @@ tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar
   return Steinberg::kResultFalse;
 }
 
-tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index, TBool state)
+tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index,
+                                           TBool state)
 {
   return super::activateBus(type, dir, index, state);
 }
 
 //-----------------------------------------------------------------------------
 
-tresult PLUGIN_API ClapAsVst3::getMidiControllerAssignment(int32 busIndex, int16 channel, Vst::CtrlNumber midiControllerNumber, Vst::ParamID& id /*out*/)
+tresult PLUGIN_API ClapAsVst3::getMidiControllerAssignment(int32 busIndex, int16 channel,
+                                                           Vst::CtrlNumber midiControllerNumber,
+                                                           Vst::ParamID& id /*out*/)
 {
   // for my first Event bus and for MIDI channel 0 and for MIDI CC Volume only
   if (busIndex == 0)  // && channel == 0) // && midiControllerNumber == Vst::kCtrlVolume)
@@ -289,7 +300,8 @@ int32 ClapAsVst3::getNoteExpressionCount(int32 busIndex, int16 channel)
 }
 
 /** Returns note change type info. */
-tresult ClapAsVst3::getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex, Vst::NoteExpressionTypeInfo& info /*out*/)
+tresult ClapAsVst3::getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex,
+                                          Vst::NoteExpressionTypeInfo& info /*out*/)
 {
   if (busIndex == 0 && channel == 0)
   {
@@ -299,13 +311,19 @@ tresult ClapAsVst3::getNoteExpressionInfo(int32 busIndex, int16 channel, int32 n
 }
 
 /** Gets a user readable representation of the normalized note change value. */
-tresult ClapAsVst3::getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, Vst::NoteExpressionValue valueNormalized /*in*/, Vst::String128 string /*out*/)
+tresult ClapAsVst3::getNoteExpressionStringByValue(int32 busIndex, int16 channel,
+                                                   Vst::NoteExpressionTypeID id,
+                                                   Vst::NoteExpressionValue valueNormalized /*in*/,
+                                                   Vst::String128 string /*out*/)
 {
   return _noteExpressions.getNoteExpressionStringByValue(id, valueNormalized, string);
 }
 
 /** Converts the user readable representation to the normalized note change value. */
-tresult ClapAsVst3::getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, const Vst::TChar* string /*in*/, Vst::NoteExpressionValue& valueNormalized /*out*/)
+tresult ClapAsVst3::getNoteExpressionValueByString(int32 busIndex, int16 channel,
+                                                   Vst::NoteExpressionTypeID id,
+                                                   const Vst::TChar* string /*in*/,
+                                                   Vst::NoteExpressionValue& valueNormalized /*out*/)
 {
   return _noteExpressions.getNoteExpressionValueByString(id, string, valueNormalized);
 }
@@ -321,12 +339,13 @@ tresult ClapAsVst3::getNoteExpressionValueByString(int32 busIndex, int16 channel
 
 static Vst::SpeakerArrangement speakerArrFromPortType(const char* port_type)
 {
-  static const std::pair<const char*, Vst::SpeakerArrangement> arrangementmap[] = {{CLAP_PORT_MONO, Vst::SpeakerArr::kMono},
-                                                                                   {CLAP_PORT_STEREO, Vst::SpeakerArr::kStereo},
-                                                                                   // {CLAP_PORT_AMBISONIC, Vst::SpeakerArr::kAmbi1stOrderACN} <- we need also CLAP_EXT_AMBISONIC
-                                                                                   // {CLAP_PORT_SURROUND, Vst::SpeakerArr::kStereoSurround}, // add when CLAP_EXT_SURROUND is not draft anymore
-                                                                                   // TODO: add more PortTypes to Speaker Arrangement
-                                                                                   {nullptr, Vst::SpeakerArr::kEmpty}};
+  static const std::pair<const char*, Vst::SpeakerArrangement> arrangementmap[] = {
+      {CLAP_PORT_MONO, Vst::SpeakerArr::kMono},
+      {CLAP_PORT_STEREO, Vst::SpeakerArr::kStereo},
+      // {CLAP_PORT_AMBISONIC, Vst::SpeakerArr::kAmbi1stOrderACN} <- we need also CLAP_EXT_AMBISONIC
+      // {CLAP_PORT_SURROUND, Vst::SpeakerArr::kStereoSurround}, // add when CLAP_EXT_SURROUND is not draft anymore
+      // TODO: add more PortTypes to Speaker Arrangement
+      {nullptr, Vst::SpeakerArr::kEmpty}};
 
   auto p = &arrangementmap[0];
   while (p->first)
@@ -360,7 +379,8 @@ void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t* info, bool is_inp
 
 void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t* info, uint32_t index, bool is_input)
 {
-  if ((info->supported_dialects & CLAP_NOTE_DIALECT_MIDI) || (info->supported_dialects & CLAP_NOTE_DIALECT_CLAP))
+  if ((info->supported_dialects & CLAP_NOTE_DIALECT_MIDI) ||
+      (info->supported_dialects & CLAP_NOTE_DIALECT_CLAP))
   {
     auto numchannels = 16;
     if (_vst3specifics)
@@ -493,7 +513,8 @@ bool ClapAsVst3::checkMIDIDialectSupport()
   return false;
 }
 
-void ClapAsVst3::setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin_audio_ports_t* audioports)
+void ClapAsVst3::setupAudioBusses(const clap_plugin_t* plugin,
+                                  const clap_plugin_audio_ports_t* audioports)
 {
   if (!audioports) return;
   auto numAudioInputs = audioports->count(plugin, true);
@@ -561,7 +582,8 @@ void ClapAsVst3::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
 
   {
     Vst::String128 rootname(STR16("root"));
-    Vst::Unit* newunit = new Vst::Unit(rootname, Vst::kNoParentUnitId, Vst::kRootUnitId);  // a new unit without a program list
+    Vst::Unit* newunit = new Vst::Unit(rootname, Vst::kNoParentUnitId,
+                                       Vst::kRootUnitId);  // a new unit without a program list
     addUnit(newunit);
   }
 
@@ -573,7 +595,8 @@ void ClapAsVst3::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
     clap_param_info info;
     if (params->get_info(plugin, i, &info))
     {
-      auto p = Vst3Parameter::create(&info, [&](const char* modstring) { return this->getOrCreateUnitInfo(modstring); });
+      auto p = Vst3Parameter::create(
+          &info, [&](const char* modstring) { return this->getOrCreateUnitInfo(modstring); });
       // auto p = Vst3Parameter::create(&info,nullptr);
       parameters.addParameter(p);
     }
@@ -605,19 +628,32 @@ void ClapAsVst3::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
 
   // setting up noteexpression
 
-  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_VOLUME) _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kVolumeTypeID, S16("Volume"), S16("Vol"), S16(""), 0, nullptr, 0));
-  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PAN) _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kPanTypeID, S16("Panorama"), S16("Pan"), S16(""), 0, nullptr, 0));
+  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_VOLUME)
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
+        Vst::NoteExpressionTypeIDs::kVolumeTypeID, S16("Volume"), S16("Vol"), S16(""), 0, nullptr, 0));
+  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PAN)
 
-  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING) _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kTuningTypeID, S16("Tuning"), S16("Tun"), S16(""), 0, nullptr, 0));
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
+        Vst::NoteExpressionTypeIDs::kPanTypeID, S16("Panorama"), S16("Pan"), S16(""), 0, nullptr, 0));
+
+  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING)
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
+        Vst::NoteExpressionTypeIDs::kTuningTypeID, S16("Tuning"), S16("Tun"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_VIBRATO)
-    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kVibratoTypeID, S16("Vibrato"), S16("Vibr"), S16(""), 0, nullptr, 0));
+    _noteExpressions.addNoteExpressionType(
+        new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kVibratoTypeID, S16("Vibrato"),
+                                    S16("Vibr"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_EXPRESSION)
-    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kExpressionTypeID, S16("Expression"), S16("Expr"), S16(""), 0, nullptr, 0));
+    _noteExpressions.addNoteExpressionType(
+        new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kExpressionTypeID, S16("Expression"),
+                                    S16("Expr"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_BRIGHTNESS)
-    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kBrightnessTypeID, S16("Brightness"), S16("Brit"), S16(""), 0, nullptr, 0));
+    _noteExpressions.addNoteExpressionType(
+        new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kBrightnessTypeID, S16("Brightness"),
+                                    S16("Brit"), S16(""), 0, nullptr, 0));
 
   // PRESSURE is handled by IMidiMapping (-> Polypressure)
 }
@@ -631,8 +667,11 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
     vstflags |= Vst::RestartFlags::kMidiCCAssignmentChanged;
   }
 
-  vstflags |= ((flags & CLAP_PARAM_RESCAN_VALUES) ? (uint32_t)Vst::RestartFlags::kParamValuesChanged : 0u);
-  vstflags |= ((flags & CLAP_PARAM_RESCAN_INFO) ? Vst::RestartFlags::kParamValuesChanged | Vst::RestartFlags::kParamTitlesChanged : 0u);
+  vstflags |=
+      ((flags & CLAP_PARAM_RESCAN_VALUES) ? (uint32_t)Vst::RestartFlags::kParamValuesChanged : 0u);
+  vstflags |= ((flags & CLAP_PARAM_RESCAN_INFO)
+                   ? Vst::RestartFlags::kParamValuesChanged | Vst::RestartFlags::kParamTitlesChanged
+                   : 0u);
   if (vstflags != 0)
   {
     // update parameter values in our own tree
@@ -692,7 +731,8 @@ bool ClapAsVst3::gui_request_hide()
 
 void ClapAsVst3::latency_changed()
 {
-  if (this->componentHandler) this->componentHandler->restartComponent(Vst::RestartFlags::kLatencyChanged);
+  if (this->componentHandler)
+    this->componentHandler->restartComponent(Vst::RestartFlags::kLatencyChanged);
 }
 
 void ClapAsVst3::tail_changed()
@@ -825,7 +865,8 @@ void ClapAsVst3::onIdle()
     {
       // setup a ProcessAdapter just for flush with no audio
       Clap::ProcessAdapter pa;
-      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0, this->parameters, componentHandler, nullptr, false, false);
+      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0,
+                         this->parameters, componentHandler, nullptr, false, false);
       pa.flush();
     }
   }
@@ -994,7 +1035,8 @@ struct FDHandler : Steinberg::Linux::IEventHandler, public Steinberg::FObject
   ClapAsVst3* _parent{nullptr};
   int _fd{0};
   clap_posix_fd_flags_t _flags{};
-  FDHandler(ClapAsVst3* parent, int fd, clap_posix_fd_flags_t flags) : _parent(parent), _fd(fd), _flags(flags)
+  FDHandler(ClapAsVst3* parent, int fd, clap_posix_fd_flags_t flags)
+      : _parent(parent), _fd(fd), _flags(flags)
   {
   }
   void PLUGIN_API onFDIsSet(Steinberg::Linux::FileDescriptor) override

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -13,7 +13,7 @@
 
 #if WIN
 #include <tchar.h>
-#define S16(x) reinterpret_cast<const Steinberg::Vst::TChar *>(_T(x))
+#define S16(x) reinterpret_cast<const Steinberg::Vst::TChar*>(_T(x))
 #endif
 #if MAC
 #define S16(x) u##x
@@ -24,12 +24,12 @@
 
 struct ClapHostExtensions
 {
-  static inline ClapAsVst3 *self(const clap_host_t *host) { return static_cast<ClapAsVst3 *>(host->host_data); }
-  static void mark_dirty(const clap_host_t *host) { self(host)->mark_dirty(); }
+  static inline ClapAsVst3* self(const clap_host_t* host) { return static_cast<ClapAsVst3*>(host->host_data); }
+  static void mark_dirty(const clap_host_t* host) { self(host)->mark_dirty(); }
   const clap_host_state_t _state = {mark_dirty};
 };
 
-tresult PLUGIN_API ClapAsVst3::initialize(FUnknown *context)
+tresult PLUGIN_API ClapAsVst3::initialize(FUnknown* context)
 {
   auto result = super::initialize(context);
   if (result == kResultOk)
@@ -64,10 +64,8 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
 {
   if (state)
   {
-    if (_active)
-      return kResultFalse;
-    if (!_plugin->activate())
-      return kResultFalse;
+    if (_active) return kResultFalse;
+    if (!_plugin->activate()) return kResultFalse;
     _active = true;
     _processAdapter = new Clap::ProcessAdapter();
 
@@ -75,10 +73,8 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
 
     // the processAdapter needs to know a few things to intercommunicate between VST3 host and CLAP plugin.
 
-    _processAdapter->setupProcessing(_plugin->_plugin, _plugin->_ext._params, this->audioInputs, this->audioOutputs,
-                                     this->_largestBlocksize, this->eventInputs.size(), this->eventOutputs.size(),
-                                     parameters, componentHandler, this, supportsnoteexpression,
-                                     _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
+    _processAdapter->setupProcessing(_plugin->_plugin, _plugin->_ext._params, this->audioInputs, this->audioOutputs, this->_largestBlocksize, this->eventInputs.size(), this->eventOutputs.size(), parameters, componentHandler, this,
+                                     supportsnoteexpression, _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
     updateAudioBusses();
 
     os::attach(this);
@@ -97,7 +93,7 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
   return super::setActive(state);
 }
 
-tresult PLUGIN_API ClapAsVst3::process(Vst::ProcessData &data)
+tresult PLUGIN_API ClapAsVst3::process(Vst::ProcessData& data)
 {
   auto thisFn = _plugin->AlwaysAudioThread();
   this->_processAdapter->process(data);
@@ -113,15 +109,9 @@ tresult PLUGIN_API ClapAsVst3::canProcessSampleSize(int32 symbolicSampleSize)
   return kResultOk;
 }
 
-tresult PLUGIN_API ClapAsVst3::setState(IBStream *state)
-{
-  return (_plugin->load(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
-}
+tresult PLUGIN_API ClapAsVst3::setState(IBStream* state) { return (_plugin->load(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse); }
 
-tresult PLUGIN_API ClapAsVst3::getState(IBStream *state)
-{
-  return (_plugin->save(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
-}
+tresult PLUGIN_API ClapAsVst3::getState(IBStream* state) { return (_plugin->save(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse); }
 
 uint32 PLUGIN_API ClapAsVst3::getLatencySamples()
 {
@@ -140,14 +130,13 @@ uint32 PLUGIN_API ClapAsVst3::getTailSamples()
     auto tailsize = this->_plugin->_ext._tail->get(_plugin->_plugin);
 
     // Any value greater or equal to INT32_MAX implies infinite tail.
-    if (tailsize >= INT32_MAX)
-      return Vst::kInfiniteTail;
+    if (tailsize >= INT32_MAX) return Vst::kInfiniteTail;
     return tailsize;
   }
   return super::getTailSamples();
 }
 
-tresult PLUGIN_API ClapAsVst3::setupProcessing(Vst::ProcessSetup &newSetup)
+tresult PLUGIN_API ClapAsVst3::setupProcessing(Vst::ProcessSetup& newSetup)
 {
   if (newSetup.symbolicSampleSize != Vst::kSample32)
   {
@@ -185,18 +174,11 @@ tresult PLUGIN_API ClapAsVst3::setProcessing(TBool state)
   return result;
 }
 
-tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement *inputs, int32 numIns,
-                                                  Vst::SpeakerArrangement *outputs, int32 numOuts)
-{
-  return super::setBusArrangements(inputs, numIns, outputs, numOuts);
-};
+tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns, Vst::SpeakerArrangement* outputs, int32 numOuts) { return super::setBusArrangements(inputs, numIns, outputs, numOuts); };
 
-tresult PLUGIN_API ClapAsVst3::getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement &arr)
-{
-  return super::getBusArrangement(dir, index, arr);
-}
+tresult PLUGIN_API ClapAsVst3::getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement& arr) { return super::getBusArrangement(dir, index, arr); }
 
-IPlugView *PLUGIN_API ClapAsVst3::createView(FIDString name)
+IPlugView* PLUGIN_API ClapAsVst3::createView(FIDString name)
 {
   if (_plugin->_ext._gui)
   {
@@ -218,7 +200,7 @@ IPlugView *PLUGIN_API ClapAsVst3::createView(FIDString name)
           attachTimers(_wrappedview->getRunLoop());
           attachPosixFD(_wrappedview->getRunLoop());
 #else
-          (void)this; // silence warning on non-linux
+          (void)this;  // silence warning on non-linux
 #endif
         });
     return _wrappedview;
@@ -226,10 +208,9 @@ IPlugView *PLUGIN_API ClapAsVst3::createView(FIDString name)
   return nullptr;
 }
 
-tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized,
-                                                     Vst::String128 string)
+tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized, Vst::String128 string)
 {
-  auto param = (Vst3Parameter *)this->getParameterObject(id);
+  auto param = (Vst3Parameter*)this->getParameterObject(id);
   auto val = param->asClapValue(valueNormalized);
 
   char outbuf[128];
@@ -244,10 +225,9 @@ tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::Param
   return super::getParamStringByValue(id, valueNormalized, string);
 }
 
-tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar *string,
-                                                     Vst::ParamValue &valueNormalized)
+tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar* string, Vst::ParamValue& valueNormalized)
 {
-  auto param = (Vst3Parameter *)this->getParameterObject(id);
+  auto param = (Vst3Parameter*)this->getParameterObject(id);
   Steinberg::String m(string);
   char inbuf[128];
   m.copyTo8(inbuf, 0, 128);
@@ -260,19 +240,14 @@ tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar
   return Steinberg::kResultFalse;
 }
 
-tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index, TBool state)
-{
-  return super::activateBus(type, dir, index, state);
-}
+tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index, TBool state) { return super::activateBus(type, dir, index, state); }
 
 //-----------------------------------------------------------------------------
 
-tresult PLUGIN_API ClapAsVst3::getMidiControllerAssignment(int32 busIndex, int16 channel,
-                                                           Vst::CtrlNumber midiControllerNumber,
-                                                           Vst::ParamID &id /*out*/)
+tresult PLUGIN_API ClapAsVst3::getMidiControllerAssignment(int32 busIndex, int16 channel, Vst::CtrlNumber midiControllerNumber, Vst::ParamID& id /*out*/)
 {
   // for my first Event bus and for MIDI channel 0 and for MIDI CC Volume only
-  if (busIndex == 0) // && channel == 0) // && midiControllerNumber == Vst::kCtrlVolume)
+  if (busIndex == 0)  // && channel == 0) // && midiControllerNumber == Vst::kCtrlVolume)
   {
     id = _IMidiMappingIDs[channel][midiControllerNumber];
     return kResultTrue;
@@ -293,8 +268,7 @@ int32 ClapAsVst3::getNoteExpressionCount(int32 busIndex, int16 channel)
 }
 
 /** Returns note change type info. */
-tresult ClapAsVst3::getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex,
-                                          Vst::NoteExpressionTypeInfo &info /*out*/)
+tresult ClapAsVst3::getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex, Vst::NoteExpressionTypeInfo& info /*out*/)
 {
   if (busIndex == 0 && channel == 0)
   {
@@ -304,17 +278,13 @@ tresult ClapAsVst3::getNoteExpressionInfo(int32 busIndex, int16 channel, int32 n
 }
 
 /** Gets a user readable representation of the normalized note change value. */
-tresult ClapAsVst3::getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id,
-                                                   Vst::NoteExpressionValue valueNormalized /*in*/,
-                                                   Vst::String128 string /*out*/)
+tresult ClapAsVst3::getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, Vst::NoteExpressionValue valueNormalized /*in*/, Vst::String128 string /*out*/)
 {
   return _noteExpressions.getNoteExpressionStringByValue(id, valueNormalized, string);
 }
 
 /** Converts the user readable representation to the normalized note change value. */
-tresult ClapAsVst3::getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id,
-                                                   const Vst::TChar *string /*in*/,
-                                                   Vst::NoteExpressionValue &valueNormalized /*out*/)
+tresult ClapAsVst3::getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, const Vst::TChar* string /*in*/, Vst::NoteExpressionValue& valueNormalized /*out*/)
 {
   return _noteExpressions.getNoteExpressionValueByString(id, string, valueNormalized);
 }
@@ -322,21 +292,20 @@ tresult ClapAsVst3::getNoteExpressionValueByString(int32 busIndex, int16 channel
 #endif
 
 ////-----------------------------------------------------------------------------
-// tresult PLUGIN_API ClapAsVst3::queryInterface(const TUID iid, void** obj)
+//tresult PLUGIN_API ClapAsVst3::queryInterface(const TUID iid, void** obj)
 //{
 //	  DEF_INTERFACE(IMidiMapping)
 //		return SingleComponentEffect::queryInterface(iid, obj);
-// }
+//}
 
-static Vst::SpeakerArrangement speakerArrFromPortType(const char *port_type)
+static Vst::SpeakerArrangement speakerArrFromPortType(const char* port_type)
 {
-  static const std::pair<const char *, Vst::SpeakerArrangement> arrangementmap[] = {
-      {CLAP_PORT_MONO, Vst::SpeakerArr::kMono},
-      {CLAP_PORT_STEREO, Vst::SpeakerArr::kStereo},
-      // {CLAP_PORT_AMBISONIC, Vst::SpeakerArr::kAmbi1stOrderACN} <- we need also CLAP_EXT_AMBISONIC
-      // {CLAP_PORT_SURROUND, Vst::SpeakerArr::kStereoSurround}, // add when CLAP_EXT_SURROUND is not draft anymore
-      // TODO: add more PortTypes to Speaker Arrangement
-      {nullptr, Vst::SpeakerArr::kEmpty}};
+  static const std::pair<const char*, Vst::SpeakerArrangement> arrangementmap[] = {{CLAP_PORT_MONO, Vst::SpeakerArr::kMono},
+                                                                                   {CLAP_PORT_STEREO, Vst::SpeakerArr::kStereo},
+                                                                                   // {CLAP_PORT_AMBISONIC, Vst::SpeakerArr::kAmbi1stOrderACN} <- we need also CLAP_EXT_AMBISONIC
+                                                                                   // {CLAP_PORT_SURROUND, Vst::SpeakerArr::kStereoSurround}, // add when CLAP_EXT_SURROUND is not draft anymore
+                                                                                   // TODO: add more PortTypes to Speaker Arrangement
+                                                                                   {nullptr, Vst::SpeakerArr::kEmpty}};
 
   auto p = &arrangementmap[0];
   while (p->first)
@@ -351,7 +320,7 @@ static Vst::SpeakerArrangement speakerArrFromPortType(const char *port_type)
   return Vst::SpeakerArr::kEmpty;
 }
 
-void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t *info, bool is_input)
+void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t* info, bool is_input)
 {
   auto spk = speakerArrFromPortType(info->port_type);
   auto bustype = (info->flags & CLAP_AUDIO_PORT_IS_MAIN) ? Vst::BusTypes::kMain : Vst::BusTypes::kAux;
@@ -368,7 +337,7 @@ void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t *info, bool is_inp
   }
 }
 
-void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input)
+void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t* info, uint32_t index, bool is_input)
 {
   if ((info->supported_dialects & CLAP_NOTE_DIALECT_MIDI) || (info->supported_dialects & CLAP_NOTE_DIALECT_CLAP))
   {
@@ -403,7 +372,7 @@ void ClapAsVst3::updateAudioBusses()
   }
 }
 
-static std::vector<std::string> split(const std::string &s, char delimiter)
+static std::vector<std::string> split(const std::string& s, char delimiter)
 {
   std::vector<std::string> tokens;
   std::string token;
@@ -415,7 +384,7 @@ static std::vector<std::string> split(const std::string &s, char delimiter)
   return tokens;
 }
 
-Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char *modulename)
+Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char* modulename)
 {
   // lookup the modulename fast and return the unitID
   auto loc = _moduleToUnit.find(modulename);
@@ -434,7 +403,7 @@ Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char *modulename)
   // we will ensure that it is being created one by one
   auto path = split(modulename, '/');
   std::string curpath;
-  Vst::UnitID id = Vst::kRootUnitId; // there is already a root element
+  Vst::UnitID id = Vst::kRootUnitId;  // there is already a root element
   size_t i = 0;
   while (path.size() > i)
   {
@@ -457,7 +426,7 @@ Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char *modulename)
       if (VST3::StringConvert::convert(u8name, name))
       {
         Vst::UnitID newid = static_cast<Steinberg::int32>(units.size());
-        Vst::Unit *newunit = new Vst::Unit(name, newid, id); // a new unit without a program list
+        Vst::Unit* newunit = new Vst::Unit(name, newid, id);  // a new unit without a program list
         addUnit(newunit);
         _moduleToUnit[u8name] = newid;
         id = newid;
@@ -470,9 +439,9 @@ Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char *modulename)
 
 // Clap::IHost
 
-void ClapAsVst3::setupWrapperSpecifics(const clap_plugin_t *plugin)
+void ClapAsVst3::setupWrapperSpecifics(const clap_plugin_t* plugin)
 {
-  _vst3specifics = (clap_plugin_as_vst3_t *)plugin->get_extension(plugin, CLAP_PLUGIN_AS_VST3);
+  _vst3specifics = (clap_plugin_as_vst3_t*)plugin->get_extension(plugin, CLAP_PLUGIN_AS_VST3);
   if (_vst3specifics)
   {
     _numMidiChannels = _vst3specifics->getNumMIDIChannels(_plugin->_plugin, 0);
@@ -503,10 +472,9 @@ bool ClapAsVst3::checkMIDIDialectSupport()
   return false;
 }
 
-void ClapAsVst3::setupAudioBusses(const clap_plugin_t *plugin, const clap_plugin_audio_ports_t *audioports)
+void ClapAsVst3::setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin_audio_ports_t* audioports)
 {
-  if (!audioports)
-    return;
+  if (!audioports) return;
   auto numAudioInputs = audioports->count(plugin, true);
   auto numAudioOutputs = audioports->count(plugin, false);
 
@@ -530,10 +498,9 @@ void ClapAsVst3::setupAudioBusses(const clap_plugin_t *plugin, const clap_plugin
   }
 }
 
-void ClapAsVst3::setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_note_ports_t *noteports)
+void ClapAsVst3::setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports)
 {
-  if (!noteports)
-    return;
+  if (!noteports) return;
   auto numMIDIInPorts = noteports->count(plugin, true);
   auto numMIDIOutPorts = noteports->count(plugin, false);
 
@@ -563,10 +530,9 @@ void ClapAsVst3::setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_
   }
 }
 
-void ClapAsVst3::setupParameters(const clap_plugin_t *plugin, const clap_plugin_params_t *params)
+void ClapAsVst3::setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params)
 {
-  if (!params)
-    return;
+  if (!params) return;
 
   // clear the units, they will be rebuild during the parameter conversion
   _moduleToUnit.clear();
@@ -574,8 +540,7 @@ void ClapAsVst3::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
 
   {
     Vst::String128 rootname(STR16("root"));
-    Vst::Unit *newunit =
-        new Vst::Unit(rootname, Vst::kNoParentUnitId, Vst::kRootUnitId); // a new unit without a program list
+    Vst::Unit* newunit = new Vst::Unit(rootname, Vst::kNoParentUnitId, Vst::kRootUnitId);  // a new unit without a program list
     addUnit(newunit);
   }
 
@@ -587,8 +552,7 @@ void ClapAsVst3::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
     clap_param_info info;
     if (params->get_info(plugin, i, &info))
     {
-      auto p =
-          Vst3Parameter::create(&info, [&](const char *modstring) { return this->getOrCreateUnitInfo(modstring); });
+      auto p = Vst3Parameter::create(&info, [&](const char* modstring) { return this->getOrCreateUnitInfo(modstring); });
       // auto p = Vst3Parameter::create(&info,nullptr);
       parameters.addParameter(p);
     }
@@ -620,29 +584,19 @@ void ClapAsVst3::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
 
   // setting up noteexpression
 
-  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_VOLUME)
-    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
-        Vst::NoteExpressionTypeIDs::kVolumeTypeID, S16("Volume"), S16("Vol"), S16(""), 0, nullptr, 0));
-  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PAN)
+  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_VOLUME) _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kVolumeTypeID, S16("Volume"), S16("Vol"), S16(""), 0, nullptr, 0));
+  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PAN) _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kPanTypeID, S16("Panorama"), S16("Pan"), S16(""), 0, nullptr, 0));
 
-    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
-        Vst::NoteExpressionTypeIDs::kPanTypeID, S16("Panorama"), S16("Pan"), S16(""), 0, nullptr, 0));
-
-  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING)
-    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
-        Vst::NoteExpressionTypeIDs::kTuningTypeID, S16("Tuning"), S16("Tun"), S16(""), 0, nullptr, 0));
+  if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING) _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kTuningTypeID, S16("Tuning"), S16("Tun"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_VIBRATO)
-    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
-        Vst::NoteExpressionTypeIDs::kVibratoTypeID, S16("Vibrato"), S16("Vibr"), S16(""), 0, nullptr, 0));
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kVibratoTypeID, S16("Vibrato"), S16("Vibr"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_EXPRESSION)
-    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
-        Vst::NoteExpressionTypeIDs::kExpressionTypeID, S16("Expression"), S16("Expr"), S16(""), 0, nullptr, 0));
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kExpressionTypeID, S16("Expression"), S16("Expr"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_BRIGHTNESS)
-    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
-        Vst::NoteExpressionTypeIDs::kBrightnessTypeID, S16("Brightness"), S16("Brit"), S16(""), 0, nullptr, 0));
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kBrightnessTypeID, S16("Brightness"), S16("Brit"), S16(""), 0, nullptr, 0));
 
   // PRESSURE is handled by IMidiMapping (-> Polypressure)
 }
@@ -657,9 +611,7 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
   }
 
   vstflags |= ((flags & CLAP_PARAM_RESCAN_VALUES) ? (uint32_t)Vst::RestartFlags::kParamValuesChanged : 0u);
-  vstflags |= ((flags & CLAP_PARAM_RESCAN_INFO)
-                   ? Vst::RestartFlags::kParamValuesChanged | Vst::RestartFlags::kParamTitlesChanged
-                   : 0u);
+  vstflags |= ((flags & CLAP_PARAM_RESCAN_INFO) ? Vst::RestartFlags::kParamValuesChanged | Vst::RestartFlags::kParamTitlesChanged : 0u);
   if (vstflags != 0)
   {
     // update parameter values in our own tree
@@ -667,7 +619,7 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
     for (decltype(len) i = 0; i < len; ++i)
     {
       auto p = parameters.getParameterByIndex(i);
-      auto p1 = static_cast<Vst3Parameter *>(p);
+      auto p1 = static_cast<Vst3Parameter*>(p);
       if (!p1->isMidi)
       {
         double val;
@@ -696,15 +648,11 @@ bool ClapAsVst3::gui_can_resize()
   return (componentHandler2 != nullptr);
 }
 
-bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height)
-{
-  return _wrappedview->request_resize(width, height);
-}
+bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height) { return _wrappedview->request_resize(width, height); }
 
 bool ClapAsVst3::gui_request_show()
 {
-  if (componentHandler2)
-    return (componentHandler2->requestOpenEditor() == kResultOk);
+  if (componentHandler2) return (componentHandler2->requestOpenEditor() == kResultOk);
   return false;
 }
 
@@ -712,8 +660,7 @@ bool ClapAsVst3::gui_request_hide() { return false; }
 
 void ClapAsVst3::latency_changed()
 {
-  if (this->componentHandler)
-    this->componentHandler->restartComponent(Vst::RestartFlags::kLatencyChanged);
+  if (this->componentHandler) this->componentHandler->restartComponent(Vst::RestartFlags::kLatencyChanged);
 }
 
 void ClapAsVst3::tail_changed()
@@ -724,16 +671,14 @@ void ClapAsVst3::tail_changed()
 
 void ClapAsVst3::mark_dirty()
 {
-  if (componentHandler2)
-    componentHandler2->setDirty(true);
+  if (componentHandler2) componentHandler2->setDirty(true);
 }
 
 void ClapAsVst3::request_callback() { _requestUICallback = true; }
 
 void ClapAsVst3::restartPlugin()
 {
-  if (componentHandler)
-    componentHandler->restartComponent(Vst::RestartFlags::kReloadComponent);
+  if (componentHandler) componentHandler->restartComponent(Vst::RestartFlags::kReloadComponent);
 }
 
 void ClapAsVst3::onBeginEdit(clap_id id)
@@ -741,7 +686,7 @@ void ClapAsVst3::onBeginEdit(clap_id id)
   // receive beginEdit and pass it to the internal queue
   _queueToUI.push(beginEvent(id));
 }
-void ClapAsVst3::onPerformEdit(const clap_event_param_value_t *value)
+void ClapAsVst3::onPerformEdit(const clap_event_param_value_t* value)
 {
   // receive a value change and pass it to the internal queue
   _queueToUI.push(valueEvent(value));
@@ -749,7 +694,7 @@ void ClapAsVst3::onPerformEdit(const clap_event_param_value_t *value)
 void ClapAsVst3::onEndEdit(clap_id id) { _queueToUI.push(endEvent(id)); }
 
 // ext-timer
-bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id *timer_id)
+bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id* timer_id)
 {
   // restrict the timer to 30ms
   if (period_ms < 30)
@@ -760,7 +705,7 @@ bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id *timer_id)
   auto l = _timersObjects.size();
   for (decltype(l) i = 0; i < l; ++i)
   {
-    auto &to = _timersObjects[i];
+    auto& to = _timersObjects[i];
     if (to.period == 0)
     {
       // reuse timer object. Lets choose not to use 0 as a timer id, just
@@ -790,7 +735,7 @@ bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id *timer_id)
 }
 bool ClapAsVst3::unregister_timer(clap_id timer_id)
 {
-  for (auto &to : _timersObjects)
+  for (auto& to : _timersObjects)
   {
     if (to.timer_id == timer_id)
     {
@@ -817,19 +762,19 @@ void ClapAsVst3::onIdle()
   {
     switch (n._type)
     {
-    case queueEvent::type_t::editstart:
-      beginEdit(n._data._id);
+      case queueEvent::type_t::editstart:
+        beginEdit(n._data._id);
+        break;
+      case queueEvent::type_t::editvalue:
+      {
+        auto param = (Vst3Parameter*)(parameters.getParameter(n._data._value.param_id & 0x7FFFFFFF));
+        auto v = n._data._value.value;
+        performEdit(param->getInfo().id, param->asVst3Value(v));
+      }
       break;
-    case queueEvent::type_t::editvalue:
-    {
-      auto param = (Vst3Parameter *)(parameters.getParameter(n._data._value.param_id & 0x7FFFFFFF));
-      auto v = n._data._value.value;
-      performEdit(param->getInfo().id, param->asVst3Value(v));
-    }
-    break;
-    case queueEvent::type_t::editend:
-      endEdit(n._data._id);
-      break;
+      case queueEvent::type_t::editend:
+        endEdit(n._data._id);
+        break;
     }
   }
 
@@ -842,8 +787,7 @@ void ClapAsVst3::onIdle()
     {
       // setup a ProcessAdapter just for flush with no audio
       Clap::ProcessAdapter pa;
-      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0, this->parameters,
-                         componentHandler, nullptr, false, false);
+      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0, this->parameters, componentHandler, nullptr, false, false);
       pa.flush();
     }
   }
@@ -855,15 +799,15 @@ void ClapAsVst3::onIdle()
   }
 
 #if LIN
-  if (!_iRunLoop) // don't process timers if we have a runloop.
-                  // (but if we don't have a runloop on linux onIdle isn't called
-                  // anyway so consider just not having this at all once we decide
-                  // to do with the no UI case)
+  if (!_iRunLoop)  // don't process timers if we have a runloop.
+                   // (but if we don't have a runloop on linux onIdle isn't called
+                   // anyway so consider just not having this at all once we decide
+                   // to do with the no UI case)
 #endif
   {
     // handling timerobjects
     auto now = os::getTickInMS();
-    for (auto &&to : _timersObjects)
+    for (auto&& to : _timersObjects)
     {
       if (to.period > 0)
       {
@@ -880,9 +824,9 @@ void ClapAsVst3::onIdle()
 #if LIN
 struct TimerHandler : Steinberg::Linux::ITimerHandler, public Steinberg::FObject
 {
-  ClapAsVst3 *_parent{nullptr};
+  ClapAsVst3* _parent{nullptr};
   clap_id _timerId{0};
-  TimerHandler(ClapAsVst3 *parent, clap_id timerId) : _parent(parent), _timerId(timerId) {}
+  TimerHandler(ClapAsVst3* parent, clap_id timerId) : _parent(parent), _timerId(timerId) {}
   void PLUGIN_API onTimer() final { _parent->fireTimer(_timerId); }
   DELEGATE_REFCOUNT(Steinberg::FObject)
   DEFINE_INTERFACES
@@ -892,8 +836,8 @@ struct TimerHandler : Steinberg::Linux::ITimerHandler, public Steinberg::FObject
 
 struct IdleHandler : Steinberg::Linux::ITimerHandler, public Steinberg::FObject
 {
-  ClapAsVst3 *_parent{nullptr};
-  IdleHandler(ClapAsVst3 *parent) : _parent(parent) {}
+  ClapAsVst3* _parent{nullptr};
+  IdleHandler(ClapAsVst3* parent) : _parent(parent) {}
   void PLUGIN_API onTimer() final { _parent->onIdle(); }
   DELEGATE_REFCOUNT(Steinberg::FObject)
   DEFINE_INTERFACES
@@ -901,7 +845,7 @@ struct IdleHandler : Steinberg::Linux::ITimerHandler, public Steinberg::FObject
   END_DEFINE_INTERFACES(Steinberg::FObject)
 };
 
-void ClapAsVst3::attachTimers(Steinberg::Linux::IRunLoop *r)
+void ClapAsVst3::attachTimers(Steinberg::Linux::IRunLoop* r)
 {
   if (r)
   {
@@ -917,7 +861,7 @@ void ClapAsVst3::attachTimers(Steinberg::Linux::IRunLoop *r)
     }
     _iRunLoop->registerTimer(_idleHandler.get(), 30);
 
-    for (auto &t : _timersObjects)
+    for (auto& t : _timersObjects)
     {
       if (!t.handler)
       {
@@ -928,7 +872,7 @@ void ClapAsVst3::attachTimers(Steinberg::Linux::IRunLoop *r)
   }
 }
 
-void ClapAsVst3::detachTimers(Steinberg::Linux::IRunLoop *r)
+void ClapAsVst3::detachTimers(Steinberg::Linux::IRunLoop* r)
 {
   if (r && r == _iRunLoop)
   {
@@ -937,7 +881,7 @@ void ClapAsVst3::detachTimers(Steinberg::Linux::IRunLoop *r)
       _iRunLoop->unregisterTimer(_idleHandler.get());
       _idleHandler.reset();
     }
-    for (auto &t : _timersObjects)
+    for (auto& t : _timersObjects)
     {
       if (t.handler)
       {
@@ -959,7 +903,7 @@ bool ClapAsVst3::register_fd(int fd, clap_posix_fd_flags_t flags)
 bool ClapAsVst3::modify_fd(int fd, clap_posix_fd_flags_t flags)
 {
   bool res{false};
-  for (auto &p : _posixFDObjects)
+  for (auto& p : _posixFDObjects)
   {
     if (p.fd == fd)
     {
@@ -996,23 +940,23 @@ bool ClapAsVst3::unregister_fd(int fd)
 
 struct FDHandler : Steinberg::Linux::IEventHandler, public Steinberg::FObject
 {
-  ClapAsVst3 *_parent{nullptr};
+  ClapAsVst3* _parent{nullptr};
   int _fd{0};
   clap_posix_fd_flags_t _flags{};
-  FDHandler(ClapAsVst3 *parent, int fd, clap_posix_fd_flags_t flags) : _parent(parent), _fd(fd), _flags(flags) {}
+  FDHandler(ClapAsVst3* parent, int fd, clap_posix_fd_flags_t flags) : _parent(parent), _fd(fd), _flags(flags) {}
   void PLUGIN_API onFDIsSet(Steinberg::Linux::FileDescriptor) override { _parent->firePosixFDIsSet(_fd, _flags); }
   DELEGATE_REFCOUNT(Steinberg::FObject)
   DEFINE_INTERFACES
   DEF_INTERFACE(Steinberg::Linux::IEventHandler)
   END_DEFINE_INTERFACES(Steinberg::FObject)
 };
-void ClapAsVst3::attachPosixFD(Steinberg::Linux::IRunLoop *r)
+void ClapAsVst3::attachPosixFD(Steinberg::Linux::IRunLoop* r)
 {
   if (r)
   {
     _iRunLoop = r;
 
-    for (auto &p : _posixFDObjects)
+    for (auto& p : _posixFDObjects)
     {
       if (!p.handler)
       {
@@ -1023,11 +967,11 @@ void ClapAsVst3::attachPosixFD(Steinberg::Linux::IRunLoop *r)
   }
 }
 
-void ClapAsVst3::detachPosixFD(Steinberg::Linux::IRunLoop *r)
+void ClapAsVst3::detachPosixFD(Steinberg::Linux::IRunLoop* r)
 {
   if (r && r == _iRunLoop)
   {
-    for (auto &p : _posixFDObjects)
+    for (auto& p : _posixFDObjects)
     {
       if (p.handler)
       {
@@ -1038,8 +982,5 @@ void ClapAsVst3::detachPosixFD(Steinberg::Linux::IRunLoop *r)
   }
 }
 
-void ClapAsVst3::firePosixFDIsSet(int fd, clap_posix_fd_flags_t flags)
-{
-  _plugin->_ext._posixfd->on_fd(_plugin->_plugin, fd, flags);
-}
+void ClapAsVst3::firePosixFDIsSet(int fd, clap_posix_fd_flags_t flags) { _plugin->_ext._posixfd->on_fd(_plugin->_plugin, fd, flags); }
 #endif

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -13,27 +13,23 @@
 
 #if WIN
 #include <tchar.h>
-#define S16(x) reinterpret_cast<const Steinberg::Vst::TChar*>(_T(x))
+#define S16(x) reinterpret_cast<const Steinberg::Vst::TChar *>(_T(x))
 #endif
 #if MAC
-#define S16(x) u ## x
+#define S16(x) u##x
 #endif
 #if LIN
-#define S16(x) u ## x
+#define S16(x) u##x
 #endif
 
 struct ClapHostExtensions
 {
-  static inline ClapAsVst3* self(const clap_host_t* host)
-  {
-    return static_cast<ClapAsVst3*>(host->host_data);
-  }
-  static void mark_dirty(const clap_host_t* host) { self(host)->mark_dirty(); }
-  const clap_host_state_t _state = { mark_dirty };
+  static inline ClapAsVst3 *self(const clap_host_t *host) { return static_cast<ClapAsVst3 *>(host->host_data); }
+  static void mark_dirty(const clap_host_t *host) { self(host)->mark_dirty(); }
+  const clap_host_state_t _state = {mark_dirty};
 };
 
-
-tresult PLUGIN_API ClapAsVst3::initialize(FUnknown* context)
+tresult PLUGIN_API ClapAsVst3::initialize(FUnknown *context)
 {
   auto result = super::initialize(context);
   if (result == kResultOk)
@@ -43,14 +39,13 @@ tresult PLUGIN_API ClapAsVst3::initialize(FUnknown* context)
       _plugin = Clap::Plugin::createInstance(*_library, _libraryIndex, this);
     }
     result = (_plugin->initialize()) ? kResultOk : kResultFalse;
-    if ( result )
+    if (result)
     {
       _useIMidiMapping = checkMIDIDialectSupport();
     }
   }
   if (_plugin)
   {
-
   }
   return result;
 }
@@ -75,19 +70,17 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
       return kResultFalse;
     _active = true;
     _processAdapter = new Clap::ProcessAdapter();
-    
+
     auto supportsnoteexpression = (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PRESSURE);
 
     // the processAdapter needs to know a few things to intercommunicate between VST3 host and CLAP plugin.
 
-    _processAdapter->setupProcessing(_plugin->_plugin, _plugin->_ext._params,
-      this->audioInputs, this->audioOutputs,
-      this->_largestBlocksize,
-      this->eventInputs.size(), this->eventOutputs.size(),
-      parameters, componentHandler, this,
-      supportsnoteexpression, _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
+    _processAdapter->setupProcessing(_plugin->_plugin, _plugin->_ext._params, this->audioInputs, this->audioOutputs,
+                                     this->_largestBlocksize, this->eventInputs.size(), this->eventOutputs.size(),
+                                     parameters, componentHandler, this, supportsnoteexpression,
+                                     _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
     updateAudioBusses();
-    
+
     os::attach(this);
   }
   if (!state)
@@ -104,7 +97,7 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
   return super::setActive(state);
 }
 
-tresult PLUGIN_API ClapAsVst3::process(Vst::ProcessData& data)
+tresult PLUGIN_API ClapAsVst3::process(Vst::ProcessData &data)
 {
   auto thisFn = _plugin->AlwaysAudioThread();
   this->_processAdapter->process(data);
@@ -120,12 +113,12 @@ tresult PLUGIN_API ClapAsVst3::canProcessSampleSize(int32 symbolicSampleSize)
   return kResultOk;
 }
 
-tresult PLUGIN_API ClapAsVst3::setState(IBStream* state)
+tresult PLUGIN_API ClapAsVst3::setState(IBStream *state)
 {
   return (_plugin->load(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
 }
 
-tresult PLUGIN_API ClapAsVst3::getState(IBStream* state)
+tresult PLUGIN_API ClapAsVst3::getState(IBStream *state)
 {
   return (_plugin->save(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
 }
@@ -141,7 +134,7 @@ uint32 PLUGIN_API ClapAsVst3::getLatencySamples()
 
 uint32 PLUGIN_API ClapAsVst3::getTailSamples()
 {
-  // options would be kNoTail, number of samples or kInfiniteTail  
+  // options would be kNoTail, number of samples or kInfiniteTail
   if (this->_plugin->_ext._tail)
   {
     auto tailsize = this->_plugin->_ext._tail->get(_plugin->_plugin);
@@ -154,7 +147,7 @@ uint32 PLUGIN_API ClapAsVst3::getTailSamples()
   return super::getTailSamples();
 }
 
-tresult PLUGIN_API ClapAsVst3::setupProcessing(Vst::ProcessSetup& newSetup)
+tresult PLUGIN_API ClapAsVst3::setupProcessing(Vst::ProcessSetup &newSetup)
 {
   if (newSetup.symbolicSampleSize != Vst::kSample32)
   {
@@ -192,19 +185,18 @@ tresult PLUGIN_API ClapAsVst3::setProcessing(TBool state)
   return result;
 }
 
-tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns,
-  Vst::SpeakerArrangement* outputs,
-  int32 numOuts)
+tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement *inputs, int32 numIns,
+                                                  Vst::SpeakerArrangement *outputs, int32 numOuts)
 {
   return super::setBusArrangements(inputs, numIns, outputs, numOuts);
 };
 
-tresult PLUGIN_API ClapAsVst3::getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement& arr)
+tresult PLUGIN_API ClapAsVst3::getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement &arr)
 {
   return super::getBusArrangement(dir, index, arr);
 }
 
-IPlugView* PLUGIN_API ClapAsVst3::createView(FIDString name)
+IPlugView *PLUGIN_API ClapAsVst3::createView(FIDString name)
 {
   if (_plugin->_ext._gui)
   {
@@ -234,9 +226,10 @@ IPlugView* PLUGIN_API ClapAsVst3::createView(FIDString name)
   return nullptr;
 }
 
-tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized, Vst::String128 string)
+tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized,
+                                                     Vst::String128 string)
 {
-  auto param = (Vst3Parameter*)this->getParameterObject(id);
+  auto param = (Vst3Parameter *)this->getParameterObject(id);
   auto val = param->asClapValue(valueNormalized);
 
   char outbuf[128];
@@ -244,16 +237,17 @@ tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::Param
   if (this->_plugin->_ext._params->value_to_text(_plugin->_plugin, param->id, val, outbuf, 127))
   {
     UString wrapper(&string[0], str16BufferSize(Steinberg::Vst::String128));
-    
-    wrapper.assign(outbuf,sizeof(outbuf));
+
+    wrapper.assign(outbuf, sizeof(outbuf));
     return kResultOk;
   }
   return super::getParamStringByValue(id, valueNormalized, string);
 }
 
-tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar* string, Vst::ParamValue& valueNormalized)
+tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar *string,
+                                                     Vst::ParamValue &valueNormalized)
 {
-  auto param = (Vst3Parameter*)this->getParameterObject(id);
+  auto param = (Vst3Parameter *)this->getParameterObject(id);
   Steinberg::String m(string);
   char inbuf[128];
   m.copyTo8(inbuf, 0, 128);
@@ -264,7 +258,6 @@ tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar
     return kResultOk;
   }
   return Steinberg::kResultFalse;
- 
 }
 
 tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index, TBool state)
@@ -275,10 +268,11 @@ tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirectio
 //-----------------------------------------------------------------------------
 
 tresult PLUGIN_API ClapAsVst3::getMidiControllerAssignment(int32 busIndex, int16 channel,
-  Vst::CtrlNumber midiControllerNumber, Vst::ParamID& id/*out*/)
+                                                           Vst::CtrlNumber midiControllerNumber,
+                                                           Vst::ParamID &id /*out*/)
 {
   // for my first Event bus and for MIDI channel 0 and for MIDI CC Volume only
-  if (busIndex == 0 ) // && channel == 0) // && midiControllerNumber == Vst::kCtrlVolume)
+  if (busIndex == 0) // && channel == 0) // && midiControllerNumber == Vst::kCtrlVolume)
   {
     id = _IMidiMappingIDs[channel][midiControllerNumber];
     return kResultTrue;
@@ -288,7 +282,7 @@ tresult PLUGIN_API ClapAsVst3::getMidiControllerAssignment(int32 busIndex, int16
 
 #if 1
 //----from INoteExpressionController-------------------------
-  /** Returns number of supported note change types for event bus index and channel. */
+/** Returns number of supported note change types for event bus index and channel. */
 int32 ClapAsVst3::getNoteExpressionCount(int32 busIndex, int16 channel)
 {
   if (busIndex == 0 && channel == 0)
@@ -296,11 +290,11 @@ int32 ClapAsVst3::getNoteExpressionCount(int32 busIndex, int16 channel)
     return _noteExpressions.getNoteExpressionCount();
   }
   return 0;
-  
 }
 
 /** Returns note change type info. */
-tresult ClapAsVst3::getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex, Vst::NoteExpressionTypeInfo& info /*out*/)
+tresult ClapAsVst3::getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex,
+                                          Vst::NoteExpressionTypeInfo &info /*out*/)
 {
   if (busIndex == 0 && channel == 0)
   {
@@ -310,37 +304,39 @@ tresult ClapAsVst3::getNoteExpressionInfo(int32 busIndex, int16 channel, int32 n
 }
 
 /** Gets a user readable representation of the normalized note change value. */
-tresult ClapAsVst3::getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, Vst::NoteExpressionValue valueNormalized /*in*/, Vst::String128 string /*out*/)
+tresult ClapAsVst3::getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id,
+                                                   Vst::NoteExpressionValue valueNormalized /*in*/,
+                                                   Vst::String128 string /*out*/)
 {
   return _noteExpressions.getNoteExpressionStringByValue(id, valueNormalized, string);
 }
 
 /** Converts the user readable representation to the normalized note change value. */
-tresult ClapAsVst3::getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, const Vst::TChar* string /*in*/, Vst::NoteExpressionValue& valueNormalized /*out*/) 
+tresult ClapAsVst3::getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id,
+                                                   const Vst::TChar *string /*in*/,
+                                                   Vst::NoteExpressionValue &valueNormalized /*out*/)
 {
-  return _noteExpressions.getNoteExpressionValueByString(id, string,  valueNormalized);
+  return _noteExpressions.getNoteExpressionValueByString(id, string, valueNormalized);
 }
 
 #endif
 
 ////-----------------------------------------------------------------------------
-//tresult PLUGIN_API ClapAsVst3::queryInterface(const TUID iid, void** obj)
+// tresult PLUGIN_API ClapAsVst3::queryInterface(const TUID iid, void** obj)
 //{
 //	  DEF_INTERFACE(IMidiMapping)
 //		return SingleComponentEffect::queryInterface(iid, obj);
-//}
+// }
 
-static Vst::SpeakerArrangement speakerArrFromPortType(const char* port_type)
+static Vst::SpeakerArrangement speakerArrFromPortType(const char *port_type)
 {
-  static const std::pair<const char*, Vst::SpeakerArrangement> arrangementmap[] =
-  {
-    {CLAP_PORT_MONO, Vst::SpeakerArr::kMono},
-    {CLAP_PORT_STEREO, Vst::SpeakerArr::kStereo},
-    // {CLAP_PORT_AMBISONIC, Vst::SpeakerArr::kAmbi1stOrderACN} <- we need also CLAP_EXT_AMBISONIC
-    // {CLAP_PORT_SURROUND, Vst::SpeakerArr::kStereoSurround}, // add when CLAP_EXT_SURROUND is not draft anymore
-    // TODO: add more PortTypes to Speaker Arrangement
-    {nullptr,Vst::SpeakerArr::kEmpty}
-  };
+  static const std::pair<const char *, Vst::SpeakerArrangement> arrangementmap[] = {
+      {CLAP_PORT_MONO, Vst::SpeakerArr::kMono},
+      {CLAP_PORT_STEREO, Vst::SpeakerArr::kStereo},
+      // {CLAP_PORT_AMBISONIC, Vst::SpeakerArr::kAmbi1stOrderACN} <- we need also CLAP_EXT_AMBISONIC
+      // {CLAP_PORT_SURROUND, Vst::SpeakerArr::kStereoSurround}, // add when CLAP_EXT_SURROUND is not draft anymore
+      // TODO: add more PortTypes to Speaker Arrangement
+      {nullptr, Vst::SpeakerArr::kEmpty}};
 
   auto p = &arrangementmap[0];
   while (p->first)
@@ -355,7 +351,7 @@ static Vst::SpeakerArrangement speakerArrFromPortType(const char* port_type)
   return Vst::SpeakerArr::kEmpty;
 }
 
-void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t* info, bool is_input)
+void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t *info, bool is_input)
 {
   auto spk = speakerArrFromPortType(info->port_type);
   auto bustype = (info->flags & CLAP_AUDIO_PORT_IS_MAIN) ? Vst::BusTypes::kMain : Vst::BusTypes::kAux;
@@ -370,11 +366,9 @@ void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t* info, bool is_inp
   {
     addAudioOutput(name16, spk, bustype, Vst::BusInfo::kDefaultActive);
   }
-
-
 }
 
-void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t* info, uint32_t index, bool is_input)
+void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input)
 {
   if ((info->supported_dialects & CLAP_NOTE_DIALECT_MIDI) || (info->supported_dialects & CLAP_NOTE_DIALECT_CLAP))
   {
@@ -399,18 +393,17 @@ void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t* info, uint32_t inde
 
 void ClapAsVst3::updateAudioBusses()
 {
-  for ( auto i = 0U; i < audioInputs.size() ; ++i)
+  for (auto i = 0U; i < audioInputs.size(); ++i)
   {
-    _processAdapter->activateAudioBus(Vst::kInput, i,audioInputs[i]->isActive());
+    _processAdapter->activateAudioBus(Vst::kInput, i, audioInputs[i]->isActive());
   }
   for (auto i = 0U; i < audioOutputs.size(); ++i)
   {
     _processAdapter->activateAudioBus(Vst::kOutput, i, audioOutputs[i]->isActive());
   }
-
 }
 
-static std::vector<std::string> split(const std::string& s, char delimiter)
+static std::vector<std::string> split(const std::string &s, char delimiter)
 {
   std::vector<std::string> tokens;
   std::string token;
@@ -422,7 +415,7 @@ static std::vector<std::string> split(const std::string& s, char delimiter)
   return tokens;
 }
 
-Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char* modulename)
+Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char *modulename)
 {
   // lookup the modulename fast and return the unitID
   auto loc = _moduleToUnit.find(modulename);
@@ -439,9 +432,9 @@ Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char* modulename)
 
   // the module name is not yet present as unit, so
   // we will ensure that it is being created one by one
-  auto path = split(modulename,'/');
+  auto path = split(modulename, '/');
   std::string curpath;
-  Vst::UnitID id = Vst::kRootUnitId;  // there is already a root element
+  Vst::UnitID id = Vst::kRootUnitId; // there is already a root element
   size_t i = 0;
   while (path.size() > i)
   {
@@ -464,7 +457,7 @@ Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char* modulename)
       if (VST3::StringConvert::convert(u8name, name))
       {
         Vst::UnitID newid = static_cast<Steinberg::int32>(units.size());
-        Vst::Unit* newunit = new Vst::Unit(name, newid, id);  // a new unit without a program list
+        Vst::Unit *newunit = new Vst::Unit(name, newid, id); // a new unit without a program list
         addUnit(newunit);
         _moduleToUnit[u8name] = newid;
         id = newid;
@@ -477,9 +470,9 @@ Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char* modulename)
 
 // Clap::IHost
 
-void ClapAsVst3::setupWrapperSpecifics(const clap_plugin_t* plugin)
+void ClapAsVst3::setupWrapperSpecifics(const clap_plugin_t *plugin)
 {
-  _vst3specifics = (clap_plugin_as_vst3_t*) plugin->get_extension(plugin, CLAP_PLUGIN_AS_VST3);
+  _vst3specifics = (clap_plugin_as_vst3_t *)plugin->get_extension(plugin, CLAP_PLUGIN_AS_VST3);
   if (_vst3specifics)
   {
     _numMidiChannels = _vst3specifics->getNumMIDIChannels(_plugin->_plugin, 0);
@@ -491,28 +484,29 @@ bool ClapAsVst3::checkMIDIDialectSupport()
 {
   // check if the plugin supports noteports and if one of the note ports supports MIDI dialect
   auto noteports = _plugin->_ext._noteports;
-  if (noteports )
+  if (noteports)
   {
     auto numMIDIInputs = noteports->count(_plugin->_plugin, true);
-    for (uint32_t i = 0 ; i < numMIDIInputs ; ++i )
+    for (uint32_t i = 0; i < numMIDIInputs; ++i)
     {
       clap_note_port_info_t info;
-      if ( noteports->get(_plugin->_plugin,i,true,&info) )
+      if (noteports->get(_plugin->_plugin, i, true, &info))
       {
-        if ( info.supported_dialects & CLAP_NOTE_DIALECT_MIDI )
+        if (info.supported_dialects & CLAP_NOTE_DIALECT_MIDI)
         {
           return true;
         }
       }
     }
   }
-  
+
   return false;
 }
 
-void ClapAsVst3::setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin_audio_ports_t* audioports)
+void ClapAsVst3::setupAudioBusses(const clap_plugin_t *plugin, const clap_plugin_audio_ports_t *audioports)
 {
-  if (!audioports) return;
+  if (!audioports)
+    return;
   auto numAudioInputs = audioports->count(plugin, true);
   auto numAudioOutputs = audioports->count(plugin, false);
 
@@ -536,9 +530,10 @@ void ClapAsVst3::setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin
   }
 }
 
-void ClapAsVst3::setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports)
+void ClapAsVst3::setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_note_ports_t *noteports)
 {
-  if (!noteports) return;
+  if (!noteports)
+    return;
   auto numMIDIInPorts = noteports->count(plugin, true);
   auto numMIDIOutPorts = noteports->count(plugin, false);
 
@@ -568,9 +563,10 @@ void ClapAsVst3::setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_
   }
 }
 
-void ClapAsVst3::setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params)
+void ClapAsVst3::setupParameters(const clap_plugin_t *plugin, const clap_plugin_params_t *params)
 {
-  if (!params) return;
+  if (!params)
+    return;
 
   // clear the units, they will be rebuild during the parameter conversion
   _moduleToUnit.clear();
@@ -578,7 +574,8 @@ void ClapAsVst3::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
 
   {
     Vst::String128 rootname(STR16("root"));
-    Vst::Unit* newunit = new Vst::Unit(rootname, Vst::kNoParentUnitId, Vst::kRootUnitId);  // a new unit without a program list
+    Vst::Unit *newunit =
+        new Vst::Unit(rootname, Vst::kNoParentUnitId, Vst::kRootUnitId); // a new unit without a program list
     addUnit(newunit);
   }
 
@@ -590,21 +587,19 @@ void ClapAsVst3::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
     clap_param_info info;
     if (params->get_info(plugin, i, &info))
     {
-      auto p = Vst3Parameter::create(&info, [&](const char* modstring) 
-        {
-          return this->getOrCreateUnitInfo(modstring);
-        });
+      auto p =
+          Vst3Parameter::create(&info, [&](const char *modstring) { return this->getOrCreateUnitInfo(modstring); });
       // auto p = Vst3Parameter::create(&info,nullptr);
       parameters.addParameter(p);
     }
   }
 
-  if ( _useIMidiMapping )
+  if (_useIMidiMapping)
   {
     // find free tags for IMidiMapping
     Vst::ParamID x = 0xb00000;
     _IMidiMappingEasy = true;
-    
+
     for (uint8_t channel = 0; channel < _numMidiChannels; channel++)
     {
       for (int i = 0; i < Vst::ControllerNumbers::kCountCtrlNumber; ++i)
@@ -624,40 +619,33 @@ void ClapAsVst3::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
   }
 
   // setting up noteexpression
-  
+
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_VOLUME)
-    _noteExpressions.addNoteExpressionType(
-      new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kVolumeTypeID, S16("Volume"), S16("Vol"), S16(""), 0, nullptr, 0)
-    );
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
+        Vst::NoteExpressionTypeIDs::kVolumeTypeID, S16("Volume"), S16("Vol"), S16(""), 0, nullptr, 0));
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PAN)
 
-    _noteExpressions.addNoteExpressionType(
-      new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kPanTypeID, S16("Panorama"), S16("Pan"), S16(""), 0, nullptr, 0)
-    );
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
+        Vst::NoteExpressionTypeIDs::kPanTypeID, S16("Panorama"), S16("Pan"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING)
-    _noteExpressions.addNoteExpressionType(
-      new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kTuningTypeID, S16("Tuning"), S16("Tun"), S16(""), 0, nullptr, 0)
-    );
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
+        Vst::NoteExpressionTypeIDs::kTuningTypeID, S16("Tuning"), S16("Tun"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_VIBRATO)
-    _noteExpressions.addNoteExpressionType(
-      new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kVibratoTypeID, S16("Vibrato"), S16("Vibr"), S16(""), 0, nullptr, 0)
-    );
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
+        Vst::NoteExpressionTypeIDs::kVibratoTypeID, S16("Vibrato"), S16("Vibr"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_EXPRESSION)
-    _noteExpressions.addNoteExpressionType(
-      new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kExpressionTypeID, S16("Expression"), S16("Expr"), S16(""), 0, nullptr, 0)
-    );
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
+        Vst::NoteExpressionTypeIDs::kExpressionTypeID, S16("Expression"), S16("Expr"), S16(""), 0, nullptr, 0));
 
   if (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_BRIGHTNESS)
-    _noteExpressions.addNoteExpressionType(
-      new Vst::NoteExpressionType(Vst::NoteExpressionTypeIDs::kBrightnessTypeID, S16("Brightness"), S16("Brit"), S16(""), 0, nullptr, 0)
-    );
+    _noteExpressions.addNoteExpressionType(new Vst::NoteExpressionType(
+        Vst::NoteExpressionTypeIDs::kBrightnessTypeID, S16("Brightness"), S16("Brit"), S16(""), 0, nullptr, 0));
 
   // PRESSURE is handled by IMidiMapping (-> Polypressure)
 }
-
 
 void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
 {
@@ -669,7 +657,9 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
   }
 
   vstflags |= ((flags & CLAP_PARAM_RESCAN_VALUES) ? (uint32_t)Vst::RestartFlags::kParamValuesChanged : 0u);
-  vstflags |= ((flags & CLAP_PARAM_RESCAN_INFO) ? Vst::RestartFlags::kParamValuesChanged | Vst::RestartFlags::kParamTitlesChanged : 0u);
+  vstflags |= ((flags & CLAP_PARAM_RESCAN_INFO)
+                   ? Vst::RestartFlags::kParamValuesChanged | Vst::RestartFlags::kParamTitlesChanged
+                   : 0u);
   if (vstflags != 0)
   {
     // update parameter values in our own tree
@@ -677,7 +667,7 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
     for (decltype(len) i = 0; i < len; ++i)
     {
       auto p = parameters.getParameterByIndex(i);
-      auto p1 = static_cast<Vst3Parameter*>(p);
+      auto p1 = static_cast<Vst3Parameter *>(p);
       if (!p1->isMidi)
       {
         double val;
@@ -693,18 +683,12 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
     }
     this->componentHandler->restartComponent(vstflags);
   }
-
 }
 
-void ClapAsVst3::param_clear(clap_id param, clap_param_clear_flags flags)
-{
-}
+void ClapAsVst3::param_clear(clap_id param, clap_param_clear_flags flags) {}
 
 // request_flush requests a defered call to flush if there is no processing
-void ClapAsVst3::param_request_flush()
-{
-  _requestedFlush = true;
-}
+void ClapAsVst3::param_request_flush() { _requestedFlush = true; }
 
 bool ClapAsVst3::gui_can_resize()
 {
@@ -724,10 +708,7 @@ bool ClapAsVst3::gui_request_show()
   return false;
 }
 
-bool ClapAsVst3::gui_request_hide()
-{
-  return false;
-}
+bool ClapAsVst3::gui_request_hide() { return false; }
 
 void ClapAsVst3::latency_changed()
 {
@@ -747,35 +728,28 @@ void ClapAsVst3::mark_dirty()
     componentHandler2->setDirty(true);
 }
 
-void ClapAsVst3::request_callback()
-{
-  _requestUICallback = true;
-}
+void ClapAsVst3::request_callback() { _requestUICallback = true; }
 
 void ClapAsVst3::restartPlugin()
-{  
-  if (componentHandler) componentHandler->restartComponent(Vst::RestartFlags::kReloadComponent);
+{
+  if (componentHandler)
+    componentHandler->restartComponent(Vst::RestartFlags::kReloadComponent);
 }
 
 void ClapAsVst3::onBeginEdit(clap_id id)
 {
   // receive beginEdit and pass it to the internal queue
   _queueToUI.push(beginEvent(id));
-
 }
-void ClapAsVst3::onPerformEdit(const clap_event_param_value_t* value)
+void ClapAsVst3::onPerformEdit(const clap_event_param_value_t *value)
 {
   // receive a value change and pass it to the internal queue
   _queueToUI.push(valueEvent(value));
 }
-void ClapAsVst3::onEndEdit(clap_id id)
-{
-  _queueToUI.push(endEvent(id));
-
-}
+void ClapAsVst3::onEndEdit(clap_id id) { _queueToUI.push(endEvent(id)); }
 
 // ext-timer
-bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id* timer_id)
+bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id *timer_id)
 {
   // restrict the timer to 30ms
   if (period_ms < 30)
@@ -786,7 +760,7 @@ bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id* timer_id)
   auto l = _timersObjects.size();
   for (decltype(l) i = 0; i < l; ++i)
   {
-    auto& to = _timersObjects[i];
+    auto &to = _timersObjects[i];
     if (to.period == 0)
     {
       // reuse timer object. Lets choose not to use 0 as a timer id, just
@@ -804,8 +778,8 @@ bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id* timer_id)
     }
   }
   // create a new timer object
-  auto newid = (clap_id)(l+1000);
-  TimerObject f{ period_ms, os::getTickInMS() + period_ms, newid };
+  auto newid = (clap_id)(l + 1000);
+  TimerObject f{period_ms, os::getTickInMS() + period_ms, newid};
   *timer_id = newid;
   _timersObjects.push_back(f);
 #if LIN
@@ -816,7 +790,7 @@ bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id* timer_id)
 }
 bool ClapAsVst3::unregister_timer(clap_id timer_id)
 {
-  for (auto& to : _timersObjects)
+  for (auto &to : _timersObjects)
   {
     if (to.timer_id == timer_id)
     {
@@ -825,7 +799,7 @@ bool ClapAsVst3::unregister_timer(clap_id timer_id)
 #if LIN
       if (to.handler && _iRunLoop)
       {
-          _iRunLoop->unregisterTimer(to.handler.get());
+        _iRunLoop->unregisterTimer(to.handler.get());
       }
       to.handler.reset();
 #endif
@@ -847,12 +821,12 @@ void ClapAsVst3::onIdle()
       beginEdit(n._data._id);
       break;
     case queueEvent::type_t::editvalue:
-      {
-        auto param = (Vst3Parameter*)(parameters.getParameter(n._data._value.param_id & 0x7FFFFFFF));
-        auto v = n._data._value.value;
-        performEdit(param->getInfo().id, param->asVst3Value(v));
-      }
-      break;
+    {
+      auto param = (Vst3Parameter *)(parameters.getParameter(n._data._value.param_id & 0x7FFFFFFF));
+      auto v = n._data._value.value;
+      performEdit(param->getInfo().id, param->asVst3Value(v));
+    }
+    break;
     case queueEvent::type_t::editend:
       endEdit(n._data._id);
       break;
@@ -868,7 +842,8 @@ void ClapAsVst3::onIdle()
     {
       // setup a ProcessAdapter just for flush with no audio
       Clap::ProcessAdapter pa;
-      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0, this->parameters, componentHandler, nullptr, false, false);
+      pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0, this->parameters,
+                         componentHandler, nullptr, false, false);
       pa.flush();
     }
   }
@@ -880,10 +855,10 @@ void ClapAsVst3::onIdle()
   }
 
 #if LIN
-   if (!_iRunLoop) // don't process timers if we have a runloop.
-      // (but if we don't have a runloop on linux onIdle isn't called
-      // anyway so consider just not having this at all once we decide
-      // to do with the no UI case)
+  if (!_iRunLoop) // don't process timers if we have a runloop.
+                  // (but if we don't have a runloop on linux onIdle isn't called
+                  // anyway so consider just not having this at all once we decide
+                  // to do with the no UI case)
 #endif
   {
     // handling timerobjects
@@ -892,11 +867,11 @@ void ClapAsVst3::onIdle()
     {
       if (to.period > 0)
       {
-          if (to.nexttick < now)
-          {
+        if (to.nexttick < now)
+        {
           to.nexttick = now + to.period;
           this->_plugin->_ext._timer->on_timer(_plugin->_plugin, to.timer_id);
-          }
+        }
       }
     }
   }
@@ -907,10 +882,7 @@ struct TimerHandler : Steinberg::Linux::ITimerHandler, public Steinberg::FObject
 {
   ClapAsVst3 *_parent{nullptr};
   clap_id _timerId{0};
-  TimerHandler(ClapAsVst3 *parent, clap_id timerId)
-      : _parent(parent), _timerId(timerId)
-  {
-  }
+  TimerHandler(ClapAsVst3 *parent, clap_id timerId) : _parent(parent), _timerId(timerId) {}
   void PLUGIN_API onTimer() final { _parent->fireTimer(_timerId); }
   DELEGATE_REFCOUNT(Steinberg::FObject)
   DEFINE_INTERFACES
@@ -976,10 +948,7 @@ void ClapAsVst3::detachTimers(Steinberg::Linux::IRunLoop *r)
   }
 }
 
-void ClapAsVst3::fireTimer(clap_id timer_id)
-{
-  _plugin->_ext._timer->on_timer(_plugin->_plugin, timer_id);
-}
+void ClapAsVst3::fireTimer(clap_id timer_id) { _plugin->_ext._timer->on_timer(_plugin->_plugin, timer_id); }
 
 bool ClapAsVst3::register_fd(int fd, clap_posix_fd_flags_t flags)
 {
@@ -1030,14 +999,8 @@ struct FDHandler : Steinberg::Linux::IEventHandler, public Steinberg::FObject
   ClapAsVst3 *_parent{nullptr};
   int _fd{0};
   clap_posix_fd_flags_t _flags{};
-  FDHandler(ClapAsVst3 *parent, int fd, clap_posix_fd_flags_t flags)
-      : _parent(parent), _fd(fd), _flags(flags)
-  {
-  }
-  void PLUGIN_API onFDIsSet(Steinberg::Linux::FileDescriptor) override
-  {
-    _parent->firePosixFDIsSet(_fd, _flags);
-  }
+  FDHandler(ClapAsVst3 *parent, int fd, clap_posix_fd_flags_t flags) : _parent(parent), _fd(fd), _flags(flags) {}
+  void PLUGIN_API onFDIsSet(Steinberg::Linux::FileDescriptor) override { _parent->firePosixFDIsSet(_fd, _flags); }
   DELEGATE_REFCOUNT(Steinberg::FObject)
   DEFINE_INTERFACES
   DEF_INTERFACE(Steinberg::Linux::IEventHandler)

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -24,8 +24,14 @@
 
 struct ClapHostExtensions
 {
-  static inline ClapAsVst3* self(const clap_host_t* host) { return static_cast<ClapAsVst3*>(host->host_data); }
-  static void mark_dirty(const clap_host_t* host) { self(host)->mark_dirty(); }
+  static inline ClapAsVst3* self(const clap_host_t* host)
+  {
+    return static_cast<ClapAsVst3*>(host->host_data);
+  }
+  static void mark_dirty(const clap_host_t* host)
+  {
+    self(host)->mark_dirty();
+  }
   const clap_host_state_t _state = {mark_dirty};
 };
 
@@ -109,9 +115,15 @@ tresult PLUGIN_API ClapAsVst3::canProcessSampleSize(int32 symbolicSampleSize)
   return kResultOk;
 }
 
-tresult PLUGIN_API ClapAsVst3::setState(IBStream* state) { return (_plugin->load(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse); }
+tresult PLUGIN_API ClapAsVst3::setState(IBStream* state)
+{
+  return (_plugin->load(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
+}
 
-tresult PLUGIN_API ClapAsVst3::getState(IBStream* state) { return (_plugin->save(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse); }
+tresult PLUGIN_API ClapAsVst3::getState(IBStream* state)
+{
+  return (_plugin->save(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
+}
 
 uint32 PLUGIN_API ClapAsVst3::getLatencySamples()
 {
@@ -174,9 +186,15 @@ tresult PLUGIN_API ClapAsVst3::setProcessing(TBool state)
   return result;
 }
 
-tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns, Vst::SpeakerArrangement* outputs, int32 numOuts) { return super::setBusArrangements(inputs, numIns, outputs, numOuts); };
+tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns, Vst::SpeakerArrangement* outputs, int32 numOuts)
+{
+  return super::setBusArrangements(inputs, numIns, outputs, numOuts);
+};
 
-tresult PLUGIN_API ClapAsVst3::getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement& arr) { return super::getBusArrangement(dir, index, arr); }
+tresult PLUGIN_API ClapAsVst3::getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement& arr)
+{
+  return super::getBusArrangement(dir, index, arr);
+}
 
 IPlugView* PLUGIN_API ClapAsVst3::createView(FIDString name)
 {
@@ -240,7 +258,10 @@ tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar
   return Steinberg::kResultFalse;
 }
 
-tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index, TBool state) { return super::activateBus(type, dir, index, state); }
+tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index, TBool state)
+{
+  return super::activateBus(type, dir, index, state);
+}
 
 //-----------------------------------------------------------------------------
 
@@ -637,10 +658,15 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
   }
 }
 
-void ClapAsVst3::param_clear(clap_id param, clap_param_clear_flags flags) {}
+void ClapAsVst3::param_clear(clap_id param, clap_param_clear_flags flags)
+{
+}
 
 // request_flush requests a defered call to flush if there is no processing
-void ClapAsVst3::param_request_flush() { _requestedFlush = true; }
+void ClapAsVst3::param_request_flush()
+{
+  _requestedFlush = true;
+}
 
 bool ClapAsVst3::gui_can_resize()
 {
@@ -648,7 +674,10 @@ bool ClapAsVst3::gui_can_resize()
   return (componentHandler2 != nullptr);
 }
 
-bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height) { return _wrappedview->request_resize(width, height); }
+bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height)
+{
+  return _wrappedview->request_resize(width, height);
+}
 
 bool ClapAsVst3::gui_request_show()
 {
@@ -656,7 +685,10 @@ bool ClapAsVst3::gui_request_show()
   return false;
 }
 
-bool ClapAsVst3::gui_request_hide() { return false; }
+bool ClapAsVst3::gui_request_hide()
+{
+  return false;
+}
 
 void ClapAsVst3::latency_changed()
 {
@@ -674,7 +706,10 @@ void ClapAsVst3::mark_dirty()
   if (componentHandler2) componentHandler2->setDirty(true);
 }
 
-void ClapAsVst3::request_callback() { _requestUICallback = true; }
+void ClapAsVst3::request_callback()
+{
+  _requestUICallback = true;
+}
 
 void ClapAsVst3::restartPlugin()
 {
@@ -691,7 +726,10 @@ void ClapAsVst3::onPerformEdit(const clap_event_param_value_t* value)
   // receive a value change and pass it to the internal queue
   _queueToUI.push(valueEvent(value));
 }
-void ClapAsVst3::onEndEdit(clap_id id) { _queueToUI.push(endEvent(id)); }
+void ClapAsVst3::onEndEdit(clap_id id)
+{
+  _queueToUI.push(endEvent(id));
+}
 
 // ext-timer
 bool ClapAsVst3::register_timer(uint32_t period_ms, clap_id* timer_id)
@@ -826,8 +864,13 @@ struct TimerHandler : Steinberg::Linux::ITimerHandler, public Steinberg::FObject
 {
   ClapAsVst3* _parent{nullptr};
   clap_id _timerId{0};
-  TimerHandler(ClapAsVst3* parent, clap_id timerId) : _parent(parent), _timerId(timerId) {}
-  void PLUGIN_API onTimer() final { _parent->fireTimer(_timerId); }
+  TimerHandler(ClapAsVst3* parent, clap_id timerId) : _parent(parent), _timerId(timerId)
+  {
+  }
+  void PLUGIN_API onTimer() final
+  {
+    _parent->fireTimer(_timerId);
+  }
   DELEGATE_REFCOUNT(Steinberg::FObject)
   DEFINE_INTERFACES
   DEF_INTERFACE(Steinberg::Linux::ITimerHandler)
@@ -837,8 +880,13 @@ struct TimerHandler : Steinberg::Linux::ITimerHandler, public Steinberg::FObject
 struct IdleHandler : Steinberg::Linux::ITimerHandler, public Steinberg::FObject
 {
   ClapAsVst3* _parent{nullptr};
-  IdleHandler(ClapAsVst3* parent) : _parent(parent) {}
-  void PLUGIN_API onTimer() final { _parent->onIdle(); }
+  IdleHandler(ClapAsVst3* parent) : _parent(parent)
+  {
+  }
+  void PLUGIN_API onTimer() final
+  {
+    _parent->onIdle();
+  }
   DELEGATE_REFCOUNT(Steinberg::FObject)
   DEFINE_INTERFACES
   DEF_INTERFACE(Steinberg::Linux::ITimerHandler)
@@ -892,7 +940,10 @@ void ClapAsVst3::detachTimers(Steinberg::Linux::IRunLoop* r)
   }
 }
 
-void ClapAsVst3::fireTimer(clap_id timer_id) { _plugin->_ext._timer->on_timer(_plugin->_plugin, timer_id); }
+void ClapAsVst3::fireTimer(clap_id timer_id)
+{
+  _plugin->_ext._timer->on_timer(_plugin->_plugin, timer_id);
+}
 
 bool ClapAsVst3::register_fd(int fd, clap_posix_fd_flags_t flags)
 {
@@ -943,8 +994,13 @@ struct FDHandler : Steinberg::Linux::IEventHandler, public Steinberg::FObject
   ClapAsVst3* _parent{nullptr};
   int _fd{0};
   clap_posix_fd_flags_t _flags{};
-  FDHandler(ClapAsVst3* parent, int fd, clap_posix_fd_flags_t flags) : _parent(parent), _fd(fd), _flags(flags) {}
-  void PLUGIN_API onFDIsSet(Steinberg::Linux::FileDescriptor) override { _parent->firePosixFDIsSet(_fd, _flags); }
+  FDHandler(ClapAsVst3* parent, int fd, clap_posix_fd_flags_t flags) : _parent(parent), _fd(fd), _flags(flags)
+  {
+  }
+  void PLUGIN_API onFDIsSet(Steinberg::Linux::FileDescriptor) override
+  {
+    _parent->firePosixFDIsSet(_fd, _flags);
+  }
   DELEGATE_REFCOUNT(Steinberg::FObject)
   DEFINE_INTERFACES
   DEF_INTERFACE(Steinberg::Linux::IEventHandler)
@@ -982,5 +1038,8 @@ void ClapAsVst3::detachPosixFD(Steinberg::Linux::IRunLoop* r)
   }
 }
 
-void ClapAsVst3::firePosixFDIsSet(int fd, clap_posix_fd_flags_t flags) { _plugin->_ext._posixfd->on_fd(_plugin->_plugin, fd, flags); }
+void ClapAsVst3::firePosixFDIsSet(int fd, clap_posix_fd_flags_t flags)
+{
+  _plugin->_ext._posixfd->on_fd(_plugin->_plugin, fd, flags);
+}
 #endif

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -1,15 +1,15 @@
 #pragma once
 
 /*
-		CLAP as VST3
+                CLAP as VST3
 
     Copyright (c) 2022 Timo Kaluza (defiantnerd)
 
-		This file is part of the clap-wrappers project which is released under MIT License.
-		See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+                This file is part of the clap-wrappers project which is released under MIT License.
+                See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
 
-		This VST3 opens a CLAP plugin and matches all corresponding VST3 calls to it.
-		For the VST3 Host it is a VST3 plugin, for the CLAP plugin it is a CLAP host.
+                This VST3 opens a CLAP plugin and matches all corresponding VST3 calls to it.
+                For the VST3 Host it is a VST3 plugin, for the CLAP plugin it is a CLAP host.
 
 */
 
@@ -39,279 +39,275 @@ using namespace Steinberg;
 struct ClapHostExtensions;
 namespace Clap
 {
-	class ProcessAdapter;
+  class ProcessAdapter;
 }
 
 class queueEvent
 {
 public:
-	typedef enum class type
-	{
-		editstart,
-		editvalue,
-		editend,
-	} type_t;
-	type_t _type;
-	union
-	{
-		clap_id _id;
-		clap_event_param_value_t _value;
-	} _data;
+  typedef enum class type
+  {
+    editstart,
+    editvalue,
+    editend,
+  } type_t;
+  type_t _type;
+  union
+  {
+    clap_id _id;
+    clap_event_param_value_t _value;
+  } _data;
 };
 
 class beginEvent : public queueEvent
 {
 public:
-	beginEvent(clap_id id)
-		: queueEvent()
-	{
-		this->_type = type::editstart;
-		_data._id = id;
-	}
+  beginEvent(clap_id id) : queueEvent()
+  {
+    this->_type = type::editstart;
+    _data._id = id;
+  }
 };
 
 class endEvent : public queueEvent
 {
 public:
-	endEvent(clap_id id)
-		: queueEvent()
-	{
-		this->_type = type::editend;
-		_data._id = id;
-	}
+  endEvent(clap_id id) : queueEvent()
+  {
+    this->_type = type::editend;
+    _data._id = id;
+  }
 };
 
 class valueEvent : public queueEvent
 {
 public:
-	valueEvent(const clap_event_param_value_t* value)
-		: queueEvent()
-	{
-		_type = type::editvalue;
-		_data._value = *value;
-	}
+  valueEvent(const clap_event_param_value_t *value) : queueEvent()
+  {
+    _type = type::editvalue;
+    _data._value = *value;
+  }
 };
 
-class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect
-	, public Steinberg::Vst::IMidiMapping
-	, public Steinberg::Vst::INoteExpressionController
-	, public Clap::IHost
-	, public Clap::IAutomation
-	, public os::IPlugObject
+class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
+                   public Steinberg::Vst::IMidiMapping,
+                   public Steinberg::Vst::INoteExpressionController,
+                   public Clap::IHost,
+                   public Clap::IAutomation,
+                   public os::IPlugObject
 {
 public:
+  using super = Steinberg::Vst::SingleComponentEffect;
 
-	using super = Steinberg::Vst::SingleComponentEffect;
+  static FUnknown *createInstance(void *context);
 
-	static FUnknown* createInstance(void* context);
+  ClapAsVst3(Clap::Library *lib, int number, void *context)
+      : super(), Steinberg::Vst::IMidiMapping(), Steinberg::Vst::INoteExpressionController(), _library(lib),
+        _libraryIndex(number), _creationcontext(context)
+  {
+  }
 
-	ClapAsVst3(Clap::Library* lib, int number, void* context) 
-		: super()
-		, Steinberg::Vst::IMidiMapping()
- 		, Steinberg::Vst::INoteExpressionController()
-		, _library(lib)
-		, _libraryIndex(number)
-		, _creationcontext(context) {}
+  //---from IComponent-----------------------
+  tresult PLUGIN_API initialize(FUnknown *context) override;
+  tresult PLUGIN_API terminate() override;
+  tresult PLUGIN_API setActive(TBool state) override;
+  tresult PLUGIN_API process(Vst::ProcessData &data) override;
+  tresult PLUGIN_API canProcessSampleSize(int32 symbolicSampleSize) override;
+  tresult PLUGIN_API setState(IBStream *state) override;
+  tresult PLUGIN_API getState(IBStream *state) override;
+  uint32 PLUGIN_API getLatencySamples() override;
+  uint32 PLUGIN_API getTailSamples() override;
+  tresult PLUGIN_API setupProcessing(Vst::ProcessSetup &newSetup) override;
+  tresult PLUGIN_API setProcessing(TBool state) override;
+  tresult PLUGIN_API setBusArrangements(Vst::SpeakerArrangement *inputs, int32 numIns, Vst::SpeakerArrangement *outputs,
+                                        int32 numOuts) override;
+  tresult PLUGIN_API getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement &arr) override;
+  tresult PLUGIN_API activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index, TBool state) override;
 
-	//---from IComponent-----------------------
-	tresult PLUGIN_API initialize(FUnknown* context) override;
-	tresult PLUGIN_API terminate() override;
-	tresult PLUGIN_API setActive(TBool state) override;
-	tresult PLUGIN_API process(Vst::ProcessData& data) override;
-	tresult PLUGIN_API canProcessSampleSize(int32 symbolicSampleSize) override;
-	tresult PLUGIN_API setState(IBStream* state) override;
-	tresult PLUGIN_API getState(IBStream* state) override;
-	uint32  PLUGIN_API getLatencySamples() override;
-	uint32  PLUGIN_API getTailSamples() override;
-	tresult PLUGIN_API setupProcessing(Vst::ProcessSetup& newSetup) override;
-	tresult PLUGIN_API setProcessing(TBool state) override;
-	tresult PLUGIN_API setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns,
-		Vst::SpeakerArrangement* outputs,
-		int32 numOuts) override;
-	tresult PLUGIN_API getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement& arr) override;
-	tresult PLUGIN_API activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index,
-		TBool state) override;
+  //----from IEditControllerEx1--------------------------------
+  IPlugView *PLUGIN_API createView(FIDString name) override;
+  /** Gets for a given paramID and normalized value its associated string representation. */
+  tresult PLUGIN_API getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized /*in*/,
+                                           Vst::String128 string /*out*/) override;
+  /** Gets for a given paramID and string its normalized value. */
+  tresult PLUGIN_API getParamValueByString(Vst::ParamID id, Vst::TChar *string /*in*/,
+                                           Vst::ParamValue &valueNormalized /*out*/) override;
 
-	//----from IEditControllerEx1--------------------------------
-	IPlugView* PLUGIN_API createView(FIDString name) override;
-	/** Gets for a given paramID and normalized value its associated string representation. */
-	tresult PLUGIN_API getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized /*in*/, Vst::String128 string /*out*/) override;
-	/** Gets for a given paramID and string its normalized value. */
-	tresult PLUGIN_API getParamValueByString(Vst::ParamID id, Vst::TChar* string /*in*/, Vst::ParamValue& valueNormalized /*out*/) override;
-
-	//----from IMidiMapping--------------------------------------
-	tresult PLUGIN_API getMidiControllerAssignment(int32 busIndex, int16 channel,
-		Vst::CtrlNumber midiControllerNumber, Vst::ParamID& id/*out*/) override;
+  //----from IMidiMapping--------------------------------------
+  tresult PLUGIN_API getMidiControllerAssignment(int32 busIndex, int16 channel, Vst::CtrlNumber midiControllerNumber,
+                                                 Vst::ParamID &id /*out*/) override;
 
 #if 1
-	//----from INoteExpressionController-------------------------
-		/** Returns number of supported note change types for event bus index and channel. */
-	int32 PLUGIN_API getNoteExpressionCount(int32 busIndex, int16 channel) override;
+  //----from INoteExpressionController-------------------------
+  /** Returns number of supported note change types for event bus index and channel. */
+  int32 PLUGIN_API getNoteExpressionCount(int32 busIndex, int16 channel) override;
 
-	/** Returns note change type info. */
-	tresult PLUGIN_API getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex, Vst::NoteExpressionTypeInfo& info /*out*/) override;
+  /** Returns note change type info. */
+  tresult PLUGIN_API getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex,
+                                           Vst::NoteExpressionTypeInfo &info /*out*/) override;
 
-	/** Gets a user readable representation of the normalized note change value. */
-	tresult PLUGIN_API getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, Vst::NoteExpressionValue valueNormalized /*in*/, Vst::String128 string /*out*/) override;
+  /** Gets a user readable representation of the normalized note change value. */
+  tresult PLUGIN_API getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id,
+                                                    Vst::NoteExpressionValue valueNormalized /*in*/,
+                                                    Vst::String128 string /*out*/) override;
 
-	/** Converts the user readable representation to the normalized note change value. */
-	tresult PLUGIN_API getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, const Vst::TChar* string /*in*/, Vst::NoteExpressionValue& valueNormalized /*out*/ ) override;
+  /** Converts the user readable representation to the normalized note change value. */
+  tresult PLUGIN_API getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id,
+                                                    const Vst::TChar *string /*in*/,
+                                                    Vst::NoteExpressionValue &valueNormalized /*out*/) override;
 #endif
-	//---Interface--------------------------------------------------------------------------
-	OBJ_METHODS(ClapAsVst3, SingleComponentEffect)
-	DEFINE_INTERFACES
+  //---Interface--------------------------------------------------------------------------
+  OBJ_METHODS(ClapAsVst3, SingleComponentEffect)
+  DEFINE_INTERFACES
   // since the macro above opens a local function, this code is being executed during QueryInterface() :)
-  if (::Steinberg::FUnknownPrivate::iidEqual (iid, IMidiMapping::iid))
+  if (::Steinberg::FUnknownPrivate::iidEqual(iid, IMidiMapping::iid))
   {
-    // when queried for the IMididMapping interface, check if the CLAP supports MIDI dialect on the MIDI Input busses and only return IMidiMapping then
-    if (  _useIMidiMapping ) {
+    // when queried for the IMididMapping interface, check if the CLAP supports MIDI dialect on the MIDI Input busses
+    // and only return IMidiMapping then
+    if (_useIMidiMapping)
+    {
       DEF_INTERFACE(IMidiMapping)
     }
   }
-	DEF_INTERFACE(INoteExpressionController)
-	// tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override;
-	END_DEFINE_INTERFACES(SingleComponentEffect)
-	REFCOUNT_METHODS(SingleComponentEffect);
-	
+  DEF_INTERFACE(INoteExpressionController)
+  // tresult PLUGIN_API queryInterface(const TUID iid, void** obj) override;
+  END_DEFINE_INTERFACES(SingleComponentEffect)
+  REFCOUNT_METHODS(SingleComponentEffect);
 
+  //---Clap::IHost------------------------------------------------------------------------
 
-	//---Clap::IHost------------------------------------------------------------------------
+  void setupWrapperSpecifics(const clap_plugin_t *plugin) override;
 
-	void setupWrapperSpecifics(const clap_plugin_t* plugin) override;
+  void setupAudioBusses(const clap_plugin_t *plugin, const clap_plugin_audio_ports_t *audioports) override;
+  void setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_note_ports_t *noteports) override;
+  void setupParameters(const clap_plugin_t *plugin, const clap_plugin_params_t *params) override;
 
-	void setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin_audio_ports_t* audioports) override;
-	void setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports) override;
-  void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) override;
+  void param_rescan(clap_param_rescan_flags flags) override;
+  void param_clear(clap_id param, clap_param_clear_flags flags) override;
+  void param_request_flush() override;
 
-	void param_rescan(clap_param_rescan_flags flags) override;
-	void param_clear(clap_id param, clap_param_clear_flags flags) override;
-	void param_request_flush() override;
+  bool gui_can_resize() override;
+  bool gui_request_resize(uint32_t width, uint32_t height) override;
+  bool gui_request_show() override;
+  bool gui_request_hide() override;
 
-	bool gui_can_resize() override;
-	bool gui_request_resize(uint32_t width, uint32_t height) override;
-	bool gui_request_show() override;
-	bool gui_request_hide() override;
+  void latency_changed() override;
 
-	void latency_changed() override;
+  void tail_changed() override;
 
-	void tail_changed() override;
+  void mark_dirty() override;
 
-	void mark_dirty() override;
+  void restartPlugin() override;
 
-	void restartPlugin() override;
+  void request_callback() override;
 
-	void request_callback() override;
-
-	// clap_timer support
-	bool register_timer(uint32_t period_ms, clap_id* timer_id) override;
-	bool unregister_timer(clap_id timer_id) override;
-
+  // clap_timer support
+  bool register_timer(uint32_t period_ms, clap_id *timer_id) override;
+  bool unregister_timer(clap_id timer_id) override;
 
 #if LIN
-    bool register_fd(int fd, clap_posix_fd_flags_t flags) override;
-    bool modify_fd(int fd, clap_posix_fd_flags_t flags) override;
-    bool unregister_fd(int fd) override;
+  bool register_fd(int fd, clap_posix_fd_flags_t flags) override;
+  bool modify_fd(int fd, clap_posix_fd_flags_t flags) override;
+  bool unregister_fd(int fd) override;
 #endif
 
-
 public:
-    //----from IPlugObject
-	void onIdle() override;
-private:
+  //----from IPlugObject
+  void onIdle() override;
 
-	// from Clap::IAutomation
-	void onBeginEdit(clap_id id) override;
-	void onPerformEdit(const clap_event_param_value_t* value) override;
-	void onEndEdit(clap_id id) override;
+private:
+  // from Clap::IAutomation
+  void onBeginEdit(clap_id id) override;
+  void onPerformEdit(const clap_event_param_value_t *value) override;
+  void onEndEdit(clap_id id) override;
 
   // information function to enable/disable the IMIDIMapping interface
   bool checkMIDIDialectSupport();
+
 private:
-	// helper functions
-	void addAudioBusFrom(const clap_audio_port_info_t* info, bool is_input);
-	void addMIDIBusFrom(const clap_note_port_info_t* info, uint32_t index, bool is_input);
-	void updateAudioBusses();
+  // helper functions
+  void addAudioBusFrom(const clap_audio_port_info_t *info, bool is_input);
+  void addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input);
+  void updateAudioBusses();
 
-	Vst::UnitID getOrCreateUnitInfo(const char* modulename);
-	std::map<std::string, Vst::UnitID> _moduleToUnit;
+  Vst::UnitID getOrCreateUnitInfo(const char *modulename);
+  std::map<std::string, Vst::UnitID> _moduleToUnit;
 
-	Clap::Library* _library = nullptr;
-	int _libraryIndex = 0;
-	std::shared_ptr<Clap::Plugin> _plugin;
-	ClapHostExtensions* _hostextensions = nullptr;
-	clap_plugin_as_vst3_t* _vst3specifics = nullptr;
-	Clap::ProcessAdapter* _processAdapter = nullptr;
-	WrappedView* _wrappedview = nullptr;
+  Clap::Library *_library = nullptr;
+  int _libraryIndex = 0;
+  std::shared_ptr<Clap::Plugin> _plugin;
+  ClapHostExtensions *_hostextensions = nullptr;
+  clap_plugin_as_vst3_t *_vst3specifics = nullptr;
+  Clap::ProcessAdapter *_processAdapter = nullptr;
+  WrappedView *_wrappedview = nullptr;
 
-	void* _creationcontext;																		// context from the CLAP library
+  void *_creationcontext; // context from the CLAP library
 
-	// plugin state
-	bool _active = false;
-	bool _processing = false;
-	std::mutex _processingLock;
-	std::atomic_bool _requestedFlush = false;
-	std::atomic_bool _requestUICallback = false;
+  // plugin state
+  bool _active = false;
+  bool _processing = false;
+  std::mutex _processingLock;
+  std::atomic_bool _requestedFlush = false;
+  std::atomic_bool _requestUICallback = false;
 
-	// the queue from audiothread to UI thread
-	util::fixedqueue<queueEvent, 8192> _queueToUI;
+  // the queue from audiothread to UI thread
+  util::fixedqueue<queueEvent, 8192> _queueToUI;
 
-	// for IMidiMapping
+  // for IMidiMapping
   bool _useIMidiMapping = false;
-	Vst::ParamID _IMidiMappingIDs[16][Vst::ControllerNumbers::kCountCtrlNumber] = {}; // 16 MappingIDs for 16 Channels
-	bool _IMidiMappingEasy = true;
-	uint8_t _numMidiChannels = 16;
-	uint32_t _largestBlocksize = 0;
+  Vst::ParamID _IMidiMappingIDs[16][Vst::ControllerNumbers::kCountCtrlNumber] = {}; // 16 MappingIDs for 16 Channels
+  bool _IMidiMappingEasy = true;
+  uint8_t _numMidiChannels = 16;
+  uint32_t _largestBlocksize = 0;
 
-	// for timer
-	struct TimerObject
-	{
-		uint32_t period = 0;		// if period is 0 the entry is unused (and can be reused)
-		uint64_t nexttick = 0;
-		clap_id timer_id = 0;
+  // for timer
+  struct TimerObject
+  {
+    uint32_t period = 0; // if period is 0 the entry is unused (and can be reused)
+    uint64_t nexttick = 0;
+    clap_id timer_id = 0;
 #if LIN
-        Steinberg::IPtr<Steinberg::Linux::ITimerHandler> handler = nullptr;
+    Steinberg::IPtr<Steinberg::Linux::ITimerHandler> handler = nullptr;
 #endif
-	};
-	std::vector<TimerObject> _timersObjects;
+  };
+  std::vector<TimerObject> _timersObjects;
 
 #if LIN
-    Steinberg::IPtr<Steinberg::Linux::ITimerHandler> _idleHandler;
+  Steinberg::IPtr<Steinberg::Linux::ITimerHandler> _idleHandler;
 
-    void attachTimers(Steinberg::Linux::IRunLoop *);
-    void detachTimers(Steinberg::Linux::IRunLoop *);
-    Steinberg::Linux::IRunLoop *_iRunLoop{nullptr};
+  void attachTimers(Steinberg::Linux::IRunLoop *);
+  void detachTimers(Steinberg::Linux::IRunLoop *);
+  Steinberg::Linux::IRunLoop *_iRunLoop{nullptr};
 #endif
 
-
 #if LIN
-    // for timer
-    struct PosixFDObject
-    {
-        PosixFDObject(int f, clap_posix_fd_flags_t fl) : fd(f), flags(fl) {}
-        int fd = 0;
-        clap_posix_fd_flags_t flags = 0;
-        Steinberg::IPtr<Steinberg::Linux::IEventHandler> handler = nullptr;
-    };
-    std::vector<PosixFDObject> _posixFDObjects;
+  // for timer
+  struct PosixFDObject
+  {
+    PosixFDObject(int f, clap_posix_fd_flags_t fl) : fd(f), flags(fl) {}
+    int fd = 0;
+    clap_posix_fd_flags_t flags = 0;
+    Steinberg::IPtr<Steinberg::Linux::IEventHandler> handler = nullptr;
+  };
+  std::vector<PosixFDObject> _posixFDObjects;
 
-    void attachPosixFD(Steinberg::Linux::IRunLoop *);
-    void detachPosixFD(Steinberg::Linux::IRunLoop *);
+  void attachPosixFD(Steinberg::Linux::IRunLoop *);
+  void detachPosixFD(Steinberg::Linux::IRunLoop *);
 #endif
 
 public:
-    void fireTimer(clap_id timer_id);
-    void firePosixFDIsSet(int fd, clap_posix_fd_flags_t flags);
+  void fireTimer(clap_id timer_id);
+  void firePosixFDIsSet(int fd, clap_posix_fd_flags_t flags);
+
 private:
+  // INoteExpression
+  Vst::NoteExpressionTypeContainer _noteExpressions;
 
-	// INoteExpression
-	Vst::NoteExpressionTypeContainer _noteExpressions;
-
-   // add a copiler options for which NE to support
-	uint32_t _expressionmap =
+  // add a copiler options for which NE to support
+  uint32_t _expressionmap =
 #if CLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS
-           clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_ALL;
+      clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_ALL;
 #else
-            clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PRESSURE;
+      clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PRESSURE;
 #endif
-
 };

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -102,12 +102,12 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   static FUnknown* createInstance(void* context);
 
   ClapAsVst3(Clap::Library* lib, int number, void* context)
-      : super()
-      , Steinberg::Vst::IMidiMapping()
-      , Steinberg::Vst::INoteExpressionController()
-      , _library(lib)
-      , _libraryIndex(number)
-      , _creationcontext(context)
+    : super()
+    , Steinberg::Vst::IMidiMapping()
+    , Steinberg::Vst::INoteExpressionController()
+    , _library(lib)
+    , _libraryIndex(number)
+    , _creationcontext(context)
   {
   }
 

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -39,7 +39,7 @@ using namespace Steinberg;
 struct ClapHostExtensions;
 namespace Clap
 {
-  class ProcessAdapter;
+class ProcessAdapter;
 }
 
 class queueEvent

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -96,7 +96,9 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect, public Steinber
 
   static FUnknown* createInstance(void* context);
 
-  ClapAsVst3(Clap::Library* lib, int number, void* context) : super(), Steinberg::Vst::IMidiMapping(), Steinberg::Vst::INoteExpressionController(), _library(lib), _libraryIndex(number), _creationcontext(context) {}
+  ClapAsVst3(Clap::Library* lib, int number, void* context) : super(), Steinberg::Vst::IMidiMapping(), Steinberg::Vst::INoteExpressionController(), _library(lib), _libraryIndex(number), _creationcontext(context)
+  {
+  }
 
   //---from IComponent-----------------------
   tresult PLUGIN_API initialize(FUnknown* context) override;
@@ -265,7 +267,9 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect, public Steinber
   // for timer
   struct PosixFDObject
   {
-    PosixFDObject(int f, clap_posix_fd_flags_t fl) : fd(f), flags(fl) {}
+    PosixFDObject(int f, clap_posix_fd_flags_t fl) : fd(f), flags(fl)
+    {
+    }
     int fd = 0;
     clap_posix_fd_flags_t flags = 0;
     Steinberg::IPtr<Steinberg::Linux::IEventHandler> handler = nullptr;

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -102,12 +102,12 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   static FUnknown* createInstance(void* context);
 
   ClapAsVst3(Clap::Library* lib, int number, void* context)
-      : super(),
-        Steinberg::Vst::IMidiMapping(),
-        Steinberg::Vst::INoteExpressionController(),
-        _library(lib),
-        _libraryIndex(number),
-        _creationcontext(context)
+      : super()
+      , Steinberg::Vst::IMidiMapping()
+      , Steinberg::Vst::INoteExpressionController()
+      , _library(lib)
+      , _libraryIndex(number)
+      , _creationcontext(context)
   {
   }
 

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -1,15 +1,15 @@
 #pragma once
 
 /*
-                CLAP as VST3
+		CLAP as VST3
 
     Copyright (c) 2022 Timo Kaluza (defiantnerd)
 
-                This file is part of the clap-wrappers project which is released under MIT License.
-                See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+		This file is part of the clap-wrappers project which is released under MIT License.
+		See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
 
-                This VST3 opens a CLAP plugin and matches all corresponding VST3 calls to it.
-                For the VST3 Host it is a VST3 plugin, for the CLAP plugin it is a CLAP host.
+		This VST3 opens a CLAP plugin and matches all corresponding VST3 calls to it.
+		For the VST3 Host it is a VST3 plugin, for the CLAP plugin it is a CLAP host.
 
 */
 
@@ -44,7 +44,7 @@ namespace Clap
 
 class queueEvent
 {
-public:
+ public:
   typedef enum class type
   {
     editstart,
@@ -61,7 +61,7 @@ public:
 
 class beginEvent : public queueEvent
 {
-public:
+ public:
   beginEvent(clap_id id) : queueEvent()
   {
     this->_type = type::editstart;
@@ -71,7 +71,7 @@ public:
 
 class endEvent : public queueEvent
 {
-public:
+ public:
   endEvent(clap_id id) : queueEvent()
   {
     this->_type = type::editend;
@@ -81,61 +81,48 @@ public:
 
 class valueEvent : public queueEvent
 {
-public:
-  valueEvent(const clap_event_param_value_t *value) : queueEvent()
+ public:
+  valueEvent(const clap_event_param_value_t* value) : queueEvent()
   {
     _type = type::editvalue;
     _data._value = *value;
   }
 };
 
-class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
-                   public Steinberg::Vst::IMidiMapping,
-                   public Steinberg::Vst::INoteExpressionController,
-                   public Clap::IHost,
-                   public Clap::IAutomation,
-                   public os::IPlugObject
+class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect, public Steinberg::Vst::IMidiMapping, public Steinberg::Vst::INoteExpressionController, public Clap::IHost, public Clap::IAutomation, public os::IPlugObject
 {
-public:
+ public:
   using super = Steinberg::Vst::SingleComponentEffect;
 
-  static FUnknown *createInstance(void *context);
+  static FUnknown* createInstance(void* context);
 
-  ClapAsVst3(Clap::Library *lib, int number, void *context)
-      : super(), Steinberg::Vst::IMidiMapping(), Steinberg::Vst::INoteExpressionController(), _library(lib),
-        _libraryIndex(number), _creationcontext(context)
-  {
-  }
+  ClapAsVst3(Clap::Library* lib, int number, void* context) : super(), Steinberg::Vst::IMidiMapping(), Steinberg::Vst::INoteExpressionController(), _library(lib), _libraryIndex(number), _creationcontext(context) {}
 
   //---from IComponent-----------------------
-  tresult PLUGIN_API initialize(FUnknown *context) override;
+  tresult PLUGIN_API initialize(FUnknown* context) override;
   tresult PLUGIN_API terminate() override;
   tresult PLUGIN_API setActive(TBool state) override;
-  tresult PLUGIN_API process(Vst::ProcessData &data) override;
+  tresult PLUGIN_API process(Vst::ProcessData& data) override;
   tresult PLUGIN_API canProcessSampleSize(int32 symbolicSampleSize) override;
-  tresult PLUGIN_API setState(IBStream *state) override;
-  tresult PLUGIN_API getState(IBStream *state) override;
+  tresult PLUGIN_API setState(IBStream* state) override;
+  tresult PLUGIN_API getState(IBStream* state) override;
   uint32 PLUGIN_API getLatencySamples() override;
   uint32 PLUGIN_API getTailSamples() override;
-  tresult PLUGIN_API setupProcessing(Vst::ProcessSetup &newSetup) override;
+  tresult PLUGIN_API setupProcessing(Vst::ProcessSetup& newSetup) override;
   tresult PLUGIN_API setProcessing(TBool state) override;
-  tresult PLUGIN_API setBusArrangements(Vst::SpeakerArrangement *inputs, int32 numIns, Vst::SpeakerArrangement *outputs,
-                                        int32 numOuts) override;
-  tresult PLUGIN_API getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement &arr) override;
+  tresult PLUGIN_API setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns, Vst::SpeakerArrangement* outputs, int32 numOuts) override;
+  tresult PLUGIN_API getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement& arr) override;
   tresult PLUGIN_API activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index, TBool state) override;
 
   //----from IEditControllerEx1--------------------------------
-  IPlugView *PLUGIN_API createView(FIDString name) override;
+  IPlugView* PLUGIN_API createView(FIDString name) override;
   /** Gets for a given paramID and normalized value its associated string representation. */
-  tresult PLUGIN_API getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized /*in*/,
-                                           Vst::String128 string /*out*/) override;
+  tresult PLUGIN_API getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized /*in*/, Vst::String128 string /*out*/) override;
   /** Gets for a given paramID and string its normalized value. */
-  tresult PLUGIN_API getParamValueByString(Vst::ParamID id, Vst::TChar *string /*in*/,
-                                           Vst::ParamValue &valueNormalized /*out*/) override;
+  tresult PLUGIN_API getParamValueByString(Vst::ParamID id, Vst::TChar* string /*in*/, Vst::ParamValue& valueNormalized /*out*/) override;
 
   //----from IMidiMapping--------------------------------------
-  tresult PLUGIN_API getMidiControllerAssignment(int32 busIndex, int16 channel, Vst::CtrlNumber midiControllerNumber,
-                                                 Vst::ParamID &id /*out*/) override;
+  tresult PLUGIN_API getMidiControllerAssignment(int32 busIndex, int16 channel, Vst::CtrlNumber midiControllerNumber, Vst::ParamID& id /*out*/) override;
 
 #if 1
   //----from INoteExpressionController-------------------------
@@ -143,18 +130,13 @@ public:
   int32 PLUGIN_API getNoteExpressionCount(int32 busIndex, int16 channel) override;
 
   /** Returns note change type info. */
-  tresult PLUGIN_API getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex,
-                                           Vst::NoteExpressionTypeInfo &info /*out*/) override;
+  tresult PLUGIN_API getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex, Vst::NoteExpressionTypeInfo& info /*out*/) override;
 
   /** Gets a user readable representation of the normalized note change value. */
-  tresult PLUGIN_API getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id,
-                                                    Vst::NoteExpressionValue valueNormalized /*in*/,
-                                                    Vst::String128 string /*out*/) override;
+  tresult PLUGIN_API getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, Vst::NoteExpressionValue valueNormalized /*in*/, Vst::String128 string /*out*/) override;
 
   /** Converts the user readable representation to the normalized note change value. */
-  tresult PLUGIN_API getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id,
-                                                    const Vst::TChar *string /*in*/,
-                                                    Vst::NoteExpressionValue &valueNormalized /*out*/) override;
+  tresult PLUGIN_API getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, const Vst::TChar* string /*in*/, Vst::NoteExpressionValue& valueNormalized /*out*/) override;
 #endif
   //---Interface--------------------------------------------------------------------------
   OBJ_METHODS(ClapAsVst3, SingleComponentEffect)
@@ -162,8 +144,7 @@ public:
   // since the macro above opens a local function, this code is being executed during QueryInterface() :)
   if (::Steinberg::FUnknownPrivate::iidEqual(iid, IMidiMapping::iid))
   {
-    // when queried for the IMididMapping interface, check if the CLAP supports MIDI dialect on the MIDI Input busses
-    // and only return IMidiMapping then
+    // when queried for the IMididMapping interface, check if the CLAP supports MIDI dialect on the MIDI Input busses and only return IMidiMapping then
     if (_useIMidiMapping)
     {
       DEF_INTERFACE(IMidiMapping)
@@ -176,11 +157,11 @@ public:
 
   //---Clap::IHost------------------------------------------------------------------------
 
-  void setupWrapperSpecifics(const clap_plugin_t *plugin) override;
+  void setupWrapperSpecifics(const clap_plugin_t* plugin) override;
 
-  void setupAudioBusses(const clap_plugin_t *plugin, const clap_plugin_audio_ports_t *audioports) override;
-  void setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_note_ports_t *noteports) override;
-  void setupParameters(const clap_plugin_t *plugin, const clap_plugin_params_t *params) override;
+  void setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin_audio_ports_t* audioports) override;
+  void setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports) override;
+  void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) override;
 
   void param_rescan(clap_param_rescan_flags flags) override;
   void param_clear(clap_id param, clap_param_clear_flags flags) override;
@@ -202,7 +183,7 @@ public:
   void request_callback() override;
 
   // clap_timer support
-  bool register_timer(uint32_t period_ms, clap_id *timer_id) override;
+  bool register_timer(uint32_t period_ms, clap_id* timer_id) override;
   bool unregister_timer(clap_id timer_id) override;
 
 #if LIN
@@ -211,37 +192,37 @@ public:
   bool unregister_fd(int fd) override;
 #endif
 
-public:
+ public:
   //----from IPlugObject
   void onIdle() override;
 
-private:
+ private:
   // from Clap::IAutomation
   void onBeginEdit(clap_id id) override;
-  void onPerformEdit(const clap_event_param_value_t *value) override;
+  void onPerformEdit(const clap_event_param_value_t* value) override;
   void onEndEdit(clap_id id) override;
 
   // information function to enable/disable the IMIDIMapping interface
   bool checkMIDIDialectSupport();
 
-private:
+ private:
   // helper functions
-  void addAudioBusFrom(const clap_audio_port_info_t *info, bool is_input);
-  void addMIDIBusFrom(const clap_note_port_info_t *info, uint32_t index, bool is_input);
+  void addAudioBusFrom(const clap_audio_port_info_t* info, bool is_input);
+  void addMIDIBusFrom(const clap_note_port_info_t* info, uint32_t index, bool is_input);
   void updateAudioBusses();
 
-  Vst::UnitID getOrCreateUnitInfo(const char *modulename);
+  Vst::UnitID getOrCreateUnitInfo(const char* modulename);
   std::map<std::string, Vst::UnitID> _moduleToUnit;
 
-  Clap::Library *_library = nullptr;
+  Clap::Library* _library = nullptr;
   int _libraryIndex = 0;
   std::shared_ptr<Clap::Plugin> _plugin;
-  ClapHostExtensions *_hostextensions = nullptr;
-  clap_plugin_as_vst3_t *_vst3specifics = nullptr;
-  Clap::ProcessAdapter *_processAdapter = nullptr;
-  WrappedView *_wrappedview = nullptr;
+  ClapHostExtensions* _hostextensions = nullptr;
+  clap_plugin_as_vst3_t* _vst3specifics = nullptr;
+  Clap::ProcessAdapter* _processAdapter = nullptr;
+  WrappedView* _wrappedview = nullptr;
 
-  void *_creationcontext; // context from the CLAP library
+  void* _creationcontext;  // context from the CLAP library
 
   // plugin state
   bool _active = false;
@@ -255,7 +236,7 @@ private:
 
   // for IMidiMapping
   bool _useIMidiMapping = false;
-  Vst::ParamID _IMidiMappingIDs[16][Vst::ControllerNumbers::kCountCtrlNumber] = {}; // 16 MappingIDs for 16 Channels
+  Vst::ParamID _IMidiMappingIDs[16][Vst::ControllerNumbers::kCountCtrlNumber] = {};  // 16 MappingIDs for 16 Channels
   bool _IMidiMappingEasy = true;
   uint8_t _numMidiChannels = 16;
   uint32_t _largestBlocksize = 0;
@@ -263,7 +244,7 @@ private:
   // for timer
   struct TimerObject
   {
-    uint32_t period = 0; // if period is 0 the entry is unused (and can be reused)
+    uint32_t period = 0;  // if period is 0 the entry is unused (and can be reused)
     uint64_t nexttick = 0;
     clap_id timer_id = 0;
 #if LIN
@@ -275,9 +256,9 @@ private:
 #if LIN
   Steinberg::IPtr<Steinberg::Linux::ITimerHandler> _idleHandler;
 
-  void attachTimers(Steinberg::Linux::IRunLoop *);
-  void detachTimers(Steinberg::Linux::IRunLoop *);
-  Steinberg::Linux::IRunLoop *_iRunLoop{nullptr};
+  void attachTimers(Steinberg::Linux::IRunLoop*);
+  void detachTimers(Steinberg::Linux::IRunLoop*);
+  Steinberg::Linux::IRunLoop* _iRunLoop{nullptr};
 #endif
 
 #if LIN
@@ -291,15 +272,15 @@ private:
   };
   std::vector<PosixFDObject> _posixFDObjects;
 
-  void attachPosixFD(Steinberg::Linux::IRunLoop *);
-  void detachPosixFD(Steinberg::Linux::IRunLoop *);
+  void attachPosixFD(Steinberg::Linux::IRunLoop*);
+  void detachPosixFD(Steinberg::Linux::IRunLoop*);
 #endif
 
-public:
+ public:
   void fireTimer(clap_id timer_id);
   void firePosixFDIsSet(int fd, clap_posix_fd_flags_t flags);
 
-private:
+ private:
   // INoteExpression
   Vst::NoteExpressionTypeContainer _noteExpressions;
 

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -89,14 +89,25 @@ class valueEvent : public queueEvent
   }
 };
 
-class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect, public Steinberg::Vst::IMidiMapping, public Steinberg::Vst::INoteExpressionController, public Clap::IHost, public Clap::IAutomation, public os::IPlugObject
+class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
+                   public Steinberg::Vst::IMidiMapping,
+                   public Steinberg::Vst::INoteExpressionController,
+                   public Clap::IHost,
+                   public Clap::IAutomation,
+                   public os::IPlugObject
 {
  public:
   using super = Steinberg::Vst::SingleComponentEffect;
 
   static FUnknown* createInstance(void* context);
 
-  ClapAsVst3(Clap::Library* lib, int number, void* context) : super(), Steinberg::Vst::IMidiMapping(), Steinberg::Vst::INoteExpressionController(), _library(lib), _libraryIndex(number), _creationcontext(context)
+  ClapAsVst3(Clap::Library* lib, int number, void* context)
+      : super(),
+        Steinberg::Vst::IMidiMapping(),
+        Steinberg::Vst::INoteExpressionController(),
+        _library(lib),
+        _libraryIndex(number),
+        _creationcontext(context)
   {
   }
 
@@ -112,19 +123,26 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect, public Steinber
   uint32 PLUGIN_API getTailSamples() override;
   tresult PLUGIN_API setupProcessing(Vst::ProcessSetup& newSetup) override;
   tresult PLUGIN_API setProcessing(TBool state) override;
-  tresult PLUGIN_API setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns, Vst::SpeakerArrangement* outputs, int32 numOuts) override;
-  tresult PLUGIN_API getBusArrangement(Vst::BusDirection dir, int32 index, Vst::SpeakerArrangement& arr) override;
-  tresult PLUGIN_API activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index, TBool state) override;
+  tresult PLUGIN_API setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns,
+                                        Vst::SpeakerArrangement* outputs, int32 numOuts) override;
+  tresult PLUGIN_API getBusArrangement(Vst::BusDirection dir, int32 index,
+                                       Vst::SpeakerArrangement& arr) override;
+  tresult PLUGIN_API activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index,
+                                 TBool state) override;
 
   //----from IEditControllerEx1--------------------------------
   IPlugView* PLUGIN_API createView(FIDString name) override;
   /** Gets for a given paramID and normalized value its associated string representation. */
-  tresult PLUGIN_API getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized /*in*/, Vst::String128 string /*out*/) override;
+  tresult PLUGIN_API getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized /*in*/,
+                                           Vst::String128 string /*out*/) override;
   /** Gets for a given paramID and string its normalized value. */
-  tresult PLUGIN_API getParamValueByString(Vst::ParamID id, Vst::TChar* string /*in*/, Vst::ParamValue& valueNormalized /*out*/) override;
+  tresult PLUGIN_API getParamValueByString(Vst::ParamID id, Vst::TChar* string /*in*/,
+                                           Vst::ParamValue& valueNormalized /*out*/) override;
 
   //----from IMidiMapping--------------------------------------
-  tresult PLUGIN_API getMidiControllerAssignment(int32 busIndex, int16 channel, Vst::CtrlNumber midiControllerNumber, Vst::ParamID& id /*out*/) override;
+  tresult PLUGIN_API getMidiControllerAssignment(int32 busIndex, int16 channel,
+                                                 Vst::CtrlNumber midiControllerNumber,
+                                                 Vst::ParamID& id /*out*/) override;
 
 #if 1
   //----from INoteExpressionController-------------------------
@@ -132,13 +150,19 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect, public Steinber
   int32 PLUGIN_API getNoteExpressionCount(int32 busIndex, int16 channel) override;
 
   /** Returns note change type info. */
-  tresult PLUGIN_API getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex, Vst::NoteExpressionTypeInfo& info /*out*/) override;
+  tresult PLUGIN_API getNoteExpressionInfo(int32 busIndex, int16 channel, int32 noteExpressionIndex,
+                                           Vst::NoteExpressionTypeInfo& info /*out*/) override;
 
   /** Gets a user readable representation of the normalized note change value. */
-  tresult PLUGIN_API getNoteExpressionStringByValue(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, Vst::NoteExpressionValue valueNormalized /*in*/, Vst::String128 string /*out*/) override;
+  tresult PLUGIN_API getNoteExpressionStringByValue(int32 busIndex, int16 channel,
+                                                    Vst::NoteExpressionTypeID id,
+                                                    Vst::NoteExpressionValue valueNormalized /*in*/,
+                                                    Vst::String128 string /*out*/) override;
 
   /** Converts the user readable representation to the normalized note change value. */
-  tresult PLUGIN_API getNoteExpressionValueByString(int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, const Vst::TChar* string /*in*/, Vst::NoteExpressionValue& valueNormalized /*out*/) override;
+  tresult PLUGIN_API getNoteExpressionValueByString(
+      int32 busIndex, int16 channel, Vst::NoteExpressionTypeID id, const Vst::TChar* string /*in*/,
+      Vst::NoteExpressionValue& valueNormalized /*out*/) override;
 #endif
   //---Interface--------------------------------------------------------------------------
   OBJ_METHODS(ClapAsVst3, SingleComponentEffect)
@@ -161,7 +185,8 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect, public Steinber
 
   void setupWrapperSpecifics(const clap_plugin_t* plugin) override;
 
-  void setupAudioBusses(const clap_plugin_t* plugin, const clap_plugin_audio_ports_t* audioports) override;
+  void setupAudioBusses(const clap_plugin_t* plugin,
+                        const clap_plugin_audio_ports_t* audioports) override;
   void setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports) override;
   void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) override;
 
@@ -238,7 +263,8 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect, public Steinber
 
   // for IMidiMapping
   bool _useIMidiMapping = false;
-  Vst::ParamID _IMidiMappingIDs[16][Vst::ControllerNumbers::kCountCtrlNumber] = {};  // 16 MappingIDs for 16 Channels
+  Vst::ParamID _IMidiMappingIDs[16][Vst::ControllerNumbers::kCountCtrlNumber] =
+      {};  // 16 MappingIDs for 16 Channels
   bool _IMidiMappingEasy = true;
   uint8_t _numMidiChannels = 16;
   uint32_t _largestBlocksize = 0;

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -278,8 +278,12 @@ IPluginFactory* GetPluginFactoryEntryPoint()
 
       gCreationContexts.push_back(
           {&gClapLibrary, ctr,
-           PClassInfo2(lcid, PClassInfo::kManyInstances, kVstAudioEffectClass, plugname, 0 /* the only flag is usually Vst:kDistributable, but CLAPs aren't distributable */, features.c_str(), pluginvendor, clapdescr->version, kVstVersionString)});
-      gPluginFactory->registerClass(&gCreationContexts.back().classinfo, ClapAsVst3::createInstance, &gCreationContexts.back());
+           PClassInfo2(
+               lcid, PClassInfo::kManyInstances, kVstAudioEffectClass, plugname,
+               0 /* the only flag is usually Vst:kDistributable, but CLAPs aren't distributable */,
+               features.c_str(), pluginvendor, clapdescr->version, kVstVersionString)});
+      gPluginFactory->registerClass(&gCreationContexts.back().classinfo, ClapAsVst3::createInstance,
+                                    &gCreationContexts.back());
     }
   }
   else

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -1,45 +1,44 @@
 /*
 
-		CLAP AS VST3 - Entrypoint
+                CLAP AS VST3 - Entrypoint
 
-		Copyright (c) 2022 Timo Kaluza (defiantnerd)
+                Copyright (c) 2022 Timo Kaluza (defiantnerd)
 
-		This file is part of the clap-wrappers project which is released under MIT License.
-		See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+                This file is part of the clap-wrappers project which is released under MIT License.
+                See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
 
-		Provides the entry function for the VST3 flavor of the wrapped plugin.
+                Provides the entry function for the VST3 flavor of the wrapped plugin.
 
-		When the VST3 factory is being scanned, this tries to locate a clap_entry function
-		in the following order and stops if a .clap binary has been found:
+                When the VST3 factory is being scanned, this tries to locate a clap_entry function
+                in the following order and stops if a .clap binary has been found:
 
-		1) checks for exported `clap_enty` in this binary itself (statically linked wrapper)
-		2) determines it's own filename without the .vst3 ending and determines a list of all valid CLAP search paths (see below) and
-		   a) checks each CLAP search path for a matching .clap
-			 b) checks it's own parent folder name and tries to add it to the .clap path. This allows a vst3 wrapper placed in
-					{any VST3 Folder}/mevendor/myplugin.vst3 to match {any CLAP folder}/mevendor/myplugin.clap
-			 c) checks all subfolders in the CLAP folders for a matching .clap.
-		
-		Valid CLAP search paths are also documented in clap/include/clap/entry.h:
+                1) checks for exported `clap_enty` in this binary itself (statically linked wrapper)
+                2) determines it's own filename without the .vst3 ending and determines a list of all valid CLAP search
+   paths (see below) and a) checks each CLAP search path for a matching .clap b) checks it's own parent folder name and
+   tries to add it to the .clap path. This allows a vst3 wrapper placed in {any VST3 Folder}/mevendor/myplugin.vst3 to
+   match {any CLAP folder}/mevendor/myplugin.clap c) checks all subfolders in the CLAP folders for a matching .clap.
 
-		// CLAP plugins standard search path:
+                Valid CLAP search paths are also documented in clap/include/clap/entry.h:
+
+                // CLAP plugins standard search path:
 
     Linux
       - ~/.clap
       - /usr/lib/clap
-   
+
     Windows
       - %CommonFilesFolder%/CLAP/
       - %LOCALAPPDATA%/Programs/Common/CLAP/
-   
+
     MacOS
       - /Library/Audio/Plug-Ins/CLAP
       - ~/Library/Audio/Plug-Ins/CLAP
-   
+
     In addition to the OS-specific default locations above, a CLAP host must query the environment
     for a CLAP_PATH variable, which is a list of directories formatted in the same manner as the host
     OS binary search path (PATH on Unix, separated by `:` and Path on Windows, separated by ';', as
     of this writing).
-   
+
     Each directory should be recursively searched for files and/or bundles as appropriate in your OS
     ending with the extension `.clap`.
 
@@ -65,256 +64,254 @@ using namespace Steinberg::Vst;
 
 struct CreationContext
 {
-	Clap::Library* lib = nullptr;
-	int index = 0;
-	PClassInfo2 classinfo;
+  Clap::Library *lib = nullptr;
+  int index = 0;
+  PClassInfo2 classinfo;
 };
 
-bool findPlugin(Clap::Library& lib, const std::string& pluginfilename)
+bool findPlugin(Clap::Library &lib, const std::string &pluginfilename)
 {
-	auto parentfolder = os::getParentFolderName();
-	auto paths = Clap::getValidCLAPSearchPaths();
+  auto parentfolder = os::getParentFolderName();
+  auto paths = Clap::getValidCLAPSearchPaths();
 
-	// Strategy 1: look for a clap with the same name as this binary
-	for (auto& i : paths)
-	{
-		if ( !fs::exists(i) )
-		 continue;
-		// try to find it the CLAP folder immediately
-		auto k1 = i / pluginfilename;
-		LOGDETAIL("scanning for binary: {}", k1.u8string().c_str());
+  // Strategy 1: look for a clap with the same name as this binary
+  for (auto &i : paths)
+  {
+    if (!fs::exists(i))
+      continue;
+    // try to find it the CLAP folder immediately
+    auto k1 = i / pluginfilename;
+    LOGDETAIL("scanning for binary: {}", k1.u8string().c_str());
 
-		if (fs::exists(k1))
-		{
-     	if (lib.load(k1.u8string().c_str()))
-			{
-				return true;
-			}
-		}
+    if (fs::exists(k1))
+    {
+      if (lib.load(k1.u8string().c_str()))
+      {
+        return true;
+      }
+    }
 
-		// Strategy 2: try to locate "CLAP/vendorX/plugY.clap"  - derived from "VST3/vendorX/plugY.vst3"
-		auto k2 = i / parentfolder / pluginfilename;
-		LOGDETAIL("scanning for binary: {}", k2.u8string().c_str());
-		if (fs::exists(k2))
-		{
-			if (lib.load(k2.u8string().c_str()))
-			{
-				return true;
-			}
-		}
+    // Strategy 2: try to locate "CLAP/vendorX/plugY.clap"  - derived from "VST3/vendorX/plugY.vst3"
+    auto k2 = i / parentfolder / pluginfilename;
+    LOGDETAIL("scanning for binary: {}", k2.u8string().c_str());
+    if (fs::exists(k2))
+    {
+      if (lib.load(k2.u8string().c_str()))
+      {
+        return true;
+      }
+    }
 
-		// Strategy 3: enumerate folders in CLAP folder and try to locate the plugin in any sub folder (only one level)
-		for (const auto& subdir : fs::directory_iterator(i))
-		{
-			auto k3 = i / subdir / pluginfilename;
-			LOGDETAIL("scanning for binary: {}", k3.u8string().c_str());
-			if (fs::exists(k3))
-			{
-				if (lib.load(k3.u8string().c_str()))
-				{
-					return true;
-				}
-			}
-		}
-	}
+    // Strategy 3: enumerate folders in CLAP folder and try to locate the plugin in any sub folder (only one level)
+    for (const auto &subdir : fs::directory_iterator(i))
+    {
+      auto k3 = i / subdir / pluginfilename;
+      LOGDETAIL("scanning for binary: {}", k3.u8string().c_str());
+      if (fs::exists(k3))
+      {
+        if (lib.load(k3.u8string().c_str()))
+        {
+          return true;
+        }
+      }
+    }
+  }
 
-	return false;
+  return false;
 }
 
-IPluginFactory* GetPluginFactoryEntryPoint() {
+IPluginFactory *GetPluginFactoryEntryPoint()
+{
 
 #if _DEBUG
-  // MessageBoxA(NULL,"halt","me",MB_OK); // <- enable this on Windows to get a debug attachment to vstscanner.exe (subprocess of cbse)
+  // MessageBoxA(NULL,"halt","me",MB_OK); // <- enable this on Windows to get a debug attachment to vstscanner.exe
+  // (subprocess of cbse)
 #endif
 
 #if SMTG_OS_WINDOWS
 // #pragma comment(linker, "/EXPORT:" __FUNCTION__ "=" __FUNCDNAME__)
 #endif
 
-	// static IPtr<Steinberg::CPluginFactory> gPluginFactory = nullptr;
-	static Clap::Library gClapLibrary;
+  // static IPtr<Steinberg::CPluginFactory> gPluginFactory = nullptr;
+  static Clap::Library gClapLibrary;
 
-	static std::vector<CreationContext> gCreationContexts;
+  static std::vector<CreationContext> gCreationContexts;
 
-	// if there is no ClapLibrary yet
-	if (!gClapLibrary._pluginFactory)
-	{
-		// if this binary does not already contain a CLAP entrypoint
-		if (!gClapLibrary.hasEntryPoint())
-		{
-			// try to find a clap which filename stem matches our own
-			auto kx = os::getParentFolderName();
-			auto plugname = os::getBinaryName();
-			plugname.append(".clap");
+  // if there is no ClapLibrary yet
+  if (!gClapLibrary._pluginFactory)
+  {
+    // if this binary does not already contain a CLAP entrypoint
+    if (!gClapLibrary.hasEntryPoint())
+    {
+      // try to find a clap which filename stem matches our own
+      auto kx = os::getParentFolderName();
+      auto plugname = os::getBinaryName();
+      plugname.append(".clap");
 
-			if (!findPlugin(gClapLibrary, plugname))
-			{
-				return nullptr;
-			}
-		}
-		else
-		{
-			LOGDETAIL("detected entrypoint in this binary");
-                }
-	}
-	if (gClapLibrary.plugins.empty())
-	{
-		// with no plugins there is nothing to do..
-		LOGINFO("no plugin has been found");
-		return nullptr;
-	}
+      if (!findPlugin(gClapLibrary, plugname))
+      {
+        return nullptr;
+      }
+    }
+    else
+    {
+      LOGDETAIL("detected entrypoint in this binary");
+    }
+  }
+  if (gClapLibrary.plugins.empty())
+  {
+    // with no plugins there is nothing to do..
+    LOGINFO("no plugin has been found");
+    return nullptr;
+  }
 
-	if (!clap_version_is_compatible(gClapLibrary.plugins[0]->clap_version))
-	{
-		// CLAP version is not compatible -> eject
-		LOGINFO("CLAP version is not compatible");
-		return nullptr;
-	}
+  if (!clap_version_is_compatible(gClapLibrary.plugins[0]->clap_version))
+  {
+    // CLAP version is not compatible -> eject
+    LOGINFO("CLAP version is not compatible");
+    return nullptr;
+  }
 
-	if (!gPluginFactory)
-	{
-		// we need at least one plugin to obtain vendor/name etc.
-		auto* factoryvendor = gClapLibrary.plugins[0]->vendor;
-		auto* vendor_url = gClapLibrary.plugins[0]->url;
-		// TODO: extract the domain and prefix with info@
-		auto* contact = "info@";
+  if (!gPluginFactory)
+  {
+    // we need at least one plugin to obtain vendor/name etc.
+    auto *factoryvendor = gClapLibrary.plugins[0]->vendor;
+    auto *vendor_url = gClapLibrary.plugins[0]->url;
+    // TODO: extract the domain and prefix with info@
+    auto *contact = "info@";
 
-		// override for VST3 specifics
-		if (gClapLibrary._pluginFactoryVst3Info)
-		{
-			
-			LOGDETAIL("detected extension `{}`", CLAP_PLUGIN_FACTORY_INFO_VST3);
-			auto& v3 = gClapLibrary._pluginFactoryVst3Info;
-			if (v3->vendor) factoryvendor = v3->vendor;
-			if (v3->vendor_url) vendor_url = v3->vendor_url;
-			if (v3->email_contact) contact = v3->email_contact;
-		}
+    // override for VST3 specifics
+    if (gClapLibrary._pluginFactoryVst3Info)
+    {
 
-		static PFactoryInfo factoryInfo(
-			factoryvendor, 
-			vendor_url, 
-			contact,
-			Vst::kDefaultFactoryFlags);
+      LOGDETAIL("detected extension `{}`", CLAP_PLUGIN_FACTORY_INFO_VST3);
+      auto &v3 = gClapLibrary._pluginFactoryVst3Info;
+      if (v3->vendor)
+        factoryvendor = v3->vendor;
+      if (v3->vendor_url)
+        vendor_url = v3->vendor_url;
+      if (v3->email_contact)
+        contact = v3->email_contact;
+    }
 
-		LOGDETAIL("created factory for vendor '{}'", factoryvendor);
+    static PFactoryInfo factoryInfo(factoryvendor, vendor_url, contact, Vst::kDefaultFactoryFlags);
 
-		gPluginFactory = new Steinberg::CPluginFactory(factoryInfo);		
-		// resize the classInfo vector
-		gCreationContexts.clear();
-		gCreationContexts.reserve(gClapLibrary.plugins.size());
-		int numPlugins = static_cast<int>(gClapLibrary.plugins.size());
-		LOGDETAIL("number of plugins in factory: {}", numPlugins);
-		for (int ctr = 0; ctr < numPlugins; ++ctr)
-		{
-			auto& clapdescr = gClapLibrary.plugins[ctr];
-			auto vst3info = gClapLibrary.get_vst3_info(ctr);
+    LOGDETAIL("created factory for vendor '{}'", factoryvendor);
 
-			LOGDETAIL("  plugin #{}: '{}'", ctr, clapdescr->name);
+    gPluginFactory = new Steinberg::CPluginFactory(factoryInfo);
+    // resize the classInfo vector
+    gCreationContexts.clear();
+    gCreationContexts.reserve(gClapLibrary.plugins.size());
+    int numPlugins = static_cast<int>(gClapLibrary.plugins.size());
+    LOGDETAIL("number of plugins in factory: {}", numPlugins);
+    for (int ctr = 0; ctr < numPlugins; ++ctr)
+    {
+      auto &clapdescr = gClapLibrary.plugins[ctr];
+      auto vst3info = gClapLibrary.get_vst3_info(ctr);
 
-			std::string n(clapdescr->name);
+      LOGDETAIL("  plugin #{}: '{}'", ctr, clapdescr->name);
+
+      std::string n(clapdescr->name);
 #ifdef _DEBUG
-			n.append(" (CLAP->VST3)");
+      n.append(" (CLAP->VST3)");
 #endif
-			auto plugname = n.c_str(); //  clapdescr->name;
+      auto plugname = n.c_str(); //  clapdescr->name;
 
-			// get vendor -------------------------------------
-			auto pluginvendor = clapdescr->vendor;
-			if (pluginvendor == nullptr || *pluginvendor == 0) pluginvendor = "Unspecified Vendor";
-			if (vst3info && vst3info->vendor)
-			{
-				LOGDETAIL("  plugin supports extension '{}'", CLAP_PLUGIN_AS_VST3);
-				pluginvendor = vst3info->vendor;
-			}
+      // get vendor -------------------------------------
+      auto pluginvendor = clapdescr->vendor;
+      if (pluginvendor == nullptr || *pluginvendor == 0)
+        pluginvendor = "Unspecified Vendor";
+      if (vst3info && vst3info->vendor)
+      {
+        LOGDETAIL("  plugin supports extension '{}'", CLAP_PLUGIN_AS_VST3);
+        pluginvendor = vst3info->vendor;
+      }
 
-         TUID lcid;
-         Crypto::uuid_object g;
+      TUID lcid;
+      Crypto::uuid_object g;
 
 #ifdef CLAP_VST3_TUID_STRING
-         Steinberg::FUID f;
-         if (f.fromString(CLAP_VST3_TUID_STRING))
-         {
-            memcpy(&g, f.toTUID(), sizeof(TUID));
-            memcpy(&lcid, &g, sizeof(TUID));
-         }
-         else
+      Steinberg::FUID f;
+      if (f.fromString(CLAP_VST3_TUID_STRING))
+      {
+        memcpy(&g, f.toTUID(), sizeof(TUID));
+        memcpy(&lcid, &g, sizeof(TUID));
+      }
+      else
 #endif
-         {
-            // make id or take it from vst3 info --------------
-            std::string id(clapdescr->id);
-            if (vst3info && vst3info->componentId) {
-               memcpy(&g, vst3info->componentId, sizeof(g));
-            } else {
-               g = Crypto::create_sha1_guid_from_name(id.c_str(), id.size());
-            }
+      {
+        // make id or take it from vst3 info --------------
+        std::string id(clapdescr->id);
+        if (vst3info && vst3info->componentId)
+        {
+          memcpy(&g, vst3info->componentId, sizeof(g));
+        }
+        else
+        {
+          g = Crypto::create_sha1_guid_from_name(id.c_str(), id.size());
+        }
 
-            memcpy(&lcid, &g, sizeof(TUID));
-         }
+        memcpy(&lcid, &g, sizeof(TUID));
+      }
 
-			// features ----------------------------------------
-			std::string features;
-			if (vst3info && vst3info->features)
-			{
-				features = vst3info->features;
-			}
-			else
-			{
-				features = clapCategoriesToVST3(clapdescr->features);
-			}
+      // features ----------------------------------------
+      std::string features;
+      if (vst3info && vst3info->features)
+      {
+        features = vst3info->features;
+      }
+      else
+      {
+        features = clapCategoriesToVST3(clapdescr->features);
+      }
 
-
-#if CLAP_WRAPPER_LOGLEVEL> 1
-			{
-				const uint8_t * v = reinterpret_cast<const uint8_t*>(&g);
-				char x[sizeof(g)*2+8];
-				char* o = x;
-				constexpr char hexchar[] = "0123456789ABCDEF";
-				for (auto i = 0U ; i < sizeof(g) ; i++)
-				{
-					auto n = v[i];
-					*o++ = hexchar[(n >> 4) & 0xF];
-					*o++ = hexchar[n & 0xF];
-					if (!(i % 4)) *o++ = 32;
-				}
-				*o++ = 0;
-				LOGDETAIL("plugin id: {} -> {}", clapdescr->id,x);
-			}
+#if CLAP_WRAPPER_LOGLEVEL > 1
+      {
+        const uint8_t *v = reinterpret_cast<const uint8_t *>(&g);
+        char x[sizeof(g) * 2 + 8];
+        char *o = x;
+        constexpr char hexchar[] = "0123456789ABCDEF";
+        for (auto i = 0U; i < sizeof(g); i++)
+        {
+          auto n = v[i];
+          *o++ = hexchar[(n >> 4) & 0xF];
+          *o++ = hexchar[n & 0xF];
+          if (!(i % 4))
+            *o++ = 32;
+        }
+        *o++ = 0;
+        LOGDETAIL("plugin id: {} -> {}", clapdescr->id, x);
+      }
 #endif
 
-			gCreationContexts.push_back({ &gClapLibrary, ctr, PClassInfo2(
-				lcid,
-				PClassInfo::kManyInstances,
-				kVstAudioEffectClass,
-				plugname,
-				0		/* the only flag is usually Vst:kDistributable, but CLAPs aren't distributable */,
-				features.c_str(),
-				pluginvendor,
-				clapdescr->version,
-				kVstVersionString)
-				});
-			gPluginFactory->registerClass(&gCreationContexts.back().classinfo, ClapAsVst3::createInstance, &gCreationContexts.back());
-		}
+      gCreationContexts.push_back(
+          {&gClapLibrary, ctr,
+           PClassInfo2(lcid, PClassInfo::kManyInstances, kVstAudioEffectClass, plugname,
+                       0 /* the only flag is usually Vst:kDistributable, but CLAPs aren't distributable */,
+                       features.c_str(), pluginvendor, clapdescr->version, kVstVersionString)});
+      gPluginFactory->registerClass(&gCreationContexts.back().classinfo, ClapAsVst3::createInstance,
+                                    &gCreationContexts.back());
+    }
+  }
+  else
+    gPluginFactory->addRef();
 
-	}
-	else
-		gPluginFactory->addRef();
-	
-	return gPluginFactory; 
+  return gPluginFactory;
 }
 
 /*
-*		creates an Instance from the creationContext.
-*		actually, there is always a valid entrypoint, otherwise no factory would have been provided.
-*/
-FUnknown* ClapAsVst3::createInstance(void* context)
-{	
-	auto ctx = static_cast<CreationContext*>(context);
-	
-	LOGINFO("creating plugin {} (#{})", ctx->classinfo.name, ctx->index);
-	if (ctx->lib->hasEntryPoint())
-	{
-		// MessageBoxA(NULL, "halt", "create", MB_OK);
-		return (IAudioProcessor*)new ClapAsVst3(ctx->lib, ctx->index, context);
-	}
-	return nullptr;	// this should never happen.
-	
+ *		creates an Instance from the creationContext.
+ *		actually, there is always a valid entrypoint, otherwise no factory would have been provided.
+ */
+FUnknown *ClapAsVst3::createInstance(void *context)
+{
+  auto ctx = static_cast<CreationContext *>(context);
+
+  LOGINFO("creating plugin {} (#{})", ctx->classinfo.name, ctx->index);
+  if (ctx->lib->hasEntryPoint())
+  {
+    // MessageBoxA(NULL, "halt", "create", MB_OK);
+    return (IAudioProcessor *)new ClapAsVst3(ctx->lib, ctx->index, context);
+  }
+  return nullptr; // this should never happen.
 }

--- a/src/wrapasvst3_export_entry.cpp
+++ b/src/wrapasvst3_export_entry.cpp
@@ -1,7 +1,8 @@
 
 #include "public.sdk/source/main/pluginfactory.h"
 
-SMTG_EXPORT_SYMBOL Steinberg::IPluginFactory* PLUGIN_API GetPluginFactory() {
-   extern Steinberg::IPluginFactory *GetPluginFactoryEntryPoint();
-   return GetPluginFactoryEntryPoint();
+SMTG_EXPORT_SYMBOL Steinberg::IPluginFactory *PLUGIN_API GetPluginFactory()
+{
+  extern Steinberg::IPluginFactory *GetPluginFactoryEntryPoint();
+  return GetPluginFactoryEntryPoint();
 }

--- a/src/wrapasvst3_export_entry.cpp
+++ b/src/wrapasvst3_export_entry.cpp
@@ -1,8 +1,8 @@
 
 #include "public.sdk/source/main/pluginfactory.h"
 
-SMTG_EXPORT_SYMBOL Steinberg::IPluginFactory *PLUGIN_API GetPluginFactory()
+SMTG_EXPORT_SYMBOL Steinberg::IPluginFactory* PLUGIN_API GetPluginFactory()
 {
-  extern Steinberg::IPluginFactory *GetPluginFactoryEntryPoint();
+  extern Steinberg::IPluginFactory* GetPluginFactoryEntryPoint();
   return GetPluginFactoryEntryPoint();
 }


### PR DESCRIPTION
1. Add a .clang-format which is basically 2 spaces, allman braces, embedded namespaces.
2. Reformat the entire codebase with find src -iname "*.cpp" -o -iname "*.h" -o -iname "*.mm" | xargs clang-format -i
3. add a cmake code checks target which currently just checkes that the code remains clang formatted
4. Add a github action which runs that code check target on ubuntu on a PR