### PR TITLE
feat: check for `nullptr` in `executeDefered`

### DIFF
--- a/src/detail/vst3/os/linux.cpp
+++ b/src/detail/vst3/os/linux.cpp
@@ -167,7 +167,7 @@ void LinuxHelper::executeDefered()
 {
   for (auto p : _plugs)
   {
-    p->onIdle();
+    if (p) p->onIdle();
   }
 }
 void LinuxHelper::attach(IPlugObject* plugobject)

--- a/src/detail/vst3/os/macos.mm
+++ b/src/detail/vst3/os/macos.mm
@@ -60,7 +60,7 @@ void MacOSHelper::executeDefered()
 {
   for (auto p : _plugs)
   {
-    p->onIdle();
+    if (p) p->onIdle();
   }
 }
 

--- a/src/detail/vst3/os/windows.cpp
+++ b/src/detail/vst3/os/windows.cpp
@@ -134,7 +134,10 @@ void WindowsHelper::terminate()
 
 void WindowsHelper::executeDefered()
 {
-  for (auto&& p : _plugs) p->onIdle();
+  for (auto&& p : _plugs)
+  {
+    if (p) p->onIdle();
+  }
 }
 
 void WindowsHelper::attach(IPlugObject* plugobject)


### PR DESCRIPTION
`p` can be `nullptr` in case hosts don't call `ClapAsVst3::setActive(false)` when a plugin gets deleted.