### PR TITLE
defensive countermeasure to bug in Renoise

### DIFF
--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -17,16 +17,30 @@ namespace os
 
 class State
 {
-public:
-  State(std::function<void()> on, std::function<void()> off)
-  : _on(on)
-  , _off(off)
-  {}
-  void on(){ if ( !_state ) { _on(); } _state = true; }
-  void off(){ if ( _state ) { _off();} _state = false; }
-private:
+ public:
+  State(std::function<void()> on, std::function<void()> off) : _on(on), _off(off)
+  {
+  }
+  void on()
+  {
+    if (!_state)
+    {
+      _on();
+    }
+    _state = true;
+  }
+  void off()
+  {
+    if (_state)
+    {
+      _off();
+    }
+    _state = false;
+  }
+
+ private:
   bool _state = false;
-  std::function<void()> _on,_off;
+  std::function<void()> _on, _off;
 };
 
 class IPlugObject

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -14,9 +14,17 @@
 
 namespace os
 {
-
+  
 class State
 {
+  // the State class ensures that a specific function pair (like init/terminate) is only called in pairs.
+  // the bool _state reflects if the _on lambda has already been called
+  // on destruction, it makes sure that the _off lambda is definitely called.
+  //
+  // the construct should only be applied to when no state machine can cover this properly
+  // or your own code depends on correct calling sequences of an external code base and should
+  // help to implement defensive programming.
+  
  public:
   State(std::function<void()> on, std::function<void()> off) : _on(on), _off(off)
   {

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -7,12 +7,27 @@
 
 #include <atomic>
 #include <string>
+#include <functional>
 #define FMT_HEADER_ONLY 1
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 
 namespace os
 {
+
+class State {
+public:
+  State(std::function<void()> on, std::function<void()> off)
+  : _on(on)
+  , _off(off)
+  {}
+  void on() { if ( !_state ) { _on(); } _state = true; }
+  void off() { if ( _state ) { _off();} _state = false; }
+private:
+  bool _state = false;
+  std::function<void()> _on,_off;
+};
+
 class IPlugObject
 {
  public:

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -21,6 +21,10 @@ class State
   State(std::function<void()> on, std::function<void()> off) : _on(on), _off(off)
   {
   }
+  ~State()
+  {
+    off();
+  }
   void on()
   {
     if (!_state)

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -22,8 +22,8 @@ public:
   : _on(on)
   , _off(off)
   {}
-  void on() { if ( !_state ) { _on(); } _state = true; }
-  void off() { if ( _state ) { _off();} _state = false; }
+  void on(){ if ( !_state ) { _on(); } _state = true; }
+  void off(){ if ( _state ) { _off();} _state = false; }
 private:
   bool _state = false;
   std::function<void()> _on,_off;

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -14,7 +14,7 @@
 
 namespace os
 {
-  
+
 class State
 {
   // the State class ensures that a specific function pair (like init/terminate) is only called in pairs.
@@ -24,7 +24,7 @@ class State
   // the construct should only be applied to when no state machine can cover this properly
   // or your own code depends on correct calling sequences of an external code base and should
   // help to implement defensive programming.
-  
+
  public:
   State(std::function<void()> on, std::function<void()> off) : _on(on), _off(off)
   {

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -15,7 +15,8 @@
 namespace os
 {
 
-class State {
+class State
+{
 public:
   State(std::function<void()> on, std::function<void()> off)
   : _on(on)

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -60,7 +60,7 @@ tresult PLUGIN_API ClapAsVst3::terminate()
 {
   if (_plugin)
   {
-    _os_attached.off();  // ensure we are detached (countermeasure to Bug in Renoise)
+    _os_attached.off();  // ensure we are detached
     _plugin->terminate();
     _plugin.reset();
   }

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -60,7 +60,7 @@ tresult PLUGIN_API ClapAsVst3::terminate()
 {
   if (_plugin)
   {
-    _os_attached.off();     // ensure we are detached (countermeasure to Bug in Renoise)
+    _os_attached.off();  // ensure we are detached (countermeasure to Bug in Renoise)
     _plugin->terminate();
     _plugin.reset();
   }

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -60,6 +60,7 @@ tresult PLUGIN_API ClapAsVst3::terminate()
 {
   if (_plugin)
   {
+    _os_attached.off();     // ensure we are detached (countermeasure to Bug in Renoise)
     _plugin->terminate();
     _plugin.reset();
   }
@@ -87,11 +88,12 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
         _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
     updateAudioBusses();
 
-    os::attach(this);
+    _os_attached.on();
   }
   if (!state)
   {
-    os::detach(this);
+    _os_attached.off();
+
     if (_active)
     {
       _plugin->deactivate();

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -108,7 +108,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
     , _library(lib)
     , _libraryIndex(number)
     , _creationcontext(context)
-    , _os_attached( [this]{os::attach(this);},[this]{os::detach(this);})
+    , _os_attached( [this]{ os::attach(this); }, [this]{ os::detach(this); })
   {
   }
 

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -108,7 +108,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
     , _library(lib)
     , _libraryIndex(number)
     , _creationcontext(context)
-    , _os_attached( [this]{ os::attach(this); }, [this]{ os::detach(this); })
+    , _os_attached([this] { os::attach(this); }, [this] { os::detach(this); })
   {
   }
 

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -108,6 +108,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
     , _library(lib)
     , _libraryIndex(number)
     , _creationcontext(context)
+    , _os_attached( [this]{os::attach(this);},[this]{os::detach(this);})
   {
   }
 
@@ -253,6 +254,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   // plugin state
   bool _active = false;
+  os::State _os_attached;
   bool _processing = false;
   std::mutex _processingLock;
   std::atomic_bool _requestedFlush = false;


### PR DESCRIPTION
created a state class that ensure that a state is safely switching once between states.
added the detaching from timers etc. to member function `terminate()` too so circumvent a bug in ReNoise.