### PR TITLE
Refactor the cmake compile options a bit

### DIFF
--- a/cmake/enable_sdks.cmake
+++ b/cmake/enable_sdks.cmake
@@ -258,10 +258,19 @@ if (APPLE)
 endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
 	target_compile_options(clap-wrapper-compile-options INTERFACE -Wall -Wextra -Wno-unused-parameter -Wpedantic -Werror)
-	if (${CLAP_WRAPPER_ENABLE_ASAN})
-		message(STATUS "clap-wrapper: enabling asan build")
-		target_compile_options(clap-wrapper-sanitizer-options INTERFACE -fsanitize=address -fsanitize=undefined)
-		target_link_options(clap-wrapper-sanitizer-options INTERFACE -fsanitize=address -fsanitize=undefined)
+	if (${CLAP_WRAPPER_ENABLE_SANITIZER})
+		message(STATUS "clap-wrapper: enabling sanitizer build")
+
+		target_compile_options(clap-wrapper-sanitizer-options INTERFACE
+				-fsanitize=address,undefined,float-divide-by-zero
+				-fsanitize-address-use-after-return=always
+				-fsanitize-address-use-after-scope
+				)
+		target_link_options(clap-wrapper-sanitizer-options INTERFACE
+				-fsanitize=address,undefined,float-divide-by-zero
+				-fsanitize-address-use-after-return=always
+				-fsanitize-address-use-after-scope
+				)
 		target_link_libraries(clap-wrapper-compile-options INTERFACE clap-wrapper-sanitizer-options)
 	endif()
 endif()

--- a/src/detail/auv2/auv2_shared.h
+++ b/src/detail/auv2/auv2_shared.h
@@ -53,7 +53,7 @@ struct ClapBridge
 
     if (_clapid.empty())
     {
-      if (_idx < 0 || _idx >= _library.plugins.size())
+      if (_idx < 0 || _idx >= (int)_library.plugins.size())
       {
         std::cout << "[ERROR] cannot load by index" << std::endl;
         return;

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -132,13 +132,16 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
       clap_plugin_info_as_auv2_t v2inf;
       auto res =
           loader._pluginFactoryAUv2Info->get_auv2_info(loader._pluginFactoryAUv2Info, idx, &v2inf);
-      if (v2inf.au_type[0] != 0)
+      if (res)
       {
-        u.type = v2inf.au_type;
-      }
-      if (v2inf.au_subt[0] != 0)
-      {
-        u.subt = v2inf.au_subt;
+        if (v2inf.au_type[0] != 0)
+        {
+          u.type = v2inf.au_type;
+        }
+        if (v2inf.au_subt[0] != 0)
+        {
+          u.subt = v2inf.au_subt;
+        }
       }
     }
 


### PR DESCRIPTION
A few options (like -DPLATFORM=1 and macos filesystem and warnings) were starting to be applied multiple places and not consistently. For instance I had forgotten them on the auv2 build helper. So

1. Make a `clap-wrapper-compile-options` interface which sets up all these things
2. Set it as a link dep of the things which need it
3. Fix the build bugs with the auv2 helper from turning on warnings there and
4. Add an option to likn with asan, which is still a work in progress