### PR TITLE
Clap Proxy re-use changes

### DIFF
--- a/cmake/enable_sdks.cmake
+++ b/cmake/enable_sdks.cmake
@@ -167,8 +167,6 @@ function(DefineCLAPASVST3Sources)
 	endif()
 
 	set(wrappersources_vst3
-		src/clap_proxy.h
-		src/clap_proxy.cpp
 		src/wrapasvst3.h
 		src/wrapasvst3.cpp
 		src/wrapasvst3_entry.cpp
@@ -660,7 +658,6 @@ if (APPLE)
 	endif()
 endif()
 
-
 # Define the extensions target
 if ( NOT TARGET clap-wrapper-extensions)
 	add_library(clap-wrapper-extensions INTERFACE)
@@ -668,6 +665,8 @@ if ( NOT TARGET clap-wrapper-extensions)
 endif()
 
 add_library(clap-wrapper-shared-detail STATIC
+		src/clap_proxy.h
+		src/clap_proxy.cpp
 		src/detail/sha1.h
 		src/detail/sha1.cpp
 		src/detail/clap/fsutil.h

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -1,5 +1,6 @@
 #include "clap_proxy.h"
 #include "detail/clap/fsutil.h"
+#include <cstring>
 
 #if MAC || LIN
 #include <iostream>

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -130,7 +130,7 @@ std::shared_ptr<Plugin> Plugin::createInstance(const clap_plugin_factory* fac, s
                                                Clap::IHost* host)
 {
   auto pc = fac->get_plugin_count(fac);
-  if (idx < 0 || idx >= pc) return nullptr;
+  if (idx >= pc) return nullptr;
   auto desc = fac->get_plugin_descriptor(fac, idx);
   return createInstance(fac, desc->id, host);
 }

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -1,6 +1,5 @@
 #include "clap_proxy.h"
 #include "detail/clap/fsutil.h"
-#include "public.sdk/source/main/pluginfactory.h"
 
 #if MAC || LIN
 #include <iostream>
@@ -115,6 +114,25 @@ static void tail_changed(const clap_host_t* host)
 const clap_host_tail tail = {tail_changed};
 
 }  // namespace HostExt
+
+std::shared_ptr<Plugin> Plugin::createInstance(const clap_plugin_factory* fac, const std::string& id,
+                                               Clap::IHost* host)
+{
+  auto plug = std::shared_ptr<Plugin>(new Plugin(host));
+  auto instance = fac->create_plugin(fac, plug->getClapHostInterface(), id.c_str());
+  plug->connectClap(instance);
+
+  return plug;
+}
+
+std::shared_ptr<Plugin> Plugin::createInstance(const clap_plugin_factory* fac, size_t idx,
+                                               Clap::IHost* host)
+{
+  auto pc = fac->get_plugin_count(fac);
+  if (idx < 0 || idx >= pc) return nullptr;
+  auto desc = fac->get_plugin_descriptor(fac, idx);
+  return createInstance(fac, desc->id, host);
+}
 
 std::shared_ptr<Plugin> Plugin::createInstance(Clap::Library& library, size_t index, IHost* host)
 {

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -124,7 +124,10 @@ class Raise
 class Plugin
 {
  public:
-  static std::shared_ptr<Plugin> createInstance(Clap::Library& library, size_t index, IHost* host);
+  static std::shared_ptr<Plugin> createInstance(const clap_plugin_factory*, const std::string& id,
+                                                IHost* host);
+  static std::shared_ptr<Plugin> createInstance(const clap_plugin_factory*, size_t idx, IHost* host);
+  static std::shared_ptr<Plugin> createInstance(Clap::Library& library, size_t idx, IHost* host);
 
  protected:
   // only the Clap::Library is allowed to create instances


### PR DESCRIPTION
1. Remove a specious vst3 include
2. Move the clap-prox to the right cmake target
3. Add a few more Plugin creators from factory directly (which is useful for the static standalone, not included in this commit)