### PR TITLE
fix: by default signal that events are not handled by the plugin

### DIFF
--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -121,17 +121,17 @@ tresult PLUGIN_API WrappedView::removed()
 
 tresult PLUGIN_API WrappedView::onWheel(float distance)
 {
-  return kResultOk;
+  return kResultFalse;
 }
 
 tresult PLUGIN_API WrappedView::onKeyDown(char16 key, int16 keyCode, int16 modifiers)
 {
-  return kResultOk;
+  return kResultFalse;
 }
 
 tresult PLUGIN_API WrappedView::onKeyUp(char16 key, int16 keyCode, int16 modifiers)
 {
-  return kResultOk;
+  return kResultFalse;
 }
 
 tresult PLUGIN_API WrappedView::getSize(ViewRect* size)


### PR DESCRIPTION
As described by the [JUCE docs](https://github.com/juce-framework/JUCE/blob/22df0d2266007bccb25d6ed52b9907f60d04e971/modules/juce_audio_processors/format_types/VST3_SDK/pluginterfaces/gui/iplugview.h#L146), returning `kResultFalse` does not signal that the operation failed but that event has not been consumed and handled by the plugin. In effect, the new implementation signals that the event should be handled by the host.

CLAP itself has no mechanism as of now to signal whether events have been handled by the plugin. This could be solved in the future in form of an extension. Therefore, the returned values from the VST3 wrapper event handler are inverted as part of this PR. In effect, DAWs like FL Studio now respond to shortcuts like cmd+z to undo which would not be the case if `kResultOk` is returned.