### PR TITLE
fix: increase preallocated memory to avoid `malloc` in rt code

### DIFF
--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -110,15 +110,15 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t* plugin, const clap_plu
   _out_events.try_push = output_events_try_push;
 
   _events.clear();
-  _events.reserve(256);
+  _events.reserve(8192);
   _eventindices.clear();
   _eventindices.reserve(_events.capacity());
 
   _out_events.ctx = this;
 
-  _gesturedParameters.reserve(32);
+  _gesturedParameters.reserve(8192);
 
-  _activeNotes.reserve(64);
+  _activeNotes.reserve(256);
 
   _supportsPolyPressure = enablePolyPressure;
   _supportsTuningNoteExpression = supportsTuningNoteExpression;


### PR DESCRIPTION
dtrace log: [dtrace-inrease-prealloc.log](https://github.com/free-audio/clap-wrapper/files/12597333/dtrace-inrease-prealloc.log)

increasing the amount of preallocated memory avoids `malloc` and system calls as long as the reserved memory is not exceeded.