### PR TITLE
A rudimentary standalone wrapper

### DIFF
--- a/cmake/enable_sdks.cmake
+++ b/cmake/enable_sdks.cmake
@@ -658,6 +658,168 @@ if (APPLE)
 	endif()
 endif()
 
+function(target_add_standalone_wrapper)
+	set(oneValueArgs
+			TARGET
+			OUTPUT_NAME
+			BUNDLE_IDENTIFIER
+			BUNDLE_VERSION
+
+			PLUGIN_INDEX
+			PLUGIN_ID
+			STATICALLY_LINKED_CLAP_ENTRY
+			HOSTED_CLAP_NAME
+			)
+	cmake_parse_arguments(SA "" "${oneValueArgs}" "" ${ARGN} )
+
+	if (NOT DEFINED SA_TARGET)
+		message(FATAL_ERROR "clap-wrapper: target_add_standalone_wrapper requires a target")
+	endif()
+
+	if (NOT TARGET ${SA_TARGET})
+		message(FATAL_ERROR "clap-wrapper: standalone-target must be a target")
+	endif()
+
+	if (NOT DEFINED SA_PLUGIN_ID)
+		set(SA_PLUGIN_ID "")
+	endif()
+
+	if (NOT DEFINED SA_PLUGIN_INDEX)
+		set(SA_PLUGIN_INDEX 0)
+	endif()
+
+	if (NOT DEFINED SA_OUTPUT_NAME)
+		set(SA_OUTPUT_NAME ${SA_TARGET})
+	endif()
+
+	# TODO - make these opt in on the command line
+	if (NOT TARGET base-sdk-rtaudio)
+
+		set(RTAUDIO_TARGETNAME_UNINSTALL "rtaudio-uninstall" CACHE STRING "Name of 'uninstall' build target")
+		set(RTAUDIO_BUILD_STATIC_LIBS TRUE CACHE BOOL "static rdmidi")
+		set(RTAUDIO_BUILD_TESTING OFF CACHE BOOL "don't eject test targets")
+
+		CPMAddPackage(
+				NAME "rtaudio"
+				GITHUB_REPOSITORY "thestk/rtaudio"
+				GIT_TAG "6.0.1"
+				EXCLUDE_FROM_ALL TRUE
+				SOURCE_DIR cpm/rtaudio
+		)
+		add_library(base-sdk-rtaudio INTERFACE)
+		target_link_libraries(base-sdk-rtaudio INTERFACE rtaudio)
+	endif()
+	if (NOT TARGET base-sdk-rtmidi)
+		if (APPLE OR WIN32)
+			set(RTMIDI_API_JACK FALSE CACHE BOOL "skip jack")
+		endif()
+		set(RTMIDI_TARGETNAME_UNINSTALL "rtmidi-uninstall" CACHE STRING "Name of 'uninstall' build target")
+		set(RTMIDI_BUILD_STATIC_LIBS TRUE CACHE BOOL "static rdmidi")
+		set(RTMIDI_BUILD_TESTING OFF CACHE BOOL "don't eject test targets")
+
+		CPMAddPackage(
+				NAME "rtmidi"
+				GITHUB_REPOSITORY "thestk/rtmidi"
+				GIT_TAG "6.0.0"
+				EXCLUDE_FROM_ALL TRUE
+				SOURCE_DIR cpm/rtmidi
+		)
+		add_library(base-sdk-rtmidi INTERFACE)
+		target_link_libraries(base-sdk-rtmidi INTERFACE rtmidi)
+	endif()
+
+	set(salib ${SA_TARGET}-clap-wrapper-standalone-lib)
+	add_library(${salib} STATIC
+			${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/entry.cpp
+			${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/standalone_host.cpp
+			${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/standalone_host_audio.cpp
+			${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/standalone_host_midi.cpp
+			)
+	target_link_libraries(${salib}
+			PUBLIC
+			clap-wrapper-compile-options
+			clap-wrapper-shared-detail
+			base-sdk-rtmidi
+			base-sdk-rtaudio
+			)
+
+	if (APPLE)
+		target_sources(${salib} PRIVATE)
+		target_link_libraries(${salib}
+				PUBLIC "-framework AVFoundation" "-framework Foundation" "-framework CoreFoundation" "-framework AppKit")
+
+	endif()
+
+	if (APPLE)
+		set(MAIN_XIB "${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/macos/MainMenu.xib")
+		set(GEN_XIB "${CMAKE_BINARY_DIR}/generated_xib/${SA_TARGET}/MainMenu.xib")
+		configure_file(${MAIN_XIB} ${GEN_XIB})
+
+
+		target_sources(${SA_TARGET} PRIVATE
+				"${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/wrapasstandalone.mm"
+				${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/macos/AppDelegate.mm
+				${GEN_XIB}
+				)
+
+		set_target_properties(${SA_TARGET} PROPERTIES
+				BUNDLE TRUE
+				BUNDLE_NAME ${SA_OUTPUT_NAME}
+				OUTPUT_NAME ${SA_OUTPUT_NAME}
+				MACOSX_BUNDLE_BUNDLE_NAME ${SA_OUTPUT_NAME}
+				MACOSX_BUNDLE TRUE
+				MACOSX_BUNDLE_INFO_PLIST ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/macos/Info.plist.in
+				RESOURCE "${GEN_XIB}"
+				)
+
+		if (NOT ${CMAKE_GENERATOR} STREQUAL "Xcode")
+			message(STATUS "cmake-wrapper: ejecting xib->nib rules manually for ${CMAKE_GENERATOR} on ${SA_TARGET}")
+			find_program(IBTOOL ibtool REQUIRED)
+			add_custom_command(TARGET ${SA_TARGET} PRE_BUILD
+					COMMAND ${CMAKE_COMMAND} -E echo ${IBTOOL} --compile "$<TARGET_PROPERTY:${SA_TARGET},MACOSX_BUNDLE_BUNDLE_NAME>.app/Contents/Resources/MainMenu.nib" ${GEN_XIB}
+					COMMAND ${IBTOOL} --compile "$<TARGET_PROPERTY:${SA_TARGET},MACOSX_BUNDLE_BUNDLE_NAME>.app/Contents/Resources/MainMenu.nib" ${GEN_XIB}
+					)
+		endif()
+
+	elseif(UNIX)
+		target_sources(${SA_TARGET} PRIVATE
+				${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/wrapasstandalone.cpp)
+
+		find_package(PkgConfig REQUIRED)
+		pkg_check_modules(GTK gtkmm-3.0)
+		if (${GTK_FOUND})
+			message(STATUS "clap-wrapper: using gtkmm-3.0 for standalone")
+			target_compile_options(${salib} PUBLIC ${GTK_CFLAGS})
+			target_include_directories(${salib} PUBLIC ${GTK_INCLUDE_DIRS})
+			target_link_libraries(${salib} PUBLIC ${GTK_LINK_LIBRARIES})
+			target_compile_definitions(${salib} PUBLIC CLAP_WRAPPER_HAS_GTK3)
+			target_sources(${salib} PRIVATE ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/linux/gtkutils.cpp)
+		else()
+			message(STATUS "clap-wrapper: can't find gtkmm-3.0; no ui in standalone")
+		endif()
+
+	else()
+		target_sources(${SA_TARGET} PRIVATE
+				${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/wrapasstandalone.cpp)
+	endif()
+	if (DEFINED SA_HOSTED_CLAP_NAME)
+		set(hasclapname TRUE)
+	endif()
+	target_compile_definitions(${SA_TARGET} PRIVATE
+			PLUGIN_ID="${SA_PLUGIN_ID}"
+			PLUGIN_INDEX=${SA_PLUGIN_INDEX}
+			$<$<BOOL:${SA_STATICALLY_LINKED_CLAP_ENTRY}>:STATICALLY_LINKED_CLAP_ENTRY=1>
+			$<$<BOOL:${hasclapname}>:HOSTED_CLAP_NAME="${SA_HOSTED_CLAP_NAME}">
+			OUTPUT_NAME="${OUTPUT_NAME}"
+			)
+	target_link_libraries(${SA_TARGET} PRIVATE
+			clap-wrapper-compile-options
+			clap-wrapper-shared-detail
+			${salib}
+			)
+
+endfunction(target_add_standalone_wrapper)
+
 # Define the extensions target
 if ( NOT TARGET clap-wrapper-extensions)
 	add_library(clap-wrapper-extensions INTERFACE)

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -233,7 +233,6 @@ void Plugin::schnick()
 
 bool Plugin::initialize()
 {
-  fprintf(stderr, "Plugin Initialize\n");
   if (_ext._audioports)
   {
     _parentHost->setupAudioBusses(_plugin, _ext._audioports);
@@ -418,13 +417,18 @@ void Plugin::param_request_flush()
 // [thread-safe]
 const void* Plugin::clapExtension(const clap_host* host, const char* extension)
 {
+  std::cout << "EXTENSION " << extension << std::endl;
   if (!strcmp(extension, CLAP_EXT_LOG)) return &HostExt::log;
   if (!strcmp(extension, CLAP_EXT_PARAMS)) return &HostExt::params;
   if (!strcmp(extension, CLAP_EXT_THREAD_CHECK)) return &HostExt::threadcheck;
   if (!strcmp(extension, CLAP_EXT_GUI)) return &HostExt::hostgui;
   if (!strcmp(extension, CLAP_EXT_TIMER_SUPPORT)) return &HostExt::hosttimer;
 #if LIN
-  if (!strcmp(extension, CLAP_EXT_POSIX_FD_SUPPORT)) return &HostExt::hostposixfd;
+  if (!strcmp(extension, CLAP_EXT_POSIX_FD_SUPPORT))
+  {
+    std::cout << "Returning hpfd" << std::endl;
+    return &HostExt::hostposixfd;
+  }
 #endif
   if (!strcmp(extension, CLAP_EXT_LATENCY)) return &HostExt::latency;
   if (!strcmp(extension, CLAP_EXT_TAIL))

--- a/src/detail/standalone/entry.cpp
+++ b/src/detail/standalone/entry.cpp
@@ -1,0 +1,105 @@
+#include <memory>
+
+#include "standalone_details.h"
+#include "standalone_host.h"
+#include "entry.h"
+
+namespace Clap::Standalone
+{
+
+static std::unique_ptr<StandaloneHost> standaloneHost;
+std::shared_ptr<Clap::Plugin> plugin;
+const clap_plugin_entry *entry{nullptr};
+
+std::shared_ptr<Clap::Plugin> mainCreatePlugin(const clap_plugin_entry *ee, const std::string &clapId,
+                                               uint32_t clapIndex, int argc, char **argv)
+{
+  entry = ee;
+  LOG << "Standalone starting : " << argv[0] << std::endl;
+
+  LOG << "CLAP Version : " << entry->clap_version.major << "." << entry->clap_version.major << "."
+      << entry->clap_version.revision << std::endl;
+
+  entry->init(argv[0]);
+
+  auto fac = (const clap_plugin_factory *)entry->get_factory(CLAP_PLUGIN_FACTORY_ID);
+  if (!fac)
+  {
+    LOG << "[ERROR] entry->get_factory return nullptr" << std::endl;
+    return nullptr;
+  }
+
+  standaloneHost = std::make_unique<StandaloneHost>();
+
+  if (clapId.empty())
+  {
+    LOG << "Loading CLAP by index " << clapIndex << std::endl;
+    plugin = Clap::Plugin::createInstance(fac, clapIndex, standaloneHost.get());
+  }
+  else
+  {
+    LOG << "Loading CLAP by id '" << clapId << "'" << std::endl;
+    plugin = Clap::Plugin::createInstance(fac, clapId, standaloneHost.get());
+  }
+
+  if (!plugin)
+  {
+    LOG << "[ERROR] Unable to create plugin" << std::endl;
+    return nullptr;
+  }
+
+  standaloneHost->setPlugin(plugin);
+
+  plugin->initialize();
+
+  plugin->setSampleRate(48000);
+  plugin->setBlockSizes(32, 1024);
+  plugin->activate();
+
+  plugin->start_processing();
+
+  return plugin;
+}
+
+void mainStartAudio()
+{
+  standaloneHost->startMIDIThread();
+  standaloneHost->startAudioThread();
+}
+
+std::shared_ptr<Clap::Plugin> getMainPlugin()
+{
+  return plugin;
+}
+
+int mainWait()
+{
+  while (standaloneHost->running)
+  {
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(1s);
+  }
+  return 0;
+}
+
+int mainFinish()
+{
+  LOG << "Shutting down" << std::endl;
+
+  if (standaloneHost && plugin)
+  {
+    standaloneHost->stopAudioThread();
+    standaloneHost->stopMIDIThread();
+
+    plugin->deactivate();
+  }
+  plugin.reset();
+  standaloneHost.reset();
+
+  if (entry)
+  {
+    entry->deinit();
+  }
+  return 0;
+}
+}  // namespace Clap::Standalone

--- a/src/detail/standalone/entry.h
+++ b/src/detail/standalone/entry.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <clap/clap.h>
+#include <clap_proxy.h>
+#include <string>
+
+namespace Clap::Standalone
+{
+std::shared_ptr<Clap::Plugin> mainCreatePlugin(const clap_plugin_entry *entry, const std::string &clapId,
+                                               uint32_t clapIndex, int argc, char **argv);
+void mainStartAudio();
+
+std::shared_ptr<Clap::Plugin> getMainPlugin();
+int mainWait();
+int mainFinish();
+}  // namespace Clap::Standalone

--- a/src/detail/standalone/linux/gtkutils.cpp
+++ b/src/detail/standalone/linux/gtkutils.cpp
@@ -1,0 +1,70 @@
+#if CLAP_WRAPPER_HAS_GTK3
+
+#include <gtk/gtk.h>
+#include <gdk/gdkx.h>
+#include "gtkutils.h"
+#include "detail/standalone/standalone_details.h"
+
+namespace Clap::Standalone::Linux
+{
+
+static void activate(GtkApplication *app, gpointer user_data)
+{
+  auto g = (GtkGui *)user_data;
+  g->setupPlugin(app);
+}
+
+void GtkGui::setupPlugin(_GtkApplication *app)
+{
+  GtkWidget *window;
+
+  if (plugin->_ext._gui)
+  {
+    auto ui = plugin->_ext._gui;
+    auto p = plugin->_plugin;
+    if (!ui->is_api_supported(p, CLAP_WINDOW_API_X11, false)) LOG << "NO X11 " << std::endl;
+
+    ui->create(p, CLAP_WINDOW_API_X11, false);
+    ui->set_scale(p, 1);
+
+    uint32_t w, h;
+    ui->get_size(p, &w, &h);
+
+    window = gtk_application_window_new(app);
+    gtk_window_set_title(GTK_WINDOW(window), "Standalone Window");
+    gtk_window_set_default_size(GTK_WINDOW(window), w, h);
+    gtk_widget_show_all(window);
+
+    clap_window win;
+    win.api = CLAP_WINDOW_API_X11;
+    auto gw = gtk_widget_get_window(GTK_WIDGET(window));
+    win.x11 = GDK_WINDOW_XID(gw);
+    ui->set_parent(p, &win);
+    ui->show(p);
+  }
+}
+
+void GtkGui::initialize()
+{
+  app = gtk_application_new("org.gtk.example", G_APPLICATION_FLAGS_NONE);
+  g_signal_connect(app, "activate", G_CALLBACK(activate), this);
+}
+
+void GtkGui::setPlugin(std::shared_ptr<Clap::Plugin> p)
+{
+  plugin = p;
+}
+
+void GtkGui::runloop(int argc, char **argv)
+{
+  g_application_run(G_APPLICATION(app), argc, argv);
+}
+
+void GtkGui::shutdown()
+{
+  g_object_unref(app);
+}
+
+}  // namespace Clap::Standalone::Linux
+
+#endif

--- a/src/detail/standalone/linux/gtkutils.h
+++ b/src/detail/standalone/linux/gtkutils.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <clap_proxy.h>
+
+struct _GtkApplication;  // sigh their typedef screws up forward decls
+namespace Clap::Standalone::Linux
+{
+struct GtkGui
+{
+  _GtkApplication *app{nullptr};
+  std::shared_ptr<Clap::Plugin> plugin;
+
+  void initialize();
+  void setPlugin(std::shared_ptr<Clap::Plugin>);
+  void runloop(int argc, char **argv);
+  void shutdown();
+
+  void setupPlugin(_GtkApplication *app);
+};
+}  // namespace Clap::Standalone::Linux

--- a/src/detail/standalone/macos/AppDelegate.h
+++ b/src/detail/standalone/macos/AppDelegate.h
@@ -1,0 +1,5 @@
+#import <Cocoa/Cocoa.h>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+
+@end

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -1,0 +1,120 @@
+#import "AppDelegate.h"
+
+#include <AVFoundation/AVFoundation.h>
+
+#include "detail/standalone/entry.h"
+#include "detail/standalone/standalone_details.h"
+
+#include "detail/clap/fsutil.h"
+
+@interface AppDelegate ()
+
+@property(assign) IBOutlet NSWindow *window;
+@end
+
+@implementation AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification
+{
+  // Insert code here to initialize your application
+  const char *argv[2] = {OUTPUT_NAME, 0};
+
+  const clap_plugin_entry *entry{nullptr};
+#ifdef STATICALLY_LINKED_CLAP_ENTRY
+  extern const clap_plugin_entry clap_entry;
+  entry = &clap_entry;
+#else
+  // Library shenanigans t/k
+  std::string cn{HOSTED_CLAP_NAME};
+  LOG << "Loading " << cn << std::endl;
+
+  auto pts = Clap::getValidCLAPSearchPaths();
+
+  auto lib = Clap::Library();
+
+  for (const auto &p : pts)
+  {
+    auto cp = p / (cn + ".clap");
+
+    if (fs::is_directory(cp))
+    {
+      lib.load(cp.u8string().c_str());
+      entry = lib._pluginEntry;
+    }
+  }
+#endif
+
+  if (!entry)
+  {
+    return;
+  }
+
+  std::string pid{PLUGIN_ID};
+  int pindex{PLUGIN_INDEX};
+
+  switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo])
+  {
+    case AVAuthorizationStatusNotDetermined:
+    {
+      // The app hasn't yet asked the user for camera access.
+      [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
+                               completionHandler:^(BOOL granted) {
+                                 if (granted)
+                                 {
+                                 }
+                               }];
+      break;
+    }
+    default:
+      break;
+  }
+
+  auto plugin = Clap::Standalone::mainCreatePlugin(entry, pid, pindex, 1, (char **)argv);
+
+  [[self window] orderFrontRegardless];
+
+  if (plugin->_ext._gui)
+  {
+    auto ui = plugin->_ext._gui;
+    auto p = plugin->_plugin;
+    if (!ui->is_api_supported(p, CLAP_WINDOW_API_COCOA, false)) LOG << "NO COCOA " << std::endl;
+
+    ui->create(p, CLAP_WINDOW_API_COCOA, false);
+    ui->set_scale(p, 1);
+
+    uint32_t w, h;
+    ui->get_size(p, &w, &h);
+
+    NSView *view = [[self window] contentView];
+
+    NSSize sz;
+    sz.width = w;
+    sz.height = h;
+    [[self window] setContentSize:sz];
+
+    clap_window win;
+    win.api = CLAP_WINDOW_API_COCOA;
+    win.cocoa = view;
+    ui->set_parent(p, &win);
+    ui->show(p);
+  }
+
+  Clap::Standalone::mainStartAudio();
+}
+
+- (void)applicationWillTerminate:(NSNotification *)aNotification
+{
+  LOG << "applicationWillTerminate shutdown" << std::endl;
+  auto plugin = Clap::Standalone::getMainPlugin();
+
+  if (plugin && plugin->_ext._gui)
+  {
+    plugin->_ext._gui->hide(plugin->_plugin);
+    plugin->_ext._gui->destroy(plugin->_plugin);
+  }
+
+  // Insert code here to tear down your application
+  Clap::Standalone::mainFinish();
+}
+
+@end

--- a/src/detail/standalone/macos/Info.plist.in
+++ b/src/detail/standalone/macos/Info.plist.in
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_NAME} would like microphone access.</string>
+
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>org.cmake.CocoaExample</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/src/detail/standalone/macos/MainMenu.xib
+++ b/src/detail/standalone/macos/MainMenu.xib
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
+            <connections>
+                <outlet property="delegate" destination="Voe-Tx-rLC" id="GzC-gU-4Uq"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
+            <connections>
+                <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
+            </connections>
+        </customObject>
+        <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+        <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+            <items>
+                <menuItem title="${SA_OUTPUT_NAME}" id="1Xt-HY-uBw">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="${SA_OUTPUT_NAME}" systemMenu="apple" id="uQy-DD-JDr">
+                        <items>
+                            <menuItem title="About ${SA_OUTPUT_NAME}" id="5kV-Vb-QxS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                            <menuItem title="Hide ${SA_OUTPUT_NAME}" keyEquivalent="h" id="Olw-nP-bQN">
+                                <connections>
+                                    <action selector="hide:" target="-1" id="PnN-Uc-m68"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                <connections>
+                                    <action selector="hideOtherApplications:" target="-1" id="VT4-aY-XCT"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Show All" id="Kd2-mp-pUS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="unhideAllApplications:" target="-1" id="Dhg-Le-xox"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                            <menuItem title="Quit ${SA_OUTPUT_NAME}" keyEquivalent="q" id="4sb-4s-VLi">
+                                <connections>
+                                    <action selector="terminate:" target="-1" id="Te7-pn-YzF"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="File" id="dMs-cI-mzQ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="File" id="bib-Uj-vzu">
+                        <items>
+                            <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                <connections>
+                                    <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Open Recent" id="tXI-mr-wws">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                    <items>
+                                        <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="clearRecentDocuments:" target="-1" id="Daa-9d-B3U"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                            <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                <connections>
+                                    <action selector="saveDocument:" target="-1" id="teZ-XB-qJY"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                <connections>
+                                    <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Window" id="aUF-d1-5bR">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                        <items>
+                            <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                <connections>
+                                    <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                            <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="arrangeInFront:" target="-1" id="DRN-fu-gQh"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+            </items>
+            <point key="canvasLocation" x="-69" y="65"/>
+        </menu>
+        <window title="${SA_OUTPUT_NAME}" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="335" y="390" width="480" height="360"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
+            <view key="contentView" id="EiT-Mj-1SZ">
+                <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </view>
+            <point key="canvasLocation" x="-170" y="-212"/>
+        </window>
+    </objects>
+</document>

--- a/src/detail/standalone/standalone_details.h
+++ b/src/detail/standalone/standalone_details.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <iostream>
+#include <iomanip>
+#include <atomic>
+#define TRACE std::cout << __FILE__ << ":" << __LINE__ << ": (" << __func__ << ")" << std::endl
+#define LOG std::cout << __FILE__ << ":" << __LINE__ << ": (" << __func__ << ") "
+
+namespace Clap::Standalone
+{
+
+// TODO uncopy this
+template <typename T, uint32_t Q>
+class fixedqueue
+{
+ public:
+  inline void push(const T& val)
+  {
+    push(&val);
+  }
+  inline void push(const T* val)
+  {
+    _elements[_head] = *val;
+    _head = (_head + 1) % Q;
+  }
+  inline bool pop(T& out)
+  {
+    if (_head == _tail)
+    {
+      return false;
+    }
+    out = _elements[_tail];
+    _tail = (_tail + 1) % Q;
+    return true;
+  }
+
+ private:
+  T _elements[Q] = {};
+  std::atomic_uint32_t _head = 0u;
+  std::atomic_uint32_t _tail = 0u;
+};
+}  // namespace Clap::Standalone

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -1,0 +1,256 @@
+
+#include <cassert>
+#include "standalone_host.h"
+
+#if LIN
+#if CLAP_WRAPPER_HAS_GTK3
+#include <glib.h>
+#endif
+#endif
+
+namespace Clap::Standalone
+{
+StandaloneHost::~StandaloneHost()
+{
+}
+
+void StandaloneHost::setupAudioBusses(const clap_plugin_t *plugin,
+                                      const clap_plugin_audio_ports_t *audioports)
+{
+  if (!audioports) return;
+  numAudioInputs = audioports->count(plugin, true);
+  numAudioOutputs = audioports->count(plugin, false);
+  LOG << "inputs/outputs : " << numAudioInputs << "/" << numAudioOutputs << std::endl;
+
+  clap_audio_port_info_t info;
+  for (auto i = 0U; i < numAudioInputs; ++i)
+  {
+    audioports->get(plugin, i, true, &info);
+    LOG << "  - input " << i << " " << info.name << std::endl;
+    inputChannelByBus.push_back(info.channel_count);
+    totalInputChannels += info.channel_count;
+    if (info.flags & CLAP_AUDIO_PORT_IS_MAIN) mainInput = i;
+  }
+  for (auto i = 0U; i < numAudioOutputs; ++i)
+  {
+    audioports->get(plugin, i, false, &info);
+    LOG << "  - output " << i << " " << info.name << std::endl;
+    outputChannelByBus.push_back(info.channel_count);
+    totalOutputChannels += info.channel_count;
+    if (info.flags & CLAP_AUDIO_PORT_IS_MAIN) mainOutput = i;
+  }
+
+  assert(totalOutputChannels + totalInputChannels < utilityBufferMaxChannels);
+  if (numAudioInputs > 0) LOG << "main audio input is " << mainInput << std::endl;
+
+  if (numAudioOutputs > 0) LOG << "main audio output is " << mainOutput << std::endl;
+}
+
+void StandaloneHost::setupMIDIBusses(const clap_plugin_t *plugin,
+                                     const clap_plugin_note_ports_t *noteports)
+{
+  auto numMIDIInPorts = noteports->count(plugin, true);
+  if (numMIDIInPorts > 0)
+  {
+    clap_note_port_info_t info;
+    noteports->get(plugin, 0, true, &info);
+    if (info.supported_dialects & CLAP_NOTE_DIALECT_MIDI)
+    {
+      hasMIDIInput = true;
+    }
+    if (info.supported_dialects & CLAP_NOTE_DIALECT_CLAP)
+    {
+      hasClapNoteInput = true;
+    }
+    LOG << "Set up input: midi=" << hasMIDIInput << " clapNote=" << hasClapNoteInput << std::endl;
+  }
+  auto numMIDIOutPorts = noteports->count(plugin, false);
+  if (numMIDIOutPorts > 0)
+  {
+    createsMidiOutput = true;
+    LOG << "Midi Output not supported yet" << std::endl;
+  }
+}
+
+void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t frameCount)
+{
+  if (!running)
+  {
+    finishedRunning = true;
+    return;
+  }
+
+  auto f = (float *)pOutput;
+  clap_process process;
+  process.transport = nullptr;
+  process.in_events = &inputEvents;
+  process.out_events = &outputEvents;
+  process.frames_count = frameCount;
+
+  assert(frameCount < utilityBufferSize);
+  if (frameCount >= utilityBufferSize)
+  {
+    LOG << "frameCount " << frameCount << " is beyond utility buffer size " << utilityBufferSize
+        << std::endl;
+    std::terminate();
+  }
+
+  process.audio_outputs_count = 1;
+
+  float *bufferChanPtr[utilityBufferMaxChannels]{};
+  clap_audio_buffer buffers[utilityBufferMaxChannels]{};  // probably twice as large
+  size_t ptrIdx{0};
+  size_t bufIdx{0};
+
+  int32_t mainOutIdx{-1}, mainInIdx{-1};
+
+  process.audio_inputs = &(buffers[0]);
+  for (auto inp = 0U; inp < numAudioInputs; ++inp)
+  {
+    // For now assert sterep
+    assert(inputChannelByBus[inp] == 2);
+    bufferChanPtr[ptrIdx] = &(utilityBuffer[ptrIdx][0]);
+    memset(bufferChanPtr[ptrIdx], 0, frameCount * sizeof(float));
+    ptrIdx++;
+    bufferChanPtr[ptrIdx] = &(utilityBuffer[ptrIdx][0]);
+    memset(bufferChanPtr[ptrIdx], 0, frameCount * sizeof(float));
+    ptrIdx++;
+
+    buffers[bufIdx].channel_count = 2;
+    buffers[bufIdx].data32 = &(bufferChanPtr[ptrIdx - 2]);
+
+    if (mainInIdx < 0)
+    {
+      // TODO cleaner
+      mainInIdx = ptrIdx - 2;
+    }
+    bufIdx++;
+  }
+
+  process.audio_outputs = &(buffers[bufIdx]);
+  for (auto oup = 0U; oup < numAudioOutputs; ++oup)
+  {
+    // For now assert sterep
+    assert(outputChannelByBus[oup] == 2);
+    bufferChanPtr[ptrIdx] = &(utilityBuffer[ptrIdx][0]);
+    ptrIdx++;
+    bufferChanPtr[ptrIdx] = &(utilityBuffer[ptrIdx][0]);
+    ptrIdx++;
+
+    buffers[bufIdx].channel_count = 2;
+    buffers[bufIdx].data32 = &(bufferChanPtr[ptrIdx - 2]);
+
+    if (mainOutIdx < 0)
+    {
+      // TODO cleaner
+      mainOutIdx = ptrIdx - 2;
+    }
+
+    bufIdx++;
+  }
+
+  if (mainInIdx >= 0 && pInput)
+  {
+    auto *g = (const float *)pInput;
+    for (auto i = 0U; i < frameCount; ++i)
+    {
+      utilityBuffer[mainInIdx][i] = g[2 * i];
+      utilityBuffer[mainInIdx + 1][i] = g[2 * i + 1];
+    }
+  }
+
+  clearInputEvents();
+  clap_event_midi midi;
+  midiChunk ck;
+  while (midiToAudioQueue.pop(ck))
+  {
+    midi.port_index = 0;
+    midi.header.size = sizeof(clap_event_midi);
+    midi.header.time = 0;
+    midi.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+    midi.header.type = CLAP_EVENT_MIDI;
+    midi.header.flags = 0;
+    memcpy(midi.data, ck.dat, sizeof(ck.dat));
+    pushInputEvent(&(midi.header));
+  }
+
+  clapPlugin->_plugin->process(clapPlugin->_plugin, &process);
+
+  for (auto i = 0U; i < frameCount; ++i)
+  {
+    f[2 * i] = utilityBuffer[mainOutIdx][i];
+    f[2 * i + 1] = utilityBuffer[mainOutIdx + 1][i];
+  }
+}
+
+#if LIN
+int time_handler(void *userData)
+{
+  auto sh = (StandaloneHost *)userData;
+  sh->runTimerFn();
+  return true;
+}
+
+bool StandaloneHost::register_timer(uint32_t period_ms, clap_id *timer_id)
+{
+  if (!timersStarted)
+  {
+    LOG << "Stargint Timers" << std::endl;
+    g_timeout_add(30, time_handler, this);
+  }
+  std::lock_guard<std::mutex> g(timerMapMutex);
+  auto nid = currTimer++;
+  timerIdToPeriod[nid] = period_ms;
+  *timer_id = nid;
+  return true;
+}
+bool StandaloneHost::unregister_timer(clap_id timer_id)
+{
+  std::lock_guard<std::mutex> g(timerMapMutex);
+  timerIdToPeriod.erase(timer_id);
+  return true;
+}
+void StandaloneHost::runTimerFn()
+{
+  std::lock_guard<std::mutex> g(timerMapMutex);
+  for (const auto &[id, period] : timerIdToPeriod)
+  {
+    // To Do - don't ignore period
+    if (period > 0)
+    {
+      if (clapPlugin->_ext._timer)
+      {
+        clapPlugin->_ext._timer->on_timer(clapPlugin->_plugin, id);
+      }
+    }
+  }
+}
+
+bool StandaloneHost::register_fd(int fd, clap_posix_fd_flags_t flags)
+{
+  TRACE;
+  return false;
+}
+bool StandaloneHost::modify_fd(int fd, clap_posix_fd_flags_t flags)
+{
+  TRACE;
+  return false;
+}
+bool StandaloneHost::unregister_fd(int fd)
+{
+  TRACE;
+  return false;
+}
+
+#else
+bool StandaloneHost::register_timer(uint32_t period_ms, clap_id *timer_id)
+{
+  return false;
+}
+bool StandaloneHost::unregister_timer(clap_id timer_id)
+{
+  return false;
+}
+#endif
+
+}  // namespace Clap::Standalone

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -1,0 +1,225 @@
+#pragma once
+#include <cstring>
+#include <unordered_map>
+#include <unordered_set>
+#include <thread>
+#include <mutex>
+
+#include "standalone_details.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"  // other peoples errors are outside my scope
+#endif
+
+#include "RtAudio.h"
+#include "RtMidi.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include "clap_proxy.h"
+
+namespace Clap::Standalone
+{
+
+struct StandaloneHost : Clap::IHost
+{
+  StandaloneHost()
+  {
+    inputEvents.ctx = this;
+    inputEvents.size = ie_getsize;
+    inputEvents.get = ie_get;
+    outputEvents.ctx = this;
+    outputEvents.try_push = oe_try_push;
+  }
+  virtual ~StandaloneHost();
+
+  static bool oe_try_push(const struct clap_output_events *oe, const clap_event_header_t *evt)
+  {
+    return true;
+  }
+
+  static uint32_t ie_getsize(const struct clap_input_events *ie)
+  {
+    auto sh = (StandaloneHost *)ie->ctx;
+    return sh->inputEventSize();
+  }
+  static const clap_event_header_t *ie_get(const struct clap_input_events *ie, uint32_t idx)
+  {
+    auto sh = (StandaloneHost *)ie->ctx;
+    return sh->inputEvent(idx);
+  }
+
+  static constexpr int maxEventsPerCycle{256};
+  static constexpr int eventSize{1024};
+  static constexpr int queueSize{eventSize * maxEventsPerCycle};
+  const unsigned char eventQueue[queueSize]{};
+
+  int currInput{0};
+  void clearInputEvents()
+  {
+    currInput = 0;
+  }
+  bool pushInputEvent(clap_event_header_t *event)
+  {
+    if (event->size > eventSize)
+    {
+      LOG << "BAD EVENT" << std::endl;
+      return false;
+    }
+    if (currInput >= maxEventsPerCycle)
+    {
+      LOG << "TOO MANY EVENTS" << std::endl;
+      return false;
+    }
+    memcpy((void *)(eventQueue + currInput * eventSize), (const void *)event, event->size);
+    currInput++;
+    return true;
+  }
+  uint32_t inputEventSize()
+  {
+    return currInput;
+  }
+  const clap_event_header_t *inputEvent(uint32_t idx)
+  {
+    return (const clap_event_header_t *)(eventQueue + idx * eventSize);
+  }
+
+  std::shared_ptr<Clap::Plugin> clapPlugin;
+  void setPlugin(std::shared_ptr<Clap::Plugin> plugin)
+  {
+    this->clapPlugin = plugin;
+  }
+
+  void mark_dirty() override
+  {
+    TRACE;
+  }
+  void restartPlugin() override
+  {
+    TRACE;
+  }
+  void request_callback() override
+  {
+    TRACE;
+  }
+  void setupWrapperSpecifics(const clap_plugin_t *plugin) override
+  {
+    TRACE;
+  }
+
+  uint32_t numAudioInputs{0}, numAudioOutputs{0};
+  std::vector<uint32_t> inputChannelByBus;
+  std::vector<uint32_t> outputChannelByBus;
+  uint32_t mainInput{0}, mainOutput{0};
+  uint32_t totalInputChannels{0}, totalOutputChannels{0};
+  void setupAudioBusses(const clap_plugin_t *plugin,
+                        const clap_plugin_audio_ports_t *audioports) override;
+
+  bool hasMIDIInput{false}, hasClapNoteInput{false}, createsMidiOutput{false};
+  void setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_note_ports_t *noteports) override;
+
+  void setupParameters(const clap_plugin_t *plugin, const clap_plugin_params_t *params) override
+  {
+    TRACE;
+  }
+  void param_rescan(clap_param_rescan_flags flags) override
+  {
+    TRACE;
+  }
+  void param_clear(clap_id param, clap_param_clear_flags flags) override
+  {
+    TRACE;
+  }
+  void param_request_flush() override
+  {
+    TRACE;
+  }
+  bool gui_can_resize() override
+  {
+    TRACE;
+    return false;
+  }
+  bool gui_request_resize(uint32_t width, uint32_t height) override
+  {
+    TRACE;
+    return false;
+  }
+  bool gui_request_show() override
+  {
+    TRACE;
+    return false;
+  }
+  bool gui_request_hide() override
+  {
+    TRACE;
+    return false;
+  }
+
+#if LIN
+  std::unordered_map<clap_id, uint32_t> timerIdToPeriod;
+  clap_id currTimer{8675309};
+  std::mutex timerMapMutex;
+  void runTimerFn();
+  bool timersStarted{false};
+#endif
+
+  bool register_timer(uint32_t period_ms, clap_id *timer_id) override;
+  bool unregister_timer(clap_id timer_id) override;
+#if LIN
+  bool register_fd(int fd, clap_posix_fd_flags_t flags) override;
+  bool modify_fd(int fd, clap_posix_fd_flags_t flags) override;
+  bool unregister_fd(int fd) override;
+  bool firePosixFD();
+  std::unordered_set<int> fds;
+#endif
+
+  void latency_changed() override
+  {
+    TRACE;
+  }
+  void tail_changed() override
+  {
+    TRACE;
+  }
+
+  // Implementation in standalone_host_midi.cpp
+  struct midiChunk
+  {
+    char dat[3]{};
+    midiChunk()
+    {
+      memset(dat, 0, sizeof(dat));
+    }
+  };
+  fixedqueue<midiChunk, 4096> midiToAudioQueue;
+  std::vector<std::unique_ptr<RtMidiIn>> midiIns;
+  void startMIDIThread();
+  void stopMIDIThread();
+  void processMIDIEvents(double deltatime, std::vector<unsigned char> *message);
+  static void midiCallback(double deltatime, std::vector<unsigned char> *message, void *userData);
+
+  // in standalone_host.cpp
+  void clapProcess(void *pOutput, const void *pInoput, uint32_t frameCount);
+
+  // In standalone_host_audio.cpp
+  std::unique_ptr<RtAudio> rtaDac;
+  void startAudioThread();
+  void stopAudioThread();
+
+  clap_input_events inputEvents{};
+  clap_output_events outputEvents{};
+
+  std::atomic<bool> running{true}, finishedRunning{false};
+
+  // We need to have play buffers for the clap. For now lets assume
+  // (1) the standalone is never more than 16 total ins and outs and
+  // (2) the block size is less that 4096 * 16 and
+  // (3) memory in the standalone is pretty cheap
+  static constexpr int utilityBufferSize{4096 * 16};
+  static constexpr int utilityBufferMaxChannels{16};
+  float utilityBuffer[utilityBufferMaxChannels][utilityBufferSize]{};
+};
+}  // namespace Clap::Standalone

--- a/src/detail/standalone/standalone_host_audio.cpp
+++ b/src/detail/standalone/standalone_host_audio.cpp
@@ -1,0 +1,107 @@
+
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"  // other peoples errors are outside my scope
+#endif
+
+//#define MINIAUDIO_IMPLEMENTATION
+//#include "miniaudio.h"
+#include "RtAudio.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include "standalone_host.h"
+
+namespace Clap::Standalone
+{
+int rtaCallback(void *outputBuffer, void *inputBuffer, unsigned int nBufferFrames,
+                double /* streamTime */, RtAudioStreamStatus status, void *data)
+{
+  if (status)
+  {
+  }
+  auto sh = (StandaloneHost *)data;
+  sh->clapProcess(outputBuffer, inputBuffer, nBufferFrames);
+
+  return 0;
+}
+
+void rtaErrorCallback(RtAudioErrorType, const std::string &errorText)
+{
+  LOG << "[ERROR] RtAudio reports '" << errorText << "'" << std::endl;
+}
+
+void StandaloneHost::startAudioThread()
+{
+  rtaDac = std::make_unique<RtAudio>(RtAudio::UNSPECIFIED, &rtaErrorCallback);
+  rtaDac->showWarnings(true);
+  auto dids = rtaDac->getDeviceIds();
+  auto dnms = rtaDac->getDeviceNames();
+
+  RtAudio::StreamParameters oParams;
+  oParams.nChannels = 2;
+  oParams.firstChannel = 0;
+  oParams.deviceId = rtaDac->getDefaultOutputDevice();
+
+  RtAudio::StreamParameters iParams;
+  iParams.nChannels = 2;
+  iParams.firstChannel = 0;
+  iParams.deviceId = rtaDac->getDefaultInputDevice();
+
+  LOG << "RtAudio Attached Devices" << std::endl;
+  for (auto i = 0U; i < dids.size(); ++i)
+  {
+    if (oParams.deviceId == dids[i]) LOG << "  - Output : '" << dnms[i] << "'" << std::endl;
+  }
+  if (numAudioOutputs > 0)
+    for (auto i = 0U; i < dids.size(); ++i)
+    {
+      if (iParams.deviceId == dids[i]) LOG << "  - Input : '" << dnms[i] << "'" << std::endl;
+    }
+
+  RtAudio::StreamOptions options;
+  options.flags = RTAUDIO_SCHEDULE_REALTIME;
+
+  uint32_t bufferFrames{256};
+  if (rtaDac->openStream(&oParams, (numAudioInputs > 0) ? &iParams : nullptr, RTAUDIO_FLOAT32, 48000,
+                         &bufferFrames, &rtaCallback, (void *)this, &options))
+  {
+    LOG << "[ERROR]" << rtaDac->getErrorText() << std::endl;
+    return;
+  }
+
+  if (!rtaDac->isStreamOpen())
+  {
+    return;
+  }
+
+  if (!rtaDac->startStream())
+  {
+    return;
+  }
+
+  LOG << "RTA Started Stream" << std::endl;
+}
+
+void StandaloneHost::stopAudioThread()
+{
+  LOG << "Shutting down audio" << std::endl;
+  running = false;
+
+  // bit of a hack. Wait until we get an ack from audio callback
+  for (auto i = 0; i < 10000 && !finishedRunning; ++i)
+  {
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(1ms);
+    // todo put a sleep here
+  }
+  LOG << "Audio Thread acknowledges shutdown" << std::endl;
+
+  if (rtaDac && rtaDac->isStreamRunning()) rtaDac->stopStream();
+  LOG << "RtAudio stream stopped" << std::endl;
+  return;
+}
+}  // namespace Clap::Standalone

--- a/src/detail/standalone/standalone_host_midi.cpp
+++ b/src/detail/standalone/standalone_host_midi.cpp
@@ -1,0 +1,78 @@
+#include "standalone_host.h"
+#include "standalone_details.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"  // other peoples errors are outside my scope
+#endif
+
+#include "RtMidi.h"
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+namespace Clap::Standalone
+{
+void StandaloneHost::startMIDIThread()
+{
+  unsigned int numPorts{0};
+  try
+  {
+    LOG << "Initializing Midi" << std::endl;
+    auto midiIn = std::make_unique<RtMidiIn>();
+    numPorts = midiIn->getPortCount();
+  }
+  catch (RtMidiError &error)
+  {
+    error.printMessage();
+    exit(EXIT_FAILURE);
+  }
+
+  LOG << "MIDI: There are " << numPorts << " MIDI input sources available. Binding all.\n";
+  for (unsigned int i = 0; i < numPorts; i++)
+  {
+    try
+    {
+      auto midiIn = std::make_unique<RtMidiIn>();
+      LOG << "  - '" << midiIn->getPortName(i) << "'" << std::endl;
+      midiIn->openPort(i);
+      midiIn->setCallback(midiCallback, this);
+      midiIns.push_back(std::move(midiIn));
+    }
+    catch (RtMidiError &error)
+    {
+      error.printMessage();
+    }
+  }
+}
+
+void StandaloneHost::processMIDIEvents(double deltatime, std::vector<unsigned char> *message)
+{
+  unsigned int nBytes = message->size();
+
+  if (nBytes == 3)
+  {
+    midiChunk ck;
+    memcpy(ck.dat, message->data(), 3);
+    LOG << "Sending midi to audio thread: dat[0] = " << std::hex << (int)(*message)[0] << std::dec
+        << std::endl;
+    midiToAudioQueue.push(ck);
+  }
+}
+
+void StandaloneHost::midiCallback(double deltatime, std::vector<unsigned char> *message, void *userData)
+{
+  auto sh = (StandaloneHost *)userData;
+  sh->processMIDIEvents(deltatime, message);
+}
+
+void StandaloneHost::stopMIDIThread()
+{
+  for (auto &m : midiIns)
+  {
+    m.reset();
+  }
+}
+
+}  // namespace Clap::Standalone

--- a/src/wrapasstandalone.cpp
+++ b/src/wrapasstandalone.cpp
@@ -1,0 +1,79 @@
+
+#include <iostream>
+
+#include "detail/standalone/standalone_details.h"
+#include "detail/standalone/entry.h"
+
+#if LIN
+#if CLAP_WRAPPER_HAS_GTK3
+#include "detail/standalone/linux/gtkutils.h"
+#endif
+#endif
+
+// For now just a simple main. In the future this will branch out to
+// an [NSApplicationMain ] and so on depending on platform
+int main(int argc, char **argv)
+{
+  const clap_plugin_entry *entry{nullptr};
+#ifdef STATICALLY_LINKED_CLAP_ENTRY
+  extern const clap_plugin_entry clap_entry;
+  entry = &clap_entry;
+#else
+  // Library shenanigans t/k
+  std::string cn{HOSTED_CLAP_NAME};
+  LOG << "Loading " << cn << std::endl;
+
+  auto pts = Clap::getValidCLAPSearchPaths();
+
+  auto lib = Clap::Library();
+
+  for (const auto &p : pts)
+  {
+    auto cp = p / (cn + ".clap");
+#if MAC
+    if (fs::is_directory(cp))
+    {
+      lib.load(cp.u8string().c_str());
+      entry = lib._pluginEntry;
+    }
+#else
+    if (fs::exists(cp))
+    {
+      lib.load(cp.u8string().c_str());
+      entry = lib._pluginEntry;
+    }
+#endif
+  }
+
+#endif
+
+  if (!entry)
+  {
+    std::cerr << "Clap Standalone: No Entry as configured" << std::endl;
+    return 3;
+  }
+
+  std::string pid{PLUGIN_ID};
+  int pindex{PLUGIN_INDEX};
+
+  auto plugin = Clap::Standalone::mainCreatePlugin(entry, pid, pindex, 1, (char **)argv);
+  Clap::Standalone::mainStartAudio();
+
+#if LIN
+#if CLAP_WRAPPER_HAS_GTK3
+  Clap::Standalone::Linux::GtkGui gtkGui{};
+  gtkGui.initialize();
+  gtkGui.setPlugin(plugin);
+  gtkGui.runloop(argc, argv);
+  gtkGui.shutdown();
+  gtkGui.setPlugin(nullptr);
+#else
+  Clap::Standalone::mainWait();
+#endif
+#else
+  Clap::Standalone::mainWait();
+#endif
+
+  plugin = nullptr;
+  Clap::Standalone::mainFinish();
+}

--- a/src/wrapasstandalone.mm
+++ b/src/wrapasstandalone.mm
@@ -1,0 +1,6 @@
+#import <Cocoa/Cocoa.h>
+
+int main(int argc, const char* argv[])
+{
+  return NSApplicationMain(argc, argv);
+}


### PR DESCRIPTION
This commit provides a rudimentary standalone wrapper. The wrapper makes the following choices

1. It uses rtaudio/rtmidi for auido and midi support
2. It is a Cocoa (mac) GTK3 (lin) and just-exe-until-timo-gets-it (win) applications
3. The application binds all midi and default audio at 48k with no user choices
4. On mac and lin the application shows the gui if present
5. The commit adds cmake rules to decorate an exeecutable as as standalone with clap_entry either statically linked

There are myriad things to do to make this a production worth standalone, including state, saving options, choosing audio, a win gui, a timer loop on linux which isn't laughable, an fd loop on linux, and much more. But this at least puts the stake in the ground about project cmake and directory structure and actuall does work with conduit and clap saw demo.