### PR TITLE
Cleanup the GTK Timers and FD some

### DIFF
--- a/src/detail/standalone/entry.cpp
+++ b/src/detail/standalone/entry.cpp
@@ -72,6 +72,11 @@ std::shared_ptr<Clap::Plugin> getMainPlugin()
   return plugin;
 }
 
+StandaloneHost *getStandaloneHost()
+{
+  return standaloneHost.get();
+}
+
 int mainWait()
 {
   while (standaloneHost->running)

--- a/src/detail/standalone/entry.h
+++ b/src/detail/standalone/entry.h
@@ -11,6 +11,10 @@ std::shared_ptr<Clap::Plugin> mainCreatePlugin(const clap_plugin_entry *entry, c
 void mainStartAudio();
 
 std::shared_ptr<Clap::Plugin> getMainPlugin();
+
+struct StandaloneHost;
+StandaloneHost *getStandaloneHost();
+
 int mainWait();
 int mainFinish();
 }  // namespace Clap::Standalone

--- a/src/detail/standalone/linux/gtkutils.h
+++ b/src/detail/standalone/linux/gtkutils.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <clap_proxy.h>
+#include <unordered_set>
+#include "detail/standalone/standalone_host.h"
 
 struct _GtkApplication;  // sigh their typedef screws up forward decls
 namespace Clap::Standalone::Linux
@@ -10,11 +12,39 @@ struct GtkGui
   _GtkApplication *app{nullptr};
   std::shared_ptr<Clap::Plugin> plugin;
 
-  void initialize();
+  void initialize(Clap::Standalone::StandaloneHost *);
   void setPlugin(std::shared_ptr<Clap::Plugin>);
   void runloop(int argc, char **argv);
   void shutdown();
 
   void setupPlugin(_GtkApplication *app);
+
+  clap_id currTimer{8675309};
+  std::mutex cbMutex;
+
+  struct TimerCB
+  {
+    clap_id id;
+    GtkGui *that;
+  };
+  std::unordered_set<std::unique_ptr<TimerCB>> timerCbs;
+  std::unordered_set<clap_id> terminatedTimers;
+  int runTimerFn(clap_id id);
+  bool timersStarted{false};
+  bool register_timer(uint32_t period_ms, clap_id *timer_id);
+  bool unregister_timer(clap_id timer_id);
+
+  struct FDCB
+  {
+    uint32_t ghandle;
+    int fd;
+    clap_posix_fd_flags_t flags;
+    GtkGui *that;
+  };
+  std::unordered_set<std::unique_ptr<FDCB>> fdCbs;
+  bool register_fd(int fd, clap_posix_fd_flags_t flags);
+  // todo g_source_modify_unix_fd
+  bool unregister_fd(int fd);
+  int runFD(int fd, clap_posix_fd_flags_t flags);
 };
 }  // namespace Clap::Standalone::Linux

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -23,6 +23,14 @@
 
 namespace Clap::Standalone
 {
+#if LIN
+#if CLAP_WRAPPER_HAS_GTK3
+namespace Linux
+{
+struct GtkGui;
+}
+#endif
+#endif
 
 struct StandaloneHost : Clap::IHost
 {
@@ -159,11 +167,9 @@ struct StandaloneHost : Clap::IHost
   }
 
 #if LIN
-  std::unordered_map<clap_id, uint32_t> timerIdToPeriod;
-  clap_id currTimer{8675309};
-  std::mutex timerMapMutex;
-  void runTimerFn();
-  bool timersStarted{false};
+#if CLAP_WRAPPER_HAS_GTK3
+  Clap::Standalone::Linux::GtkGui *gtkGui{nullptr};
+#endif
 #endif
 
   bool register_timer(uint32_t period_ms, clap_id *timer_id) override;
@@ -172,8 +178,7 @@ struct StandaloneHost : Clap::IHost
   bool register_fd(int fd, clap_posix_fd_flags_t flags) override;
   bool modify_fd(int fd, clap_posix_fd_flags_t flags) override;
   bool unregister_fd(int fd) override;
-  bool firePosixFD();
-  std::unordered_set<int> fds;
+
 #endif
 
   void latency_changed() override

--- a/src/wrapasstandalone.cpp
+++ b/src/wrapasstandalone.cpp
@@ -55,7 +55,8 @@ int main(int argc, char **argv)
 #if LIN
 #if CLAP_WRAPPER_HAS_GTK3
   Clap::Standalone::Linux::GtkGui gtkGui{};
-  gtkGui.initialize();
+
+  gtkGui.initialize(Clap::Standalone::getStandaloneHost());
   gtkGui.setPlugin(plugin);
   gtkGui.runloop(argc, argv);
   gtkGui.shutdown();


### PR DESCRIPTION
The GTK timer implementation was a mess and was inlined in standalone_host.cpp. No reason we can't deletgate it all to GtkUtil though, so this commit does that. It also imlements the timers more natively.  And it uses the glib fd wrapper to do the posix fd callback, but for some reason this results in the clap saw demo / vstgui window not even opening. So some work to do there. Perhaps I need an intermediate widget?

But progress and cleaner code so suggesting we merge this even though we are still timer-only for working UIs on linux