### PR TITLE
XCode Tweaks for AUV2

### DIFF
--- a/cmake/base_sdks.cmake
+++ b/cmake/base_sdks.cmake
@@ -185,7 +185,7 @@ function(guarantee_vst3sdk)
 endfunction(guarantee_vst3sdk)
 
 function(guarantee_auv2sdk)
-    if (TARGET bsase-sdk-auv2)
+    if (TARGET base-sdk-auv2)
         return()
     endif()
     if (NOT APPLE)

--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -49,13 +49,6 @@ function(target_add_auv2_wrapper)
             )
     set(bhtgoutdir "${CMAKE_CURRENT_BINARY_DIR}/${AUV2_TARGET}-build-helper-output")
 
-    if (NOT ${CMAKE_GENERATOR} STREQUAL "Xcode")
-        add_custom_command(TARGET ${bhtg} POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E echo "clap-wrapper: blank signing ${bhtg}"
-                COMMAND ${CMAKE_COMMAND} -E codesign -s - -f "$<TARGET_FILE:${bhtg}>"
-                )
-    endif()
-
     add_custom_command(TARGET ${bhtg} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E echo "clap-wrapper: auv2 configuration output dir is ${bhtgoutdir}"
             COMMAND ${CMAKE_COMMAND} -E make_directory "${bhtgoutdir}"


### PR DESCRIPTION
1. Strip the wierd non-working signature xcode puts on the intermediate geneating exe
2. Set the PRODUCT_BUNDLE_IDENTIFIER same as the bundle identifier with a cmake xcode extension