### PR TITLE
Set BUNDLE_EXTENSION on standalone to app

### DIFF
--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -74,6 +74,7 @@ function(target_add_standalone_wrapper)
         set_target_properties(${SA_TARGET} PROPERTIES
                 BUNDLE TRUE
                 BUNDLE_NAME ${SA_OUTPUT_NAME}
+                BUNDLE_EXTENSION app
                 OUTPUT_NAME ${SA_OUTPUT_NAME}
                 MACOSX_BUNDLE_BUNDLE_NAME ${SA_OUTPUT_NAME}
                 MACOSX_BUNDLE TRUE


### PR DESCRIPTION
when you make a MACOSX_BUNDLE TRUE cmake target it makes it an 'app' automatically but since we build app component vst3 etc... it is useful when scripting to still have the BUNDLE_EXTENSION property set, like we have for the other wrappers, and cmake doesn't lift MACOSX_BUNDLE TRUE to BUNDLE_EXTEISION app

So just add this little tweak.