### PR TITLE
Apply a fix for macOS Ninja MultiConfig

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Build project
         run: |
-          cmake -S . -B ./build -G ${{ matrix.gen }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_AUV2=TRUE  -DCLAP_WRAPPER_BUILD_STANDALONE=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=downloadplug
+          cmake -S . -B ./build -G "${{ matrix.gen }}" -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_AUV2=TRUE  -DCLAP_WRAPPER_BUILD_STANDALONE=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=downloadplug
           cmake --build ./build --config Debug
 
       - name: Show Build Results

--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        gen: [Ninja, Xcode, "Ninja Multi-Config"]
+        gen: [Ninja, Xcode, "Ninja Multi-Config", "Unix Makefiles"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Build project
         run: |
-          cmake -S . -B ./build --G ${{ matrix.gen }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_AUV2=TRUE  -DCLAP_WRAPPER_BUILD_STANDALONE=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=downloadplug
+          cmake -S . -B ./build -G ${{ matrix.gen }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_AUV2=TRUE  -DCLAP_WRAPPER_BUILD_STANDALONE=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=downloadplug
           cmake --build ./build --config Debug
 
       - name: Show Build Results

--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -118,6 +118,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+
       - name: Build project
         run: |
           cmake -S . -B ./build -G ${{ matrix.gen }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_AUV2=TRUE  -DCLAP_WRAPPER_BUILD_STANDALONE=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=downloadplug

--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -53,11 +53,11 @@ jobs:
 
 
   build_feature_cpm_download:
-    name: Wrapper + CPM Downloads (lin/win)
+    name: Wrapper + CPM Downloads (win)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [windows-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -106,11 +106,12 @@ jobs:
 
 
   build_feature_xcode:
-    name: Wrapper + CPM Downloads + XCode
+    name: Wrapper + CPM Downloads + Gens
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest]
+        gen: [Ninja, Xcode, "Ninja Multi-Config"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -119,7 +120,7 @@ jobs:
 
       - name: Build project
         run: |
-          cmake -S . -B ./build -GXcode -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_AUV2=TRUE  -DCLAP_WRAPPER_BUILD_STANDALONE=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=downloadplug
+          cmake -S . -B ./build --G ${{ matrix.gen }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_AUV2=TRUE  -DCLAP_WRAPPER_BUILD_STANDALONE=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=downloadplug
           cmake --build ./build --config Debug
 
       - name: Show Build Results

--- a/cmake/shared_prologue.cmake
+++ b/cmake/shared_prologue.cmake
@@ -143,7 +143,7 @@ function(macos_bundle_flag)
             WORKING_DIRECTORY $<TARGET_PROPERTY:${MBF_TARGET},LIBRARY_OUTPUT_DIRECTORY>
             COMMAND ${CMAKE_COMMAND} -E copy
                 ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/cmake/macBundlePkgInfo
-                "$<TARGET_PROPERTY:${MBF_TARGET},MACOSX_BUNDLE_BUNDLE_NAME>.$<TARGET_PROPERTY:${MBF_TARGET},BUNDLE_EXTENSION>/Contents/PkgInfo")
+                "$<TARGET_FILE_DIR:${MBF_TARGET}>/../PkgInfo")
     endif()
     set_target_properties(${MBF_TARGET}
             PROPERTIES


### PR DESCRIPTION
1. the location of pkginfo is target_dir/.. - Thanks jatin!
2. expand CI to add ninja, ninjamc and xcode gens on macos