### PR TITLE
keep the index stable on equal timestamps

### DIFF
--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -470,9 +470,7 @@ void ProcessAdapter::sortEventIndices()
             {
               auto t1 = _events[a].header.time;
               auto t2 = _events[b].header.time;
-              if (t1 < t2) return true;
-              if (t1 == t2) return (a < b);
-              return false;
+              return (t1 == t2) ? (a < b) : (t1 < t2);
             });
 }
 

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -460,9 +460,20 @@ bool ProcessAdapter::output_events_try_push(const struct clap_output_events* lis
 void ProcessAdapter::sortEventIndices()
 {
   // just sorting the index
+  // an item must be sorted to front of
+  // if the timestamp if event[a] is earlier than
+  // the timestamp of event[b].
+  // if they have the same timestamp, the index must be preserved
+
   std::sort(_eventindices.begin(), _eventindices.end(),
             [&](size_t const& a, size_t const& b)
-            { return _events[a].header.time < _events[b].header.time; });
+            {
+              auto t1 = _events[a].header.time;
+              auto t2 = _events[b].header.time;
+              if (t1 < t2) return true;
+              if (t1 == t2) return (a < b);
+              return false;
+            });
 }
 
 void ProcessAdapter::processInputEvents(Steinberg::Vst::IEventList* eventlist)


### PR DESCRIPTION
when sorting the events by timestamp, an item must be sorted to front 
if the timestamp if event[a] is earlier than the timestamp of event[b].

if they have the same timestamp, the index must be preserved, so notes (with a note-id) are before note expressions etc.

