### PR TITLE
str8ToStr16 overflow warning

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -83,6 +83,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
+        gccver: [11, 12]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -94,7 +95,7 @@ jobs:
 
       - name: Build project
         run: |
-          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_AUV2=TRUE  -DCLAP_WRAPPER_BUILD_STANDALONE=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=downloadplug
+          cmake -S . -B ./build -DCMAKE_CXX_COMPILER=g++-${{ matrix.gccver }} -DCMAKE_C_COMPILER=gcc-${{ matrix.gccver }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_AUV2=TRUE  -DCLAP_WRAPPER_BUILD_STANDALONE=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=downloadplug
           cmake --build ./build --config Debug
 
       - name: Show Build Results

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -366,7 +366,8 @@ void ClapAsVst3::addAudioBusFrom(const clap_audio_port_info_t* info, bool is_inp
   auto bustype = (info->flags & CLAP_AUDIO_PORT_IS_MAIN) ? Vst::BusTypes::kMain : Vst::BusTypes::kAux;
   // bool supports64bit = (info->flags & CLAP_AUDIO_PORT_SUPPORTS_64BITS);
   Steinberg::char16 name16[256];
-  Steinberg::str8ToStr16(&name16[0], info->name, 256);
+  // str8tostr16 writes to position n to terminate, so don't overflow
+  Steinberg::str8ToStr16(&name16[0], info->name, 255);
   if (is_input)
   {
     addAudioInput(name16, spk, bustype, Vst::BusInfo::kDefaultActive);
@@ -389,7 +390,8 @@ void ClapAsVst3::addMIDIBusFrom(const clap_note_port_info_t* info, uint32_t inde
     }
 
     Steinberg::char16 name16[256];
-    Steinberg::str8ToStr16(&name16[0], info->name, 256);
+    // str8tostr16 writes to position n to terminate, so don't overflow
+    Steinberg::str8ToStr16(&name16[0], info->name, 255);
     if (is_input)
     {
       addEventInput(name16, numchannels, Vst::BusTypes::kMain, Vst::BusInfo::kDefaultActive);


### PR DESCRIPTION
In some cases, Steinberg::str8ToStr16(a,b,N) writes to a[N] which means you need A to have size N+1 or N to be sizeof(a)-1. I chose the later here. Also add gcc-11 (which flags this) to our CI matrix.