### PR TITLE
Cpp20 and pkginfo tweaks

### DIFF
--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -47,6 +47,7 @@ function(target_add_auv2_wrapper)
             "-framework Foundation"
             "-framework CoreFoundation"
             )
+    target_compile_options(${bhtg} PRIVATE -fno-char8_t)
     set(bhtgoutdir "${CMAKE_CURRENT_BINARY_DIR}/${AUV2_TARGET}-build-helper-output")
 
     add_custom_command(TARGET ${bhtg} POST_BUILD
@@ -140,7 +141,7 @@ function(target_add_auv2_wrapper)
             ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/auv2/auv2_shared.h
             ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/auv2/auv2_base_classes.h
             ${bhtgoutdir}/generated_entrypoints.hxx)
-
+    target_compile_options(${AUV2_TARGET} PRIVATE -fno-char8_t)
 
     if (NOT TARGET ${AUV2_TARGET}-clap-wrapper-auv2-lib)
         # For now make this an interface

--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -86,8 +86,8 @@ function(target_add_standalone_wrapper)
             message(STATUS "cmake-wrapper: ejecting xib->nib rules manually for ${CMAKE_GENERATOR} on ${SA_TARGET}")
             find_program(IBTOOL ibtool REQUIRED)
             add_custom_command(TARGET ${SA_TARGET} PRE_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E echo ${IBTOOL} --compile "$<TARGET_PROPERTY:${SA_TARGET},MACOSX_BUNDLE_BUNDLE_NAME>.app/Contents/Resources/MainMenu.nib" ${GEN_XIB}
-                    COMMAND ${IBTOOL} --compile "$<TARGET_PROPERTY:${SA_TARGET},MACOSX_BUNDLE_BUNDLE_NAME>.app/Contents/Resources/MainMenu.nib" ${GEN_XIB}
+                    COMMAND ${CMAKE_COMMAND} -E echo ${IBTOOL} --compile "$<TARGET_FILE_DIR:${SA_TARGET}>/../Resources/MainMenu.nib" ${GEN_XIB}
+                    COMMAND ${IBTOOL} --compile "$<TARGET_FILE_DIR:${SA_TARGET}>/../Resources/MainMenu.nib" ${GEN_XIB}
                     )
         endif()
 

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -89,6 +89,11 @@ function(target_add_vst3_wrapper)
         target_compile_options(${V3_TARGET}-clap-wrapper-vst3-lib PRIVATE
                 -DCLAP_SUPPORTS_ALL_NOTE_EXPRESSIONS=$<IF:$<BOOL:${V3_SUPPORTS_ALL_NOTE_EXPRESSIONS}>,1,0>
                 )
+        if (MSVC)
+            target_compile_options(${V3_TARGET}-clap-wrapper-vst3-lib PRIVATE /Zc:char8_t-)
+        else()
+            target_compile_options(${V3_TARGET}-clap-wrapper-vst3-lib PRIVATE -fno-char8_t)
+        endif()
     endif()
 
 

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -71,10 +71,10 @@ std::string getBinaryName();
 void log(const char* text);
 
 template <typename... Args>
-void log(const char* format_str, Args&&... args)
+void log(fmt::string_view format_str, Args&&... args)
 {
   fmt::memory_buffer buf;
-  fmt::format_to(std::back_inserter(buf), format_str, args...);
+  fmt::vformat_to (std::back_inserter(buf), format_str, fmt::make_format_args ( args...));
   buf.push_back(0);
   log((const char*)buf.data());
 }

--- a/src/detail/vst3/os/osutil.h
+++ b/src/detail/vst3/os/osutil.h
@@ -74,7 +74,7 @@ template <typename... Args>
 void log(fmt::string_view format_str, Args&&... args)
 {
   fmt::memory_buffer buf;
-  fmt::vformat_to (std::back_inserter(buf), format_str, fmt::make_format_args ( args...));
+  fmt::vformat_to(std::back_inserter(buf), format_str, fmt::make_format_args(args...));
   buf.push_back(0);
   log((const char*)buf.data());
 }


### PR DESCRIPTION
Three changes here:
1. Adjusting the location for the generated MainMenu.nib for the MacOS Standalone target to use `TARGET_FILE_DIR`.
2. Adding `-fno-char8_t` and `/Zc:char8_t-` flags as appropriate to avoid errors between `std::string` and `std::u8string` with C++20.
3. Using `fmt::vformat_to` rather than `fmt::format_to` to avoid errors about the format string not being known at compile-time (see [this issue](https://github.com/fmtlib/fmt/issues/2931))

Particularly for items (2) and (3), I'm not sure that my solution is the best approach, but it seems to be working for me at the moment. If folks have better suggestions, I'm happy to do those instead!