### PR TITLE
Moderate refactor of AUv2 base classes

### DIFF
--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -1,7 +1,9 @@
 #pragma once
 
 /*
- * document
+ * This is the set of wedge classes which the auv2 code generator projects onto. It is very
+ * unlikely you would need to edit these classes since they almost entirely delegate to the
+ * base class `ClapAUv2_Base` which uses CRTP to have the appropriate AU base class.
  */
 
 #include <AudioUnitSDK/AUEffectBase.h>
@@ -17,66 +19,41 @@ namespace free_audio::auv2_wrapper
 
 // -------------------------------------------------------------------------------------------------
 
-class ClapWrapper_AUV2_Effect : public ausdk::AUEffectBase
+class ClapWrapper_AUV2_Effect : public ClapAUv2_Base<ausdk::AUEffectBase, false, true, false>
 {
-  using Base = ausdk::AUEffectBase;
-  ClapBridge bridge;
+  using Base = ClapAUv2_Base<ausdk::AUEffectBase, false, true, false>;
 
  public:
   explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx,
                                    AudioComponentInstance ci)
-    : Base{ci, true}, bridge(clapname, clapid, clapidx)
+    : Base{clapname, clapid, clapidx, ci}
   {
-    std::cout << "[clap-wrapper] auv2: creating effect" << std::endl;
-    std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
-
-    bridge.initialize();
   }
 };
 
-class ClapWrapper_AUV2_NoteEffect : public ausdk::AUMIDIEffectBase
+class ClapWrapper_AUV2_NoteEffect : public ClapAUv2_Base<ausdk::AUMIDIEffectBase, false, false, true>
 {
-  using Base = ausdk::AUMIDIEffectBase;
-  ClapBridge bridge;
+  using Base = ClapAUv2_Base<ausdk::AUMIDIEffectBase, false, false, true>;
 
  public:
   explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid,
                                        int clapidx, AudioComponentInstance ci)
-    : Base{ci, true}, bridge(clapname, clapid, clapidx)
+    : Base{clapname, clapid, clapidx, ci}
   {
-    std::cout << "[clap-wrapper] auv2: creating note effect" << std::endl;
-    std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
-
-    bridge.initialize();
   }
 };
 
 // -------------------------------------------------------------------------------------------------
 
-class ClapWrapper_AUV2_Instrument : public ausdk::MusicDeviceBase
+class ClapWrapper_AUV2_Instrument : public ClapAUv2_Base<ausdk::MusicDeviceBase, true, false, false>
 {
-  using Base = ausdk::MusicDeviceBase;
-  ClapBridge bridge;
+  using Base = ClapAUv2_Base<ausdk::MusicDeviceBase, true, false, false>;
 
  public:
   explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid,
                                        int clapidx, AudioComponentInstance ci)
-    : Base{ci, 0, 1}, bridge(clapname, clapid, clapidx)
+    : Base{clapname, clapid, clapidx, ci, 0, 1}
   {
-    std::cout << "[clap-wrapper] auv2: creating instrument" << std::endl;
-    std::cout << "[clap-wrapper] auv2: id='" << clapid << "' index=" << clapidx << std::endl;
-
-    bridge.initialize();
-  }
-
-  bool StreamFormatWritable(AudioUnitScope, AudioUnitElement) override
-  {
-    return true;
-  }
-
-  bool CanScheduleParameters() const override
-  {
-    return false;
   }
 };
 }  // namespace free_audio::auv2_wrapper

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -19,9 +19,9 @@ namespace free_audio::auv2_wrapper
 
 // -------------------------------------------------------------------------------------------------
 
-class ClapWrapper_AUV2_Effect : public ClapAUv2_Base<ausdk::AUEffectBase, false, true, false>
+class ClapWrapper_AUV2_Effect : public ClapAUv2_Base<ausdk::AUEffectBase>
 {
-  using Base = ClapAUv2_Base<ausdk::AUEffectBase, false, true, false>;
+  using Base = ClapAUv2_Base<ausdk::AUEffectBase>;
 
  public:
   explicit ClapWrapper_AUV2_Effect(const std::string &clapname, const std::string &clapid, int clapidx,
@@ -31,9 +31,9 @@ class ClapWrapper_AUV2_Effect : public ClapAUv2_Base<ausdk::AUEffectBase, false,
   }
 };
 
-class ClapWrapper_AUV2_NoteEffect : public ClapAUv2_Base<ausdk::AUMIDIEffectBase, false, false, true>
+class ClapWrapper_AUV2_NoteEffect : public ClapAUv2_Base<ausdk::AUMIDIEffectBase>
 {
-  using Base = ClapAUv2_Base<ausdk::AUMIDIEffectBase, false, false, true>;
+  using Base = ClapAUv2_Base<ausdk::AUMIDIEffectBase>;
 
  public:
   explicit ClapWrapper_AUV2_NoteEffect(const std::string &clapname, const std::string &clapid,
@@ -45,9 +45,9 @@ class ClapWrapper_AUV2_NoteEffect : public ClapAUv2_Base<ausdk::AUMIDIEffectBase
 
 // -------------------------------------------------------------------------------------------------
 
-class ClapWrapper_AUV2_Instrument : public ClapAUv2_Base<ausdk::MusicDeviceBase, true, false, false>
+class ClapWrapper_AUV2_Instrument : public ClapAUv2_Base<ausdk::MusicDeviceBase>
 {
-  using Base = ClapAUv2_Base<ausdk::MusicDeviceBase, true, false, false>;
+  using Base = ClapAUv2_Base<ausdk::MusicDeviceBase>;
 
  public:
   explicit ClapWrapper_AUV2_Instrument(const std::string &clapname, const std::string &clapid,

--- a/src/detail/auv2/auv2_shared.h
+++ b/src/detail/auv2/auv2_shared.h
@@ -10,9 +10,16 @@
 
 namespace free_audio::auv2_wrapper
 {
-template <typename AUBase, bool isInstrument, bool isEffect, bool isNoteEffect>
+template <typename AUBase>
 struct ClapAUv2_Base : public AUBase
 {
+  static constexpr bool isInstrument{std::is_same_v<AUBase, ausdk::MusicDeviceBase>};
+  static constexpr bool isEffect{std::is_same_v<AUBase, ausdk::AUEffectBase>};
+  static constexpr bool isNoteEffect{std::is_same_v<AUBase, ausdk::AUMIDIEffectBase>};
+
+  static_assert(isInstrument + isEffect + isNoteEffect == 1,
+                "You must be one and only one of instrument, effect, or note effect");
+
   std::string _clapname;
   std::string _clapid;
   int _idx;
@@ -105,8 +112,8 @@ struct ClapAUv2_Base : public AUBase
       return;
     }
 
-    std::cout << "[clap-wrapper] auv2: Initialized '" << _desc->id << "' / '" << _desc->name << "'"
-              << std::endl;
+    std::cout << "[clap-wrapper] auv2: Initialized '" << _desc->id << "' / '" << _desc->name << "' / '"
+              << _desc->version << "'" << std::endl;
   }
 
   bool StreamFormatWritable(AudioUnitScope, AudioUnitElement) override


### PR DESCRIPTION
Rather than have 3 classes which have-a bridge, use CRTP to make one baseclass which inherits from the appropriate base class of the parent.