### PR TITLE
Some Standalone Cleanups

### DIFF
--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -233,7 +233,6 @@ void Plugin::schnick()
 
 bool Plugin::initialize()
 {
-  fprintf(stderr, "Plugin Initialize\n");
   if (_ext._audioports)
   {
     _parentHost->setupAudioBusses(_plugin, _ext._audioports);

--- a/src/detail/standalone/entry.cpp
+++ b/src/detail/standalone/entry.cpp
@@ -4,7 +4,7 @@
 #include "standalone_host.h"
 #include "entry.h"
 
-namespace Clap::Standalone
+namespace freeaudio::clap_wrapper::standalone
 {
 
 static std::unique_ptr<StandaloneHost> standaloneHost;
@@ -107,4 +107,4 @@ int mainFinish()
   }
   return 0;
 }
-}  // namespace Clap::Standalone
+}  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/entry.h
+++ b/src/detail/standalone/entry.h
@@ -4,7 +4,7 @@
 #include <clap_proxy.h>
 #include <string>
 
-namespace Clap::Standalone
+namespace freeaudio::clap_wrapper::standalone
 {
 std::shared_ptr<Clap::Plugin> mainCreatePlugin(const clap_plugin_entry *entry, const std::string &clapId,
                                                uint32_t clapIndex, int argc, char **argv);
@@ -17,4 +17,4 @@ StandaloneHost *getStandaloneHost();
 
 int mainWait();
 int mainFinish();
-}  // namespace Clap::Standalone
+}  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/linux/gtkutils.cpp
+++ b/src/detail/standalone/linux/gtkutils.cpp
@@ -10,7 +10,7 @@
 
 #include <cassert>
 
-namespace Clap::Standalone::Linux
+namespace freeaudio::clap_wrapper::standalone::linux
 {
 
 static void activate(GtkApplication *app, gpointer user_data)
@@ -49,7 +49,7 @@ void GtkGui::setupPlugin(_GtkApplication *app)
   }
 }
 
-void GtkGui::initialize(Clap::Standalone::StandaloneHost *sah)
+void GtkGui::initialize(freeaudio::clap_wrapper::standalone::StandaloneHost *sah)
 {
   sah->gtkGui = this;
   app = gtk_application_new("org.gtk.example", G_APPLICATION_FLAGS_NONE);
@@ -162,6 +162,6 @@ int GtkGui::runFD(int fd, clap_posix_fd_flags_t flags)
   return true;
 }
 
-}  // namespace Clap::Standalone::Linux
+}  // namespace freeaudio::clap_wrapper::standalone::linux
 
 #endif

--- a/src/detail/standalone/linux/gtkutils.h
+++ b/src/detail/standalone/linux/gtkutils.h
@@ -5,14 +5,14 @@
 #include "detail/standalone/standalone_host.h"
 
 struct _GtkApplication;  // sigh their typedef screws up forward decls
-namespace Clap::Standalone::Linux
+namespace freeaudio::clap_wrapper::standalone::linux
 {
 struct GtkGui
 {
   _GtkApplication *app{nullptr};
   std::shared_ptr<Clap::Plugin> plugin;
 
-  void initialize(Clap::Standalone::StandaloneHost *);
+  void initialize(freeaudio::clap_wrapper::standalone::StandaloneHost *);
   void setPlugin(std::shared_ptr<Clap::Plugin>);
   void runloop(int argc, char **argv);
   void shutdown();
@@ -47,4 +47,4 @@ struct GtkGui
   bool unregister_fd(int fd);
   int runFD(int fd, clap_posix_fd_flags_t flags);
 };
-}  // namespace Clap::Standalone::Linux
+}  // namespace freeaudio::clap_wrapper::standalone::linux

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -71,7 +71,8 @@
   }
 #endif
 
-  auto plugin = Clap::Standalone::mainCreatePlugin(entry, pid, pindex, 1, (char **)argv);
+  auto plugin =
+      freeaudio::clap_wrapper::standalone::mainCreatePlugin(entry, pid, pindex, 1, (char **)argv);
 
   [[self window] orderFrontRegardless];
 
@@ -101,13 +102,13 @@
     ui->show(p);
   }
 
-  Clap::Standalone::mainStartAudio();
+  freeaudio::clap_wrapper::standalone::mainStartAudio();
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification
 {
   LOG << "applicationWillTerminate shutdown" << std::endl;
-  auto plugin = Clap::Standalone::getMainPlugin();
+  auto plugin = freeaudio::clap_wrapper::standalone::getMainPlugin();
 
   if (plugin && plugin->_ext._gui)
   {
@@ -116,7 +117,7 @@
   }
 
   // Insert code here to tear down your application
-  Clap::Standalone::mainFinish();
+  freeaudio::clap_wrapper::standalone::mainFinish();
 }
 
 @end

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -8,7 +8,7 @@
 #endif
 #endif
 
-namespace Clap::Standalone
+namespace freeaudio::clap_wrapper::standalone
 {
 StandaloneHost::~StandaloneHost()
 {
@@ -234,4 +234,4 @@ bool StandaloneHost::unregister_timer(clap_id timer_id)
 }
 #endif
 
-}  // namespace Clap::Standalone
+}  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -23,11 +23,11 @@
 #include "clap_proxy.h"
 #include "detail/shared/fixedqueue.h"
 
-namespace Clap::Standalone
+namespace freeaudio::clap_wrapper::standalone
 {
 #if LIN
 #if CLAP_WRAPPER_HAS_GTK3
-namespace Linux
+namespace linux
 {
 struct GtkGui;
 }
@@ -145,7 +145,6 @@ struct StandaloneHost : Clap::IHost
   }
   void param_request_flush() override
   {
-    TRACE;
   }
   bool gui_can_resize() override
   {
@@ -170,7 +169,7 @@ struct StandaloneHost : Clap::IHost
 
 #if LIN
 #if CLAP_WRAPPER_HAS_GTK3
-  Clap::Standalone::Linux::GtkGui *gtkGui{nullptr};
+  freeaudio::clap_wrapper::standalone::linux::GtkGui *gtkGui{nullptr};
 #endif
 #endif
 
@@ -229,4 +228,4 @@ struct StandaloneHost : Clap::IHost
   static constexpr int utilityBufferMaxChannels{16};
   float utilityBuffer[utilityBufferMaxChannels][utilityBufferSize]{};
 };
-}  // namespace Clap::Standalone
+}  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_host_audio.cpp
+++ b/src/detail/standalone/standalone_host_audio.cpp
@@ -15,7 +15,7 @@
 
 #include "standalone_host.h"
 
-namespace Clap::Standalone
+namespace freeaudio::clap_wrapper::standalone
 {
 int rtaCallback(void *outputBuffer, void *inputBuffer, unsigned int nBufferFrames,
                 double /* streamTime */, RtAudioStreamStatus status, void *data)
@@ -104,4 +104,4 @@ void StandaloneHost::stopAudioThread()
   LOG << "RtAudio stream stopped" << std::endl;
   return;
 }
-}  // namespace Clap::Standalone
+}  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_host_midi.cpp
+++ b/src/detail/standalone/standalone_host_midi.cpp
@@ -12,7 +12,7 @@
 #pragma GCC diagnostic pop
 #endif
 
-namespace Clap::Standalone
+namespace freeaudio::clap_wrapper::standalone
 {
 void StandaloneHost::startMIDIThread()
 {
@@ -55,8 +55,6 @@ void StandaloneHost::processMIDIEvents(double deltatime, std::vector<unsigned ch
   {
     midiChunk ck;
     memcpy(ck.dat, message->data(), 3);
-    LOG << "Sending midi to audio thread: dat[0] = " << std::hex << (int)(*message)[0] << std::dec
-        << std::endl;
     midiToAudioQueue.push(ck);
   }
 }
@@ -75,4 +73,4 @@ void StandaloneHost::stopMIDIThread()
   }
 }
 
-}  // namespace Clap::Standalone
+}  // namespace freeaudio::clap_wrapper::standalone

--- a/src/wrapasstandalone.cpp
+++ b/src/wrapasstandalone.cpp
@@ -48,25 +48,26 @@ int main(int argc, char **argv)
   std::string pid{PLUGIN_ID};
   int pindex{PLUGIN_INDEX};
 
-  auto plugin = Clap::Standalone::mainCreatePlugin(entry, pid, pindex, 1, (char **)argv);
-  Clap::Standalone::mainStartAudio();
+  auto plugin =
+      freeaudio::clap_wrapper::standalone::mainCreatePlugin(entry, pid, pindex, 1, (char **)argv);
+  freeaudio::clap_wrapper::standalone::mainStartAudio();
 
 #if LIN
 #if CLAP_WRAPPER_HAS_GTK3
-  Clap::Standalone::Linux::GtkGui gtkGui{};
+  freeaudio::clap_wrapper::standalone::Linux::GtkGui gtkGui{};
 
-  gtkGui.initialize(Clap::Standalone::getStandaloneHost());
+  gtkGui.initialize(freeaudio::clap_wrapper::standalone::getStandaloneHost());
   gtkGui.setPlugin(plugin);
   gtkGui.runloop(argc, argv);
   gtkGui.shutdown();
   gtkGui.setPlugin(nullptr);
 #else
-  Clap::Standalone::mainWait();
+  freeaudio::clap_wrapper::standalone::mainWait();
 #endif
 #else
-  Clap::Standalone::mainWait();
+  freeaudio::clap_wrapper::standalone::mainWait();
 #endif
 
   plugin = nullptr;
-  Clap::Standalone::mainFinish();
+  freeaudio::clap_wrapper::standalone::mainFinish();
 }


### PR DESCRIPTION
1. Move to `freeaudio::clap_wrapper::standalone` namespace
2. Remove some trace statements which were distracting when actually using the standalone and which we no longer need.