### PR TITLE
Correctly handle midi packets size less than 3

### DIFF
--- a/src/detail/standalone/standalone_host_midi.cpp
+++ b/src/detail/standalone/standalone_host_midi.cpp
@@ -51,10 +51,11 @@ void StandaloneHost::processMIDIEvents(double deltatime, std::vector<unsigned ch
 {
   auto nBytes = message->size();
 
-  if (nBytes == 3)
+  if (nBytes <= 3)
   {
     midiChunk ck;
-    memcpy(ck.dat, message->data(), 3);
+    memset(ck.dat, 0, sizeof(ck.dat));
+    memcpy(ck.dat, message->data(), nBytes);
     midiToAudioQueue.push(ck);
   }
 }


### PR DESCRIPTION
Adter spending 20 minutes figuring out why my linnstrument wouldn't send channel AT to the conduit polysynth, I realized we had the standalone not forwarding messages less than size 3, and channel AT is such a message.