### PR TITLE
Use clap::helpers::Host

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -30,6 +30,7 @@ jobs:
           mkdir deps
           cd deps
           git clone https://github.com/free-audio/clap
+          git clone https://github.com/free-audio/clap-helpers
           git clone https://github.com/steinbergmedia/vst3sdk
           cd vst3sdk
           # temporary workaround, switch to vst3 sdk 3.7.7
@@ -39,7 +40,7 @@ jobs:
 
       - name: Build project
         run: |
-          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCLAP_SDK_ROOT=deps/clap -DVST3_SDK_ROOT=deps/vst3sdk -DCLAP_WRAPPER_OUTPUT_NAME=testplug
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCLAP_SDK_ROOT=deps/clap -DCLAP_HELPERS_SDK_ROOT=deps/clap-helpers -DVST3_SDK_ROOT=deps/vst3sdk -DCLAP_WRAPPER_OUTPUT_NAME=testplug
           cmake --build ./build --config Debug
 
       - name: Show Build Results

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@
 # complete description
 #
 # CLAP_SDK_ROOT The location of the clap library. Defaults to ../clap
+# CLAP_HELPERS_SDK_ROOT The location of the clap-helpers library. Defaults to ../clap-helpers
 # VST3_SDK_ROOT The location of the VST3 sdk. Defaults tp ../vst3sdk
 #
 # CLAP_WRAPPER_OUTPUT_NAME   The name of the resulting .vst3 or .component

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ git clone https://github.com/free-audio/clap-wrapper.git
 mkdir build
 cmake -B build \ 
       -DCLAP_SDK_ROOT={path to clap sdk} \
+      -DCLAP_HELPERS_SDK_ROOT={path to clap-helpers sdk} \
       -DVST3_SDK_ROOT={path to vst3 sdk} \
       -DCLAP_WRAPPER_OUTPUT_NAME="The Name of your CLAP"
 ```

--- a/cmake/base_sdks.cmake
+++ b/cmake/base_sdks.cmake
@@ -91,6 +91,41 @@ function(guarantee_clap)
     add_subdirectory(${CLAP_SDK_ROOT} base-sdk-clap EXCLUDE_FROM_ALL)
 endfunction(guarantee_clap)
 
+function(guarantee_clap_helpers)
+    if (TARGET clap-helpers)
+        if (NOT TARGET base-sdk-clap-helpers)
+            add_library(base-sdk-clap-helpers ALIAS clap-helpers)
+        endif()
+        return()
+    endif()
+
+
+    if (NOT "${CLAP_HELPERS_SDK_ROOT}" STREQUAL "")
+        # Use the provided root
+    elseif (${CLAP_WRAPPER_DOWNLOAD_DEPENDENCIES})
+        guarantee_cpm()
+        CPMAddPackage(
+                NAME "clap-helpers"
+                GITHUB_REPOSITORY "free-audio/clap-helpers"
+                GIT_TAG "7b53a685e11465154b4ccba3065224dbcbf8a893"
+                EXCLUDE_FROM_ALL TRUE
+                DOWNLOAD_ONLY TRUE
+                SOURCE_DIR cpm/clap-helpers
+        )
+        set(CLAP_HELPERS_SDK_ROOT "${CMAKE_CURRENT_BINARY_DIR}/cpm/clap-helpers")
+    else()
+        search_for_sdk_source(SDKDIR clap-helpers RESULT CLAP_HELPERS_SDK_ROOT)
+    endif()
+
+    cmake_path(CONVERT "${CLAP_HELPERS_SDK_ROOT}" TO_CMAKE_PATH_LIST CLAP_HELPERS_SDK_ROOT)
+    if(NOT EXISTS "${CLAP_HELPERS_SDK_ROOT}/include/clap/helpers/macros.hh")
+        message(FATAL_ERROR "There is no CLAP_HELPERS SDK at ${CLAP_HELPERS_SDK_ROOT}. Please set CLAP_HELPERS_SDK_ROOT appropriately ")
+    endif()
+
+    message(STATUS "clap-wrapper: Configuring clap-helpers sdk")
+    add_subdirectory(${CLAP_HELPERS_SDK_ROOT} base-sdk-clap-helpers EXCLUDE_FROM_ALL)
+endfunction(guarantee_clap_helpers)
+
 function(guarantee_vst3sdk)
     if (TARGET base-sdk-vst3)
         return()

--- a/cmake/shared_prologue.cmake
+++ b/cmake/shared_prologue.cmake
@@ -142,7 +142,7 @@ function(guarantee_clap_wrapper_shared)
             src/detail/clap/fsutil.cpp
             src/detail/clap/automation.h
             )
-    target_link_libraries(clap-wrapper-shared-detail PUBLIC clap clap-wrapper-extensions clap-wrapper-compile-options)
+    target_link_libraries(clap-wrapper-shared-detail PUBLIC clap clap-helpers clap-wrapper-extensions clap-wrapper-compile-options)
     target_include_directories(clap-wrapper-shared-detail PUBLIC libs/fmt)
     target_include_directories(clap-wrapper-shared-detail PUBLIC src)
 

--- a/cmake/wrapper_functions.cmake
+++ b/cmake/wrapper_functions.cmake
@@ -21,6 +21,7 @@ include(cmake/shared_prologue.cmake)
 include(cmake/base_sdks.cmake)
 
 guarantee_clap()
+guarantee_clap_helpers()
 guarantee_clap_wrapper_shared()
 
 

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -30,7 +30,7 @@
 namespace Clap
 {
 constexpr auto Plugin_MH = clap::helpers::MisbehaviourHandler::Ignore;
-constexpr auto Plugin_CL = clap::helpers::CheckingLevel::Maximal;
+constexpr auto Plugin_CL = clap::helpers::CheckingLevel::None;
 
 using PluginHostBase = clap::helpers::Host<Plugin_MH, Plugin_CL>;
 }  // namespace Clap


### PR DESCRIPTION
This is how I think clap::helpers::Host would be used for `clap-wrapper`

If considering merging, please make sure that before
- [x] https://github.com/free-audio/clap-helpers/pull/27 has been merged (contains a build fix when using `clap-helpers`)
- [x] https://github.com/free-audio/clap-helpers/pull/24 has been merged
- [x] include `clap-helpers` using the same pattern as `guarantee_clap` in `base_sdks.cmake`
  -  don't forget to remove the copies!