### PR TITLE
Use clap::helpers::PluginProxy

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -30,6 +30,7 @@ jobs:
           mkdir deps
           cd deps
           git clone https://github.com/free-audio/clap
+          git clone https://github.com/free-audio/clap-helpers
           git clone https://github.com/steinbergmedia/vst3sdk
           cd vst3sdk
           # temporary workaround, switch to vst3 sdk 3.7.7
@@ -39,7 +40,7 @@ jobs:
 
       - name: Build project
         run: |
-          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCLAP_SDK_ROOT=deps/clap -DVST3_SDK_ROOT=deps/vst3sdk -DCLAP_WRAPPER_OUTPUT_NAME=testplug
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCLAP_SDK_ROOT=deps/clap -DCLAP_HELPERS_SDK_ROOT=deps/clap-helpers -DVST3_SDK_ROOT=deps/vst3sdk -DCLAP_WRAPPER_OUTPUT_NAME=testplug
           cmake --build ./build --config Debug
 
       - name: Show Build Results

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@
 # complete description
 #
 # CLAP_SDK_ROOT The location of the clap library. Defaults to ../clap
+# CLAP_HELPERS_SDK_ROOT The location of the clap-helpers library. Defaults to ../clap-helpers
 # VST3_SDK_ROOT The location of the VST3 sdk. Defaults tp ../vst3sdk
 #
 # CLAP_WRAPPER_OUTPUT_NAME   The name of the resulting .vst3 or .component

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ git clone https://github.com/free-audio/clap-wrapper.git
 mkdir build
 cmake -B build \ 
       -DCLAP_SDK_ROOT={path to clap sdk} \
+      -DCLAP_HELPERS_SDK_ROOT={path to clap-helpers sdk} \
       -DVST3_SDK_ROOT={path to vst3 sdk} \
       -DCLAP_WRAPPER_OUTPUT_NAME="The Name of your CLAP"
 ```

--- a/cmake/base_sdks.cmake
+++ b/cmake/base_sdks.cmake
@@ -91,6 +91,41 @@ function(guarantee_clap)
     add_subdirectory(${CLAP_SDK_ROOT} base-sdk-clap EXCLUDE_FROM_ALL)
 endfunction(guarantee_clap)
 
+function(guarantee_clap_helpers)
+    if (TARGET clap-helpers)
+        if (NOT TARGET base-sdk-clap-helpers)
+            add_library(base-sdk-clap-helpers ALIAS clap-helpers)
+        endif()
+        return()
+    endif()
+
+
+    if (NOT "${CLAP_HELPERS_SDK_ROOT}" STREQUAL "")
+        # Use the provided root
+    elseif (${CLAP_WRAPPER_DOWNLOAD_DEPENDENCIES})
+        guarantee_cpm()
+        CPMAddPackage(
+                NAME "clap-helpers"
+                GITHUB_REPOSITORY "free-audio/clap-helpers"
+                GIT_TAG "7b53a685e11465154b4ccba3065224dbcbf8a893"
+                EXCLUDE_FROM_ALL TRUE
+                DOWNLOAD_ONLY TRUE
+                SOURCE_DIR cpm/clap-helpers
+        )
+        set(CLAP_HELPERS_SDK_ROOT "${CMAKE_CURRENT_BINARY_DIR}/cpm/clap-helpers")
+    else()
+        search_for_sdk_source(SDKDIR clap-helpers RESULT CLAP_HELPERS_SDK_ROOT)
+    endif()
+
+    cmake_path(CONVERT "${CLAP_HELPERS_SDK_ROOT}" TO_CMAKE_PATH_LIST CLAP_HELPERS_SDK_ROOT)
+    if(NOT EXISTS "${CLAP_HELPERS_SDK_ROOT}/include/clap/helpers/macros.hh")
+        message(FATAL_ERROR "There is no CLAP_HELPERS SDK at ${CLAP_HELPERS_SDK_ROOT}. Please set CLAP_HELPERS_SDK_ROOT appropriately ")
+    endif()
+
+    message(STATUS "clap-wrapper: Configuring clap-helpers sdk")
+    add_subdirectory(${CLAP_HELPERS_SDK_ROOT} base-sdk-clap-helpers EXCLUDE_FROM_ALL)
+endfunction(guarantee_clap_helpers)
+
 function(guarantee_vst3sdk)
     if (TARGET base-sdk-vst3)
         return()

--- a/cmake/base_sdks.cmake
+++ b/cmake/base_sdks.cmake
@@ -72,7 +72,7 @@ function(guarantee_clap)
         CPMAddPackage(
                 NAME "clap"
                 GITHUB_REPOSITORY "free-audio/clap"
-                GIT_TAG "1.1.8"
+                GIT_TAG "1.2.0"
                 EXCLUDE_FROM_ALL TRUE
                 DOWNLOAD_ONLY TRUE
                 SOURCE_DIR cpm/clap

--- a/cmake/base_sdks.cmake
+++ b/cmake/base_sdks.cmake
@@ -107,7 +107,7 @@ function(guarantee_clap_helpers)
         CPMAddPackage(
                 NAME "clap-helpers"
                 GITHUB_REPOSITORY "free-audio/clap-helpers"
-                GIT_TAG "7b53a685e11465154b4ccba3065224dbcbf8a893"
+                GIT_TAG "55ce91fc87288ccec19ad445e6cc23a419e70d2a"
                 EXCLUDE_FROM_ALL TRUE
                 DOWNLOAD_ONLY TRUE
                 SOURCE_DIR cpm/clap-helpers

--- a/cmake/shared_prologue.cmake
+++ b/cmake/shared_prologue.cmake
@@ -142,7 +142,7 @@ function(guarantee_clap_wrapper_shared)
             src/detail/clap/fsutil.cpp
             src/detail/clap/automation.h
             )
-    target_link_libraries(clap-wrapper-shared-detail PUBLIC clap clap-wrapper-extensions clap-wrapper-compile-options)
+    target_link_libraries(clap-wrapper-shared-detail PUBLIC clap clap-helpers clap-wrapper-extensions clap-wrapper-compile-options)
     target_include_directories(clap-wrapper-shared-detail PUBLIC libs/fmt)
     target_include_directories(clap-wrapper-shared-detail PUBLIC src)
 

--- a/cmake/wrapper_functions.cmake
+++ b/cmake/wrapper_functions.cmake
@@ -21,6 +21,7 @@ include(cmake/shared_prologue.cmake)
 include(cmake/base_sdks.cmake)
 
 guarantee_clap()
+guarantee_clap_helpers()
 guarantee_clap_wrapper_shared()
 
 

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -190,7 +190,6 @@ void Plugin::connectClap(const clap_plugin_t* clap)
   getExtension(_plugin, _ext._params, CLAP_EXT_PARAMS);
   getExtension(_plugin, _ext._audioports, CLAP_EXT_AUDIO_PORTS);
   getExtension(_plugin, _ext._noteports, CLAP_EXT_NOTE_PORTS);
-  getExtension(_plugin, _ext._midimap, CLAP_EXT_MIDI_MAPPINGS);
   getExtension(_plugin, _ext._latency, CLAP_EXT_LATENCY);
   getExtension(_plugin, _ext._render, CLAP_EXT_RENDER);
   getExtension(_plugin, _ext._tail, CLAP_EXT_TAIL);

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -1,8 +1,8 @@
 #include "clap_proxy.h"
 #include "detail/clap/fsutil.h"
 #include <clap/helpers/host.hxx>
-#include <cstring>
 #include <clap/helpers/plugin-proxy.hxx>
+#include <cstring>
 
 #if MAC || LIN
 #include <iostream>
@@ -67,16 +67,16 @@ void Plugin::connectClap(const clap_plugin_t* clap)
 {
   if (!clap) return;
 
-  _pluginProxy = std::make_unique<PluginProxy>(*clap, *this);
+  _proxy = std::make_unique<PluginProxy>(*clap, *this);
 
   // initialize the plugin
-  if (!_pluginProxy->init())
+  if (!_proxy->init())
   {
     terminate();
     return;
   }
 
-  if (_pluginProxy->canUseGui())
+  if (_proxy->canUseGui())
   {
     const char* api;
 #if WIN
@@ -89,17 +89,17 @@ void Plugin::connectClap(const clap_plugin_t* clap)
     api = CLAP_WINDOW_API_X11;
 #endif
 
-    if (!_pluginProxy->guiIsApiSupported(api, false))
+    if (!_proxy->guiIsApiSupported(api, false))
     {
       // disable GUI if not win32
-      // TODO _pluginProxy->_pluginGui = nullptr;
+      // TODO _proxy->_pluginGui = nullptr;
     }
   }
 }
 
 Plugin::~Plugin()
 {
-  if (_pluginProxy.get())
+  if (_proxy.get())
   {
     terminate();
   }
@@ -131,8 +131,8 @@ bool Plugin::initialize()
 
 void Plugin::terminate()
 {
-  _pluginProxy->destroy();
-  _pluginProxy.reset();
+  _proxy->destroy();
+  _proxy.reset();
 }
 
 void Plugin::setSampleRate(double sampleRate)
@@ -148,57 +148,57 @@ void Plugin::setBlockSizes(uint32_t minFrames, uint32_t maxFrames)
 
 bool Plugin::load(const clap_istream_t* stream) const
 {
-  if (_pluginProxy->canUseState())
+  if (_proxy->canUseState())
   {
-    return _pluginProxy->stateLoad(stream);
+    return _proxy->stateLoad(stream);
   }
   return false;
 }
 
 bool Plugin::save(const clap_ostream_t* stream) const
 {
-  if (_pluginProxy->canUseState())
+  if (_proxy->canUseState())
   {
-    return _pluginProxy->stateSave(stream);
+    return _proxy->stateSave(stream);
   }
   return false;
 }
 
 bool Plugin::activate() const
 {
-  return _pluginProxy->activate(_audioSetup.sampleRate, _audioSetup.minFrames, _audioSetup.maxFrames);
+  return _proxy->activate(_audioSetup.sampleRate, _audioSetup.minFrames, _audioSetup.maxFrames);
 }
 
 void Plugin::deactivate() const
 {
-  _pluginProxy->deactivate();
+  _proxy->deactivate();
 }
 
 bool Plugin::start_processing()
 {
   auto thisFn = AlwaysAudioThread();
-  return _pluginProxy->startProcessing();
+  return _proxy->startProcessing();
 }
 
 void Plugin::stop_processing()
 {
   auto thisFn = AlwaysAudioThread();
-  _pluginProxy->stopProcessing();
+  _proxy->stopProcessing();
 }
 
 //void Plugin::process(const clap_process_t* data)
 //{
 //  auto thisFn = AlwaysAudioThread();
-//  _pluginProxy->process(data);
+//  _proxy->process(data);
 //}
 
 const clap_plugin_gui_t* Plugin::getUI() const
 {
-  if (_pluginProxy->canUseGui())
+  if (_proxy->canUseGui())
   {
-    if (_pluginProxy->guiIsApiSupported(CLAP_WINDOW_API_WIN32, false))
+    if (_proxy->guiIsApiSupported(CLAP_WINDOW_API_WIN32, false))
     {
-      // _pluginProxy->gui...
+      // _proxy->gui...
     }
   }
   return nullptr;
@@ -216,7 +216,7 @@ void Plugin::tailChanged() noexcept
 
 PluginProxy* Plugin::getProxy() const
 {
-  return _pluginProxy.get();
+  return _proxy.get();
 }
 
 void Plugin::logLog(clap_log_severity severity, const char* msg) const noexcept

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -90,7 +90,6 @@ struct ClapPluginExtensions
   const clap_plugin_audio_ports_t* _audioports = nullptr;
   const clap_plugin_gui_t* _gui = nullptr;
   const clap_plugin_note_ports_t* _noteports = nullptr;
-  const clap_plugin_midi_mappings_t* _midimap = nullptr;
   const clap_plugin_latency_t* _latency = nullptr;
   const clap_plugin_render_t* _render = nullptr;
   const clap_plugin_tail_t* _tail = nullptr;

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -14,7 +14,6 @@
 */
 
 #include <clap/clap.h>
-#include <clap/helpers/plugin-proxy.hh>
 #include <vector>
 #include <string>
 #include <memory>
@@ -27,6 +26,7 @@
 
 #include "detail/clap/fsutil.h"
 #include <clap/helpers/host.hh>
+#include <clap/helpers/plugin-proxy.hh>
 
 namespace Clap
 {
@@ -57,10 +57,10 @@ class IHost
       const PluginProxy& plugin) = 0;  // called when a wrapper could scan for wrapper specific plugins
 
   virtual void setupAudioBusses(
-      const PluginProxy& plugin) = 0;  // called from initialize() to allow the setup of audio ports
+      const PluginProxy& proxy) = 0;  // called from initialize() to allow the setup of audio ports
   virtual void setupMIDIBusses(
-      const PluginProxy& plugin) = 0;  // called from initialize() to allow the setup of MIDI ports
-  virtual void setupParameters(const PluginProxy& plugin) = 0;
+      const PluginProxy& proxy) = 0;  // called from initialize() to allow the setup of MIDI ports
+  virtual void setupParameters(const PluginProxy& proxy) = 0;
 
   virtual void param_rescan(clap_param_rescan_flags flags) = 0;  // ext_host_params
   virtual void param_clear(clap_id param, clap_param_clear_flags flags) = 0;
@@ -247,7 +247,7 @@ class Plugin : public Clap::PluginHostBase
 
  private:
   IHost* _parentHost = nullptr;
-  std::unique_ptr<PluginProxy> _pluginProxy;
+  std::unique_ptr<PluginProxy> _proxy;
   const std::thread::id _main_thread_id = std::this_thread::get_id();
   std::atomic<uint32_t> _audio_thread_override = 0;
   std::atomic<uint32_t> _main_thread_override = 0;

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -284,15 +284,13 @@ class WrapAsAUV2 : public ausdk::AUBase,
     _queueToUI.push(TriggerUICallback());
   }
 
-  void setupWrapperSpecifics(const clap_plugin_t* plugin)
+  void setupWrapperSpecifics(const Clap::PluginProxy& pluginProxy)
       override;  // called when a wrapper could scan for wrapper specific plugins
 
-  void setupAudioBusses(const clap_plugin_t* plugin,
-                        const clap_plugin_audio_ports_t* audioports) override final;
-  void setupMIDIBusses(const clap_plugin_t* plugin,
-                       const clap_plugin_note_ports_t* noteports)
+  void setupAudioBusses(const Clap::PluginProxy& pluginProxy) override final;
+  void setupMIDIBusses(const Clap::PluginProxy& pluginProxy)
       override final;  // called from initialize() to allow the setup of MIDI ports
-  void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) override final;
+  void setupParameters(const Clap::PluginProxy& pluginProxy) override final;
 
   void param_rescan(clap_param_rescan_flags flags) override;
 

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -284,13 +284,13 @@ class WrapAsAUV2 : public ausdk::AUBase,
     _queueToUI.push(TriggerUICallback());
   }
 
-  void setupWrapperSpecifics(const Clap::PluginProxy& pluginProxy)
+  void setupWrapperSpecifics(const Clap::PluginProxy& proxy)
       override;  // called when a wrapper could scan for wrapper specific plugins
 
-  void setupAudioBusses(const Clap::PluginProxy& pluginProxy) override final;
-  void setupMIDIBusses(const Clap::PluginProxy& pluginProxy)
+  void setupAudioBusses(const Clap::PluginProxy& proxy) override final;
+  void setupMIDIBusses(const Clap::PluginProxy& proxy)
       override final;  // called from initialize() to allow the setup of MIDI ports
-  void setupParameters(const Clap::PluginProxy& pluginProxy) override final;
+  void setupParameters(const Clap::PluginProxy& proxy) override final;
 
   void param_rescan(clap_param_rescan_flags flags) override;
 

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -262,7 +262,7 @@ void ProcessAdapter::process(ProcessData& data)
   }
 #endif
 
-  _pluginProxy.process(&_processData);
+  _proxy.process(&_processData);
 
   processOutputEvents();
 

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -40,12 +40,9 @@ ProcessAdapter::~ProcessAdapter()
 }
 
 void ProcessAdapter::setupProcessing(ausdk::AUScope& audioInputs, ausdk::AUScope& audioOutputs,
-                                     const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params,
                                      Clap::IAutomation* automationInterface, ParameterTree* parameters,
                                      uint32_t numMaxSamples, uint32_t preferredMIDIDialect)
 {
-  _plugin = plugin;
-  _ext_params = ext_params;
   _automation = automationInterface;
   _parameters = parameters;
 
@@ -265,7 +262,7 @@ void ProcessAdapter::process(ProcessData& data)
   }
 #endif
 
-  _plugin->process(_plugin, &_processData);
+  _pluginProxy.process(&_processData);
 
   processOutputEvents();
 

--- a/src/detail/auv2/process.h
+++ b/src/detail/auv2/process.h
@@ -15,6 +15,8 @@
  */
 
 #include <clap/clap.h>
+#include "clap_proxy.h"
+#include <clap/helpers/plugin-proxy.hxx>
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -72,6 +74,10 @@ struct ProcessData
 class ProcessAdapter
 {
  public:
+  ProcessAdapter(const Clap::PluginProxy& pluginProxy) : _pluginProxy{pluginProxy}
+  {
+  }
+
   typedef union clap_multi_event
   {
     clap_event_header_t header;
@@ -83,7 +89,6 @@ class ProcessAdapter
   } clap_multi_event_t;
 
   void setupProcessing(ausdk::AUScope& audioInputs, ausdk::AUScope& audioOutputs,
-                       const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params,
                        Clap::IAutomation* automationInterface, ParameterTree* parameters,
 
                        uint32_t numMaxSamples, uint32_t preferredMIDIDialect);
@@ -116,8 +121,7 @@ class ProcessAdapter
   void removeFromActiveNotes(const clap_event_note* note);
 
   // the plugin
-  const clap_plugin_t* _plugin = nullptr;
-  const clap_plugin_params_t* _ext_params = nullptr;
+  const Clap::PluginProxy& _pluginProxy;
 
   // for automation gestures
   std::vector<clap_id> _gesturedParameters;

--- a/src/detail/auv2/process.h
+++ b/src/detail/auv2/process.h
@@ -74,7 +74,7 @@ struct ProcessData
 class ProcessAdapter
 {
  public:
-  ProcessAdapter(const Clap::PluginProxy& pluginProxy) : _pluginProxy{pluginProxy}
+  ProcessAdapter(const Clap::PluginProxy& proxy) : _proxy{proxy}
   {
   }
 
@@ -121,7 +121,7 @@ class ProcessAdapter
   void removeFromActiveNotes(const clap_event_note* note);
 
   // the plugin
-  const Clap::PluginProxy& _pluginProxy;
+  const Clap::PluginProxy& _proxy;
 
   // for automation gestures
   std::vector<clap_id> _gesturedParameters;

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -86,32 +86,32 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   LOGINFO("[clap-wrapper] creating NSView");
 
   ui = *cont;
-  auto pluginProxy = ui._plugin->getProxy();
-  pluginProxy->guiCreate(CLAP_WINDOW_API_COCOA, false);
+  auto proxy = ui._plugin->getProxy();
+  proxy->guiCreate(CLAP_WINDOW_API_COCOA, false);
 
   // actually, the host should send an appropriate size,
   // yet, they actually just send utter garbage, so: don't care
   // if (size.width == 0 || size.height == 0)
   {
-    // pluginProxy->guiGetSize(,)
+    // proxy->guiGetSize(,)
     uint32_t w, h;
-    if (pluginProxy->guiGetSize(&w, &h))
+    if (proxy->guiGetSize(&w, &h))
     {
       size = {(double)w, (double)h};
     }
   }
   self = [super initWithFrame:NSMakeRect(0, 0, size.width, size.height)];
 
-  // pluginProxy->guiShow();
+  // proxy->guiShow();
 
   clap_window_t m;
   m.api = CLAP_WINDOW_API_COCOA;
   m.ptr = self;
 
-  pluginProxy->guiSetParent(&m);
-  pluginProxy->guiSetScale(1.0);
+  proxy->guiSetParent(&m);
+  proxy->guiSetScale(1.0);
 
-  if (pluginProxy->guiCanResize()) pluginProxy->guiSetSize(size.width, size.height);
+  if (proxy->guiCanResize()) proxy->guiSetSize(size.width, size.height);
 
   idleTimer = nil;
   CFTimeInterval TIMER_INTERVAL = .05;  // In SurgeGUISynthesizer.h it uses 50 ms
@@ -134,8 +134,8 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   {
     CFRunLoopTimerInvalidate(idleTimer);
   }
-  auto pluginProxy = ui._plugin->getProxy();
-  pluginProxy->guiDestroy();
+  auto proxy = ui._plugin->getProxy();
+  proxy->guiDestroy();
 
   [super dealloc];
 }
@@ -144,11 +144,11 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   LOGINFO("[clap-wrapper] new size");
 
   [super setFrame:newSize];
-  auto pluginProxy = ui._plugin->getProxy();
-  pluginProxy->guiSetScale(1.0);
-  pluginProxy->guiSetSize(newSize.size.width, newSize.size.height);
+  auto proxy = ui._plugin->getProxy();
+  proxy->guiSetScale(1.0);
+  proxy->guiSetSize(newSize.size.width, newSize.size.height);
 
-  // pluginProxy->guiShow();
+  // proxy->guiShow();
 }
 
 @end

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -86,32 +86,32 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   LOGINFO("[clap-wrapper] creating NSView");
 
   ui = *cont;
-  ui._plugin->_ext._gui->create(ui._plugin->_plugin, CLAP_WINDOW_API_COCOA, false);
-  auto gui = ui._plugin->_ext._gui;
+  auto pluginProxy = ui._plugin->getProxy();
+  pluginProxy->guiCreate(CLAP_WINDOW_API_COCOA, false);
 
   // actually, the host should send an appropriate size,
   // yet, they actually just send utter garbage, so: don't care
   // if (size.width == 0 || size.height == 0)
   {
-    // gui->get_size(ui._plugin->_plugin,)
+    // pluginProxy->guiGetSize(,)
     uint32_t w, h;
-    if (gui->get_size(ui._plugin->_plugin, &w, &h))
+    if (pluginProxy->guiGetSize(&w, &h))
     {
       size = {(double)w, (double)h};
     }
   }
   self = [super initWithFrame:NSMakeRect(0, 0, size.width, size.height)];
 
-  // gui->show(ui._plugin->_plugin);
+  // pluginProxy->guiShow();
 
   clap_window_t m;
   m.api = CLAP_WINDOW_API_COCOA;
   m.ptr = self;
 
-  gui->set_parent(ui._plugin->_plugin, &m);
-  gui->set_scale(ui._plugin->_plugin, 1.0);
+  pluginProxy->guiSetParent(&m);
+  pluginProxy->guiSetScale(1.0);
 
-  if (gui->can_resize(ui._plugin->_plugin)) gui->set_size(ui._plugin->_plugin, size.width, size.height);
+  if (pluginProxy->guiCanResize()) pluginProxy->guiSetSize(size.width, size.height);
 
   idleTimer = nil;
   CFTimeInterval TIMER_INTERVAL = .05;  // In SurgeGUISynthesizer.h it uses 50 ms
@@ -126,7 +126,6 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (void)doIdle
 {
-  // auto gui = ui._plugin->_ext._gui;
 }
 - (void)dealloc
 {
@@ -135,8 +134,8 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   {
     CFRunLoopTimerInvalidate(idleTimer);
   }
-  auto gui = ui._plugin->_ext._gui;
-  gui->destroy(ui._plugin->_plugin);
+  auto pluginProxy = ui._plugin->getProxy();
+  pluginProxy->guiDestroy();
 
   [super dealloc];
 }
@@ -145,11 +144,11 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   LOGINFO("[clap-wrapper] new size");
 
   [super setFrame:newSize];
-  auto gui = ui._plugin->_ext._gui;
-  gui->set_scale(ui._plugin->_plugin, 1.0);
-  gui->set_size(ui._plugin->_plugin, newSize.size.width, newSize.size.height);
+  auto pluginProxy = ui._plugin->getProxy();
+  pluginProxy->guiSetScale(1.0);
+  pluginProxy->guiSetSize(newSize.size.width, newSize.size.height);
 
-  // gui->show(ui._plugin->_plugin);
+  // pluginProxy->guiShow();
 }
 
 @end

--- a/src/detail/standalone/entry.cpp
+++ b/src/detail/standalone/entry.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<Clap::Plugin> mainCreatePlugin(const clap_plugin_entry *ee, cons
   auto pt = getStandaloneSettingsPath();
   if (pt.has_value())
   {
-    auto loadPath = *pt / plugin->_plugin->desc->id;
+    auto loadPath = *pt / plugin->getProxy()->clapPlugin()->desc->id;
     try
     {
       if (fs::exists(loadPath / "settings.clapwrapper"))
@@ -117,7 +117,7 @@ int mainFinish()
     auto pt = getStandaloneSettingsPath();
     if (pt.has_value())
     {
-      auto savePath = *pt / plugin->_plugin->desc->id;
+      auto savePath = *pt / plugin->getProxy()->clapPlugin()->desc->id;
       LOG << "Saving settings to '" << savePath << "'" << std::endl;
       try
       {

--- a/src/detail/standalone/linux/gtkutils.cpp
+++ b/src/detail/standalone/linux/gtkutils.cpp
@@ -23,16 +23,16 @@ void GtkGui::setupPlugin(_GtkApplication *app)
 {
   GtkWidget *window;
 
-  auto pluginProxy = plugin->getProxy();
-  if (pluginProxy->canUseGui())
+  const auto proxy = plugin->getProxy();
+  if (proxy->canUseGui())
   {
-    if (!pluginProxy->guiIsApiSupported(CLAP_WINDOW_API_X11, false)) LOG << "NO X11 " << std::endl;
+    if (!proxy->guiIsApiSupported(CLAP_WINDOW_API_X11, false)) LOG << "NO X11 " << std::endl;
 
-    pluginProxy->guiCreate(CLAP_WINDOW_API_X11, false);
-    pluginProxy->guiSetScale(1);
+    proxy->guiCreate(CLAP_WINDOW_API_X11, false);
+    proxy->guiSetScale(1);
 
     uint32_t w, h;
-    pluginProxy->guiGetSize(w, &h);
+    proxy->guiGetSize(w, &h);
 
     window = gtk_application_window_new(app);
     gtk_window_set_title(GTK_WINDOW(window), "Standalone Window");
@@ -43,8 +43,8 @@ void GtkGui::setupPlugin(_GtkApplication *app)
     win.api = CLAP_WINDOW_API_X11;
     auto gw = gtk_widget_get_window(GTK_WIDGET(window));
     win.x11 = GDK_WINDOW_XID(gw);
-    pluginProxy->guiSetParent(win);
-    pluginProxy->guiShow();
+    proxy->guiSetParent(win);
+    proxy->guiShow();
   }
 }
 
@@ -105,7 +105,8 @@ int GtkGui::runTimerFn(clap_id id)
   std::lock_guard<std::mutex> g{cbMutex};
   if (terminatedTimers.find(id) != terminatedTimers.end()) return false;
 
-  if (plugin->getProxy()->canUseTimer()) plugin->getProxy()->timerSupportOnTimer(id);
+  const auto proxy = plugin->getProxy();
+  if (proxy->canUseTimer()) proxy->timerSupportOnTimer(id);
   return true;
 }
 
@@ -154,9 +155,10 @@ bool GtkGui::unregister_fd(int fd)
 
 int GtkGui::runFD(int fd, clap_posix_fd_flags_t flags)
 {
-  if (plugin->getProxy()->canUsePosixFdSupport())
+  const auto proxy = plugin->getProxy();
+  if (proxy->canUsePosixFdSupport())
   {
-    plugin->getProxy()->posixFdSupportOnFd(fd, flags);
+    proxy->posixFdSupportOnFd(fd, flags);
   }
   return true;
 }

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -77,16 +77,16 @@
 
   [[self window] orderFrontRegardless];
 
-  auto pluginProxy = plugin->getProxy();
-  if (pluginProxy->canUseGui())
+  const auto proxy = plugin->getProxy();
+  if (proxy->canUseGui())
   {
-    if (!pluginProxy->guiIsApiSupported(CLAP_WINDOW_API_COCOA, false)) LOG << "NO COCOA " << std::endl;
+    if (!proxy->guiIsApiSupported(CLAP_WINDOW_API_COCOA, false)) LOG << "NO COCOA " << std::endl;
 
-    pluginProxy->guiCreate(CLAP_WINDOW_API_COCOA, false);
-    pluginProxy->guiSetScale(1);
+    proxy->guiCreate(CLAP_WINDOW_API_COCOA, false);
+    proxy->guiSetScale(1);
 
     uint32_t w, h;
-    pluginProxy->guiGetSize(&w, &h);
+    proxy->guiGetSize(&w, &h);
 
     NSView *view = [[self window] contentView];
 
@@ -98,8 +98,8 @@
     clap_window win;
     win.api = CLAP_WINDOW_API_COCOA;
     win.cocoa = view;
-    pluginProxy->guiSetParent(&win);
-    pluginProxy->guiShow();
+    proxy->guiSetParent(&win);
+    proxy->guiShow();
   }
 
   freeaudio::clap_wrapper::standalone::getStandaloneHost()->onRequestResize =
@@ -119,10 +119,11 @@
   LOG << "applicationWillTerminate shutdown" << std::endl;
   auto plugin = freeaudio::clap_wrapper::standalone::getMainPlugin();
 
-  if (plugin && plugin->getProxy()->canUseGui())
+  const auto proxy = plugin ? plugin->getProxy() : nullptr;
+  if (proxy && proxy->canUseGui())
   {
-    plugin->getProxy()->guiHide();
-    plugin->getProxy()->guiDestroy();
+    proxy->guiHide();
+    proxy->guiDestroy();
   }
 
   // Insert code here to tear down your application

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -77,17 +77,16 @@
 
   [[self window] orderFrontRegardless];
 
-  if (plugin->_ext._gui)
+  auto pluginProxy = plugin->getProxy();
+  if (pluginProxy->canUseGui())
   {
-    auto ui = plugin->_ext._gui;
-    auto p = plugin->_plugin;
-    if (!ui->is_api_supported(p, CLAP_WINDOW_API_COCOA, false)) LOG << "NO COCOA " << std::endl;
+    if (!pluginProxy->guiIsApiSupported(CLAP_WINDOW_API_COCOA, false)) LOG << "NO COCOA " << std::endl;
 
-    ui->create(p, CLAP_WINDOW_API_COCOA, false);
-    ui->set_scale(p, 1);
+    pluginProxy->guiCreate(CLAP_WINDOW_API_COCOA, false);
+    pluginProxy->guiSetScale(1);
 
     uint32_t w, h;
-    ui->get_size(p, &w, &h);
+    pluginProxy->guiGetSize(&w, &h);
 
     NSView *view = [[self window] contentView];
 
@@ -99,8 +98,8 @@
     clap_window win;
     win.api = CLAP_WINDOW_API_COCOA;
     win.cocoa = view;
-    ui->set_parent(p, &win);
-    ui->show(p);
+    pluginProxy->guiSetParent(&win);
+    pluginProxy->guiShow();
   }
 
   freeaudio::clap_wrapper::standalone::getStandaloneHost()->onRequestResize =
@@ -120,10 +119,10 @@
   LOG << "applicationWillTerminate shutdown" << std::endl;
   auto plugin = freeaudio::clap_wrapper::standalone::getMainPlugin();
 
-  if (plugin && plugin->_ext._gui)
+  if (plugin && plugin->getProxy()->canUseGui())
   {
-    plugin->_ext._gui->hide(plugin->_plugin);
-    plugin->_ext._gui->destroy(plugin->_plugin);
+    plugin->getProxy()->guiHide();
+    plugin->getProxy()->guiDestroy();
   }
 
   // Insert code here to tear down your application

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -129,7 +129,7 @@ struct StandaloneHost : Clap::IHost
   {
     TRACE;
   }
-  void setupWrapperSpecifics(const clap_plugin_t *plugin) override
+  void setupWrapperSpecifics(const Clap::PluginProxy &plugin) override
   {
     TRACE;
   }
@@ -142,13 +142,12 @@ struct StandaloneHost : Clap::IHost
   std::vector<uint32_t> outputChannelByBus;
   uint32_t mainInput{0}, mainOutput{0};
   uint32_t totalInputChannels{0}, totalOutputChannels{0};
-  void setupAudioBusses(const clap_plugin_t *plugin,
-                        const clap_plugin_audio_ports_t *audioports) override;
+  void setupAudioBusses(const Clap::PluginProxy &plugin) override;
 
   bool hasMIDIInput{false}, hasClapNoteInput{false}, createsMidiOutput{false};
-  void setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_note_ports_t *noteports) override;
+  void setupMIDIBusses(const Clap::PluginProxy &plugin) override;
 
-  void setupParameters(const clap_plugin_t *plugin, const clap_plugin_params_t *params) override
+  void setupParameters(const Clap::PluginProxy &plugin) override
   {
     TRACE;
   }

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -129,7 +129,7 @@ struct StandaloneHost : Clap::IHost
   {
     TRACE;
   }
-  void setupWrapperSpecifics(const Clap::PluginProxy &plugin) override
+  void setupWrapperSpecifics(const Clap::PluginProxy &proxy) override
   {
     TRACE;
   }
@@ -142,12 +142,12 @@ struct StandaloneHost : Clap::IHost
   std::vector<uint32_t> outputChannelByBus;
   uint32_t mainInput{0}, mainOutput{0};
   uint32_t totalInputChannels{0}, totalOutputChannels{0};
-  void setupAudioBusses(const Clap::PluginProxy &plugin) override;
+  void setupAudioBusses(const Clap::PluginProxy &proxy) override;
 
   bool hasMIDIInput{false}, hasClapNoteInput{false}, createsMidiOutput{false};
-  void setupMIDIBusses(const Clap::PluginProxy &plugin) override;
+  void setupMIDIBusses(const Clap::PluginProxy &proxy) override;
 
-  void setupParameters(const Clap::PluginProxy &plugin) override
+  void setupParameters(const Clap::PluginProxy &proxy) override
   {
     TRACE;
   }

--- a/src/detail/standalone/windows/helper.h
+++ b/src/detail/standalone/windows/helper.h
@@ -226,10 +226,11 @@ int Window::OnDestroy(HWND h, UINT m, WPARAM w, LPARAM l)
 {
   auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
 
-  if (plugin && plugin->getProxy()->canUseGui())
+  const auto proxy = plugin ? plugin->getProxy() : nullptr;
+  if (proxy && proxy->canUseGui())
   {
-    plugin->getProxy()->guiHide();
-    plugin->getProxy()->guiDestroy();
+    proxy->guiHide();
+    proxy->guiDestroy();
   }
 
   ::PostQuitMessage(0);
@@ -276,19 +277,19 @@ int Window::OnKeyDown(HWND h, UINT m, WPARAM w, LPARAM l)
 int Window::OnWindowPosChanged(HWND h, UINT m, WPARAM w, LPARAM l)
 {
   auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
-  auto pluginProxy = plugin->getProxy();
+  const auto proxy = plugin->getProxy();
 
   auto dpi{::GetDpiForWindow(h)};
   auto scaleFactor{static_cast<float>(dpi) / static_cast<float>(USER_DEFAULT_SCREEN_DPI)};
 
-  if (pluginProxy->guiCanResize())
+  if (proxy->guiCanResize())
   {
     RECT r{0, 0, 0, 0};
     ::GetClientRect(h, &r);
     uint32_t w = (r.right - r.left);
     uint32_t h = (r.bottom - r.top);
-    pluginProxy->guiAdjustSize(&w, &h);
-    pluginProxy->guiSetSize(w, h);
+    proxy->guiAdjustSize(&w, &h);
+    proxy->guiSetSize(w, h);
   }
 
 #ifdef _DEBUG

--- a/src/detail/standalone/windows/winutils.cpp
+++ b/src/detail/standalone/windows/winutils.cpp
@@ -49,7 +49,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine
   int pindex{PLUGIN_INDEX};
 
   auto plugin{freeaudio::clap_wrapper::standalone::mainCreatePlugin(entry, pid, pindex, 1, __argv)};
-  auto pluginProxy = plugin->getProxy();
+  const auto proxy = plugin->getProxy();
 
   freeaudio::clap_wrapper::standalone::mainStartAudio();
 
@@ -61,24 +61,24 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine
 
   win32Gui.plugin = plugin;
 
-  if (pluginProxy->canUseGui())
+  if (proxy->canUseGui())
   {
-    pluginProxy->guiCreate(CLAP_WINDOW_API_WIN32, false);
+    proxy->guiCreate(CLAP_WINDOW_API_WIN32, false);
 
     freeaudio::clap_wrapper::standalone::windows::Window window;
 
     auto dpi{::GetDpiForWindow(window.m_hwnd)};
     auto scaleFactor{static_cast<float>(dpi) / static_cast<float>(USER_DEFAULT_SCREEN_DPI)};
-    pluginProxy->guiSetScale(scaleFactor);
+    proxy->guiSetScale(scaleFactor);
 
-    if (pluginProxy->guiCanResize())
+    if (proxy->guiCanResize())
     {
       // We can check here if we had a previous size but we aren't saving state yet
     }
 
     uint32_t w{0};
     uint32_t h{0};
-    pluginProxy->guiGetSize(&w, &h);
+    proxy->guiGetSize(&w, &h);
 
     RECT r{0, 0, 0, 0};
     r.right = w;
@@ -86,7 +86,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine
     ::AdjustWindowRectExForDpi(&r, WS_OVERLAPPEDWINDOW, 0, 0, dpi);
     ::SetWindowPos(window.m_hwnd, nullptr, 0, 0, (r.right - r.left), (r.bottom - r.top), SWP_NOMOVE);
 
-    if (!pluginProxy->guiCanResize())
+    if (!proxy->guiCanResize())
     {
       ::SetWindowLongPtr(window.m_hwnd, GWL_STYLE,
                          ::GetWindowLongPtr(window.m_hwnd, GWL_STYLE) & ~WS_OVERLAPPEDWINDOW |
@@ -96,9 +96,9 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine
     clap_window win;
     win.api = CLAP_WINDOW_API_WIN32;
     win.win32 = (void*)window.m_hwnd;
-    pluginProxy->guiSetParent(&win);
+    proxy->guiSetParent(&win);
 
-    pluginProxy->guiShow();
+    proxy->guiShow();
 
     ::ShowWindow(window.m_hwnd, SW_SHOWDEFAULT);
   }

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -12,13 +12,14 @@
 #include <pluginterfaces/gui/iplugview.h>
 #include <clap/clap.h>
 #include <functional>
+#include "clap_proxy.h"
 
 using namespace Steinberg;
 
 class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
 {
  public:
-  WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui, std::function<void()> onDestroy,
+  WrappedView(const Clap::PluginProxy& pluginProxy, std::function<void()> onDestroy,
               std::function<void()> onRunLoopAvailable);
   ~WrappedView();
 
@@ -90,8 +91,7 @@ class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
  private:
   void ensure_ui();
   void drop_ui();
-  const clap_plugin_t* _plugin = nullptr;
-  const clap_plugin_gui_t* _extgui = nullptr;
+  const Clap::PluginProxy& _pluginProxy;
   std::function<void()> _onDestroy = nullptr, _onRunLoopAvailable = nullptr;
   clap_window_t _window = {nullptr, {nullptr}};
   IPlugFrame* _plugFrame = nullptr;

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -19,7 +19,7 @@ using namespace Steinberg;
 class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
 {
  public:
-  WrappedView(const Clap::PluginProxy& pluginProxy, std::function<void()> onDestroy,
+  WrappedView(const Clap::PluginProxy& guiProxy, std::function<void()> onDestroy,
               std::function<void()> onRunLoopAvailable);
   ~WrappedView();
 
@@ -91,7 +91,7 @@ class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
  private:
   void ensure_ui();
   void drop_ui();
-  const Clap::PluginProxy& _pluginProxy;
+  const Clap::PluginProxy& _proxy;
   std::function<void()> _onDestroy = nullptr, _onRunLoopAvailable = nullptr;
   clap_window_t _window = {nullptr, {nullptr}};
   IPlugFrame* _plugFrame = nullptr;

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -157,13 +157,13 @@ inline clap_sectime doubleToSecTime(double t)
 void ProcessAdapter::flush()
 {
   // minimal processing if params are supported by the plugin
-  if (_pluginProxy.canUseParams())
+  if (_proxy.canUseParams())
   {
     _events.clear();
     _eventindices.clear();
 
     // sortEventIndices(); call only if there would be any input event
-    _pluginProxy.paramsFlush(_processData.in_events, _processData.out_events);
+    _proxy.paramsFlush(_processData.in_events, _processData.out_events);
   }
 }
 
@@ -392,20 +392,20 @@ void ProcessAdapter::process(Steinberg::Vst::ProcessData& data)
         doProcess = false;
     }
     if (doProcess)
-      _pluginProxy.process(&_processData);
+      _proxy.process(&_processData);
     else
     {
-      if (_pluginProxy.canUseParams())
+      if (_proxy.canUseParams())
       {
-        _pluginProxy.paramsFlush(_processData.in_events, _processData.out_events);
+        _proxy.paramsFlush(_processData.in_events, _processData.out_events);
       }
     }
   }
   else
   {
-    if (_pluginProxy.canUseParams())
+    if (_proxy.canUseParams())
     {
-      _pluginProxy.paramsFlush(_processData.in_events, _processData.out_events);
+      _proxy.paramsFlush(_processData.in_events, _processData.out_events);
     }
     else
     {

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -65,7 +65,7 @@ class ProcessAdapter
 		}
 #endif
 
-  ProcessAdapter(const Clap::PluginProxy& pluginProxy) : _pluginProxy{pluginProxy}
+  ProcessAdapter(const Clap::PluginProxy& proxy) : _proxy{proxy}
   {
   }
 
@@ -97,7 +97,7 @@ class ProcessAdapter
   void removeFromActiveNotes(const clap_event_note* note);
 
   // the plugin
-  const Clap::PluginProxy& _pluginProxy;
+  const Clap::PluginProxy& _proxy;
 
   Steinberg::Vst::ParameterContainer* parameters = nullptr;
   Steinberg::Vst::IComponentHandler* _componentHandler = nullptr;

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -33,6 +33,7 @@
 #include <memory>
 
 #include "../clap/automation.h"
+#include "clap_proxy.h"
 
 namespace Clap
 {
@@ -64,8 +65,11 @@ class ProcessAdapter
 		}
 #endif
 
-  void setupProcessing(const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params,
-                       Steinberg::Vst::BusList& audioinputs, Steinberg::Vst::BusList& audiooutputs,
+  ProcessAdapter(const Clap::PluginProxy& pluginProxy) : _pluginProxy{pluginProxy}
+  {
+  }
+
+  void setupProcessing(Steinberg::Vst::BusList& audioinputs, Steinberg::Vst::BusList& audiooutputs,
                        uint32_t numSamples, size_t numEventInputs, size_t numEventOutputs,
                        Steinberg::Vst::ParameterContainer& params,
                        Steinberg::Vst::IComponentHandler* componenthandler, IAutomation* automation,
@@ -93,8 +97,7 @@ class ProcessAdapter
   void removeFromActiveNotes(const clap_event_note* note);
 
   // the plugin
-  const clap_plugin_t* _plugin = nullptr;
-  const clap_plugin_params_t* _ext_params = nullptr;
+  const Clap::PluginProxy& _pluginProxy;
 
   Steinberg::Vst::ParameterContainer* parameters = nullptr;
   Steinberg::Vst::IComponentHandler* _componentHandler = nullptr;

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -183,12 +183,11 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   //---Clap::IHost------------------------------------------------------------------------
 
-  void setupWrapperSpecifics(const clap_plugin_t* plugin) override;
+  void setupWrapperSpecifics(const Clap::PluginProxy& pluginProxy) override;
 
-  void setupAudioBusses(const clap_plugin_t* plugin,
-                        const clap_plugin_audio_ports_t* audioports) override;
-  void setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports) override;
-  void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) override;
+  void setupAudioBusses(const Clap::PluginProxy& pluginProxy) override;
+  void setupMIDIBusses(const Clap::PluginProxy& pluginProxy) override;
+  void setupParameters(const Clap::PluginProxy& pluginProxy) override;
 
   void param_rescan(clap_param_rescan_flags flags) override;
   void param_clear(clap_id param, clap_param_clear_flags flags) override;
@@ -244,7 +243,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   Clap::Library* _library = nullptr;
   int _libraryIndex = 0;
   std::shared_ptr<Clap::Plugin> _plugin;
-  clap_plugin_as_vst3_t* _vst3specifics = nullptr;
+  const clap_plugin_as_vst3_t* _vst3specifics = nullptr;
   Clap::ProcessAdapter* _processAdapter = nullptr;
   WrappedView* _wrappedview = nullptr;
 

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -183,11 +183,11 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   //---Clap::IHost------------------------------------------------------------------------
 
-  void setupWrapperSpecifics(const Clap::PluginProxy& pluginProxy) override;
+  void setupWrapperSpecifics(const Clap::PluginProxy& proxy) override;
 
-  void setupAudioBusses(const Clap::PluginProxy& pluginProxy) override;
-  void setupMIDIBusses(const Clap::PluginProxy& pluginProxy) override;
-  void setupParameters(const Clap::PluginProxy& pluginProxy) override;
+  void setupAudioBusses(const Clap::PluginProxy& proxy) override;
+  void setupMIDIBusses(const Clap::PluginProxy& proxy) override;
+  void setupParameters(const Clap::PluginProxy& proxy) override;
 
   void param_rescan(clap_param_rescan_flags flags) override;
   void param_clear(clap_id param, clap_param_clear_flags flags) override;


### PR DESCRIPTION
This is how clap::helpers::PluginProxy would be used for `clap-wrapper`

I had to remove the line where the gui extension pointer is set to nullptr if the gui api isn't supported and I'm not sure on how to resolve this.

If considering merging, please make sure that before
- [x] https://github.com/free-audio/clap-helpers/pull/27 has been merged
- [x] CMake files are adjusted to include clap-helpers as well
- [x] Potential conflicts with #176 are resolved 