### PR TITLE
Update standalone utility buffer size

### DIFF
--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -236,11 +236,11 @@ struct StandaloneHost : Clap::IHost
   std::atomic<bool> running{true}, finishedRunning{false};
 
   // We need to have play buffers for the clap. For now lets assume
-  // (1) the standalone is never more than 16 total ins and outs and
+  // (1) the standalone is never more than 64 total ins and outs and
   // (2) the block size is less that 4096 * 16 and
   // (3) memory in the standalone is pretty cheap
   static constexpr int utilityBufferSize{4096 * 16};
-  static constexpr int utilityBufferMaxChannels{16};
+  static constexpr int utilityBufferMaxChannels{64};
   float utilityBuffer[utilityBufferMaxChannels][utilityBufferSize]{};
 };
 }  // namespace freeaudio::clap_wrapper::standalone


### PR DESCRIPTION
The standalone statically allocates working space for the io buffers for the process call. I had assumed max channels was 16, but short circuit has 20 stereo outputs, so move this to 64 for now. Probably better to dynamically allocate it at startup in the future.