### PR TITLE
A simple standalone save/retrieve

### DIFF
--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -68,6 +68,7 @@ function(target_add_standalone_wrapper)
         target_sources(${SA_TARGET} PRIVATE
                 "${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/wrapasstandalone.mm"
                 ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/macos/AppDelegate.mm
+                ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/macos/StandaloneFunctions.mm
                 ${GEN_XIB}
                 )
 

--- a/src/detail/standalone/macos/StandaloneFunctions.mm
+++ b/src/detail/standalone/macos/StandaloneFunctions.mm
@@ -1,0 +1,20 @@
+
+
+#include <Foundation/Foundation.h>
+#include "detail/standalone/standalone_host.h"
+
+namespace freeaudio::clap_wrapper::standalone
+{
+std::optional<fs::path> getStandaloneSettingsPath()
+{
+  auto *fileManager = [NSFileManager defaultManager];
+  auto *resultURLs = [fileManager URLsForDirectory:NSApplicationSupportDirectory
+                                         inDomains:NSUserDomainMask];
+  if (resultURLs)
+  {
+    auto *u = [resultURLs objectAtIndex:0];
+    return fs::path{[u fileSystemRepresentation]} / "clap-wrapper-standalone";
+  }
+  return std::nullopt;
+}
+}  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -1,6 +1,7 @@
 
 #include <cassert>
 #include "standalone_host.h"
+#include <fstream>
 
 #if LIN
 #if CLAP_WRAPPER_HAS_GTK3
@@ -10,6 +11,15 @@
 
 namespace freeaudio::clap_wrapper::standalone
 {
+
+#if !MAC
+std::optional<fs::path> getStandaloneSettingsPath()
+{
+  TRACE;
+  return std::nullopt;
+}
+#endif
+
 StandaloneHost::~StandaloneHost()
 {
 }
@@ -233,5 +243,75 @@ bool StandaloneHost::unregister_timer(clap_id timer_id)
   return false;
 }
 #endif
+
+static int64_t clapwrite(const clap_ostream *s, const void *buffer, uint64_t size)
+{
+  auto ofs = static_cast<std::ofstream *>(s->ctx);
+  ofs->write((const char *)buffer, size);
+  return size;
+}
+
+static int64_t clapread(const struct clap_istream *s, void *buffer, uint64_t size)
+{
+  auto ifs = static_cast<std::ifstream *>(s->ctx);
+
+  // Oh this API is so terrible. I think this is right?
+  ifs->read(static_cast<char *>(buffer), size);
+  if (ifs->rdstate() == std::ios::goodbit || ifs->rdstate() == std::ios::eofbit) return ifs->gcount();
+
+  if (ifs->rdstate() & std::ios::eofbit) return ifs->gcount();
+
+  return -1;
+}
+
+bool StandaloneHost::saveStandaloneAndPluginSettings(const fs::path &intoDir, const fs::path &withName)
+{
+  // This should obviously be a more robust file format. What we
+  // want is an envelope containing the standalone settings and then
+  // the streamed plugin data. What we have here is just the streamed
+  // plugin data with no settings space for audio port selection etc...
+
+  std::ofstream ofs(intoDir / withName, std::ios::out | std::ios::binary);
+  if (!ofs.is_open())
+  {
+    LOG << "Unable to open for writing " << (intoDir / withName).u8string() << std::endl;
+    return false;
+  }
+  if (!clapPlugin || !clapPlugin->_ext._state)
+  {
+    return false;
+  }
+  clap_ostream cos{};
+  cos.ctx = &ofs;
+  cos.write = clapwrite;
+  clapPlugin->_ext._state->save(clapPlugin->_plugin, &cos);
+  ofs.close();
+
+  return true;
+}
+
+bool StandaloneHost::tryLoadStandaloneAndPluginSettings(const fs::path &fromDir,
+                                                        const fs::path &withName)
+{
+  // see comment above on this file format being not just the
+  // raw stream in the future
+  auto fsp = fromDir / withName;
+  std::ifstream ifs(fsp, std::ios::in | std::ios::binary);
+  if (!ifs.is_open())
+  {
+    LOG << "Unable to open for reading " << fsp.u8string() << std::endl;
+    return false;
+  }
+  if (!clapPlugin || !clapPlugin->_ext._state)
+  {
+    return false;
+  }
+  clap_istream cis{};
+  cis.ctx = &ifs;
+  cis.read = clapread;
+  clapPlugin->_ext._state->load(clapPlugin->_plugin, &cis);
+  ifs.close();
+  return true;
+}
 
 }  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -5,8 +5,11 @@
 #include <unordered_set>
 #include <thread>
 #include <mutex>
+#include <optional>
 
 #include "standalone_details.h"
+
+#include "detail/clap/fsutil.h"
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -42,6 +45,8 @@ struct Win32Gui;
 }
 #endif
 #endif
+
+std::optional<fs::path> getStandaloneSettingsPath();
 
 struct StandaloneHost : Clap::IHost
 {
@@ -128,6 +133,9 @@ struct StandaloneHost : Clap::IHost
   {
     TRACE;
   }
+
+  bool saveStandaloneAndPluginSettings(const fs::path &intoDir, const fs::path &withName);
+  bool tryLoadStandaloneAndPluginSettings(const fs::path &fromDir, const fs::path &withName);
 
   uint32_t numAudioInputs{0}, numAudioOutputs{0};
   std::vector<uint32_t> inputChannelByBus;


### PR DESCRIPTION
- Standalone tries to save and retrieve state on start and stop
- Requires an OS specific default path which is only coded on macos now
- Currently uses use the raw data stream; obviously we want to expand this with an envelope for standalone settings in the near future