### PR TITLE
In explicit (single plugin via cmake config) mode, include UI

### DIFF
--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -17,6 +17,7 @@ namespace fs = ghc::filesystem;
 struct auInfo
 {
   std::string name, vers, type, subt, manu, manunm, clapid, desc, clapname;
+  bool explicitMode{false};
 
   const std::string factoryBase{"wrapAsAUV2_inst"};
 
@@ -169,6 +170,7 @@ int main(int argc, char **argv)
     }
     int idx = 2;
     auInfo u;
+    u.explicitMode = true;
     u.name = std::string(argv[idx++]);
     u.clapname = u.name;
     u.vers = std::string(argv[idx++]);
@@ -357,7 +359,17 @@ int main(int argc, char **argv)
     idx = 0;
     for (const auto &u : units)
     {
-      auto strcid = u.clapid;
+      std::string strcid;
+
+      if (u.explicitMode)
+      {
+        strcid = u.name + " " + u.type + " " + u.subt + " " + u.manunm + " " + u.manu;
+      }
+      else
+      {
+        strcid = u.clapid;
+      }
+
       for (auto &c : strcid)
       {
         if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'A') || (c >= '0' && c <= '9'))
@@ -382,9 +394,16 @@ int main(int argc, char **argv)
         cppf << "#undef CLAP_WRAPPER_TIMER_CALLBACK" << std::endl;
         cppf << "#undef CLAP_WRAPPER_FILL_AUCV" << std::endl;
 
-        fillOSS << "\n  if (strcmp(_plugin->_plugin->desc->id,\"" << u.clapid << "\") == 0) {\n";
-        fillOSS << "    return fillAUCV_" << on << "(viewInfo);\n";
-        fillOSS << "  }\n";
+        if (u.explicitMode)
+        {
+          fillOSS << "    return fillAUCV_" << on << "(viewInfo);\n";
+        }
+        else
+        {
+          fillOSS << "\n  if (strcmp(_plugin->_plugin->desc->id,\"" << u.clapid << "\") == 0) {\n";
+          fillOSS << "    return fillAUCV_" << on << "(viewInfo);\n";
+          fillOSS << "  }\n";
+        }
       }
       idx++;
     }


### PR DESCRIPTION
do this by still making a name etc... but skipping the if in the explicit single-plugin mode.