### PR TITLE
AUv2: Bus Shape and Stream Format; Tempo Corrected

### DIFF
--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -107,6 +107,9 @@ class WrapAsAUV2 : public ausdk::AUBase,
                       AudioComponentInstance ci);
   virtual ~WrapAsAUV2();
 
+ protected:
+  void PostConstructor() override;
+
  private:
   AUV2_Type _autype;
 
@@ -131,6 +134,14 @@ class WrapAsAUV2 : public ausdk::AUBase,
   {
     return true;
   }
+
+  AUChannelInfo cinfo[1];
+  UInt32 SupportedNumChannels(const AUChannelInfo** outInfo) override;
+  bool ValidFormat(AudioUnitScope inScope, AudioUnitElement inElement,
+                   const AudioStreamBasicDescription& inNewFormat) override;
+  OSStatus ChangeStreamFormat(AudioUnitScope inScope, AudioUnitElement inElement,
+                              const AudioStreamBasicDescription& inPrevFormat,
+                              const AudioStreamBasicDescription& inNewFormat) override;
 
   bool CanScheduleParameters() const override
   {


### PR DESCRIPTION
AUv2 changes

1. Set input and output topology to match the CLAP
2. Support stream format and channel count appropriately
3. Update input and output count in PostConstructor idiom
4. Fix a units conversion on tempo (but more to do here I think)

With this change, all the conduit items *except* the ring modulator validate. Conduit also doesn't have a multi-out synth yet, so I'll add one of those too and we can keep testing.