### PR TITLE
De-Deuplicate a Link in Standalone

### DIFF
--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -141,7 +141,6 @@ function(target_add_standalone_wrapper)
 
     target_link_libraries(${SA_TARGET} PRIVATE
             clap-wrapper-compile-options
-            clap-wrapper-shared-detail
             ${salib}
             )
 endfunction(target_add_standalone_wrapper)


### PR DESCRIPTION
The standalone shared lib ${salib} contained clap-wrapper-shared but we also explicitly linked it to the standalone. This didn't cause any harm but raises a warning at link time on xcode 15 so remove the specious extra link target