### PR TITLE
AUv2 tempo/clock matches CLAP

### DIFF
--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -148,6 +148,10 @@ class Plugin
   bool initialize();
   void terminate();
   void setSampleRate(double sampleRate);
+  double getSampleRate() const
+  {
+    return _audioSetup.sampleRate;
+  }
   void setBlockSizes(uint32_t minFrames, uint32_t maxFrames);
 
   bool load(const clap_istream_t* stream) const;

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -183,8 +183,7 @@ void ProcessAdapter::process(ProcessData& data)
     _transport.loop_end_beats = data._cycleStart;
     _transport.loop_end_beats = data._cycleEnd;
 
-    // I think this is wrong - current song pos is samples
-    _transport.song_pos_seconds = doubleToSecTime(data._currentSongPos);
+    _transport.song_pos_seconds = doubleToSecTime(data._currentSongPosInSeconds);
     _transport.flags |= CLAP_TRANSPORT_HAS_SECONDS_TIMELINE;
   }
   if (data._AUbeatAndTempoValid)
@@ -205,6 +204,7 @@ void ProcessAdapter::process(ProcessData& data)
     _transport.flags |= CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
     _transport.tsig_denom = data._musicalDenominator;
     _transport.tsig_num = data._musicalNumerator;
+    _transport.bar_start = data._currentDownBeat * CLAP_BEATTIME_FACTOR;
   }
 
   if (_numInputs)

--- a/src/detail/auv2/process.h
+++ b/src/detail/auv2/process.h
@@ -48,7 +48,7 @@ struct ProcessData
   // information from the AU Host
   Float64 _cycleStart;
   Float64 _cycleEnd;
-  Float64 _currentSongPos;  // outCurrentSampleInTimeLine
+  Float64 _currentSongPosInSeconds;  // outCurrentSampleInTimeLine
 
   Boolean _isPlaying;
   Boolean _transportChanged;

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -859,9 +859,11 @@ OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags& inFlags, const AudioTime
     // TODO: clarify how we can get transportStateProc2
     // mHostCallbackInfo.transportStateProc2
 #if 1
-    data._AUtransportValid = (noErr == CallHostTransportState(&data._isPlaying, &data._transportChanged,
-                                                              &data._currentSongPos, &data._isLooping,
-                                                              &data._cycleStart, &data._cycleEnd));
+    data._AUtransportValid =
+        (noErr == CallHostTransportState(&data._isPlaying, &data._transportChanged,
+                                         &data._currentSongPosInSeconds, &data._isLooping,
+                                         &data._cycleStart, &data._cycleEnd));
+    data._currentSongPosInSeconds /= std::max(_plugin->getSampleRate(), 1.0);  // just in case
     data._AUbeatAndTempoValid = (noErr == CallHostBeatAndTempo(&data._beat, &data._tempo));
     data._AUmusicalTimeValid =
         (noErr == CallHostMusicalTimeLocation(&data._offsetToNextBeat, &data._musicalNumerator,


### PR DESCRIPTION
With this change, the fields of the AUv2 conduit clap monitor in logic have the same units and behaviour as the conduit clap monitor as a clap in BWS.