### PR TITLE
Console Cleanup; Option to skip AUv2 per-plugin

### DIFF
--- a/include/clapwrapper/auv2.h
+++ b/include/clapwrapper/auv2.h
@@ -18,7 +18,9 @@ typedef struct clap_plugin_factory_as_auv2
   const char *manufacturer_code;  // your 'manu' field
   const char *manufacturer_name;  // your manufacturer display name
 
-  // populate information about this particular auv2. Return false if we cannot.
+  // populate information about this particular auv2. If this method returns
+  // false, the CLAP Plugin at the given index will not be exported into the
+  // resulting AUv2
   bool(CLAP_ABI *get_auv2_info)(const clap_plugin_factory_as_auv2 *factory, uint32_t index,
                                 clap_plugin_info_as_auv2_t *info);
 } clap_plugin_factory_as_auv2_t;

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -82,13 +82,15 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
   {
     manu = loader._pluginFactoryAUv2Info->manufacturer_code;
     manuName = loader._pluginFactoryAUv2Info->manufacturer_name;
-    std::cout << "  - using factor manufacturer '" << manuName << "' (" << manu << ")" << std::endl;
+    std::cout << "  - using factory manufacturer '" << manuName << "' (" << manu << ")" << std::endl;
   }
 
   static const char *encoder = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
   for (const auto *clapPlug : loader.plugins)
   {
     auto u = auInfo();
+    bool doExport = true;
+
     u.name = clapPlug->name;
     u.clapname = clapname;
     u.clapid = clapPlug->id;
@@ -145,9 +147,17 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
           u.subt = v2inf.au_subt;
         }
       }
+      else
+      {
+        doExport = false;
+        std::cout << "  - Skipping Audio Unit Export for index " << idx << "/" << u.clapid << std::endl;
+      }
     }
 
-    units.push_back(u);
+    if (doExport)
+    {
+      units.push_back(u);
+    }
     idx++;
   }
   return true;

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -83,7 +83,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (id)initWithAUv2:(free_audio::auv2_wrapper::ui_connection *)cont preferredSize:(NSSize)size
 {
-  LOGINFO("[clap-wrapper] create NS View begin");
+  LOGINFO("[clap-wrapper] creating NSView");
 
   ui = *cont;
   ui._plugin->_ext._gui->create(ui._plugin->_plugin, CLAP_WINDOW_API_COCOA, false);
@@ -110,7 +110,8 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
   gui->set_parent(ui._plugin->_plugin, &m);
   gui->set_scale(ui._plugin->_plugin, 1.0);
-  gui->set_size(ui._plugin->_plugin, size.width, size.height);
+
+  if (gui->can_resize(ui._plugin->_plugin)) gui->set_size(ui._plugin->_plugin, size.width, size.height);
 
   idleTimer = nil;
   CFTimeInterval TIMER_INTERVAL = .05;  // In SurgeGUISynthesizer.h it uses 50 ms
@@ -120,7 +121,6 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
                                    CLAP_WRAPPER_TIMER_CALLBACK, &TimerContext);
   if (idleTimer) CFRunLoopAddTimer(CFRunLoopGetMain(), idleTimer, kCFRunLoopCommonModes);
 
-  LOGINFO("[clap-wrapper] create NS View end");
   return self;
 }
 
@@ -159,7 +159,6 @@ bool CLAP_WRAPPER_FILL_AUCV(AudioUnitCocoaViewInfo *viewInfo)
   // now we are in m&m land..
   auto bundle = [NSBundle bundleForClass:[CLAP_WRAPPER_COCOA_CLASS class]];
 
-  LOGINFO("[clap-wrapper] fill AudioUnitCocoaViewInfo {}", __func__);
   if (bundle)
   {
     // Get the URL for the main bundle
@@ -174,10 +173,10 @@ bool CLAP_WRAPPER_FILL_AUCV(AudioUnitCocoaViewInfo *viewInfo)
 #undef ascf
 
     *viewInfo = {cfUrl, {className}};
-    LOGINFO("[clap-wrapper] fill AudioUnitCocoaViewInfo: - class is \"{}\"",
+    LOGINFO("[clap-wrapper] created AudioUnitCocoaView: - class is \"{}\"",
             CFStringGetCStringPtr(className, kCFStringEncodingUTF8));
     return true;
   }
-  LOGINFO("[clap-wrapper] fill AudioUnitCocoaViewInfo: FAILED");
+  LOGINFO("[clap-wrapper] create AudioUnitCocoaView failed: {}", __func__);
   return false;
 }

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -51,7 +51,7 @@ void pffffrzz()
 
 bool WrapAsAUV2::initializeClapDesc()
 {
-  LOGINFO("[clap-wrapper auv2: id={} index: {}\n", _clapid, _idx);
+  LOGINFO("[clap-wrapper] auv2: id={} index: {}", _clapid, _idx);
 
   if (!_library.hasEntryPoint())
   {
@@ -250,7 +250,8 @@ void WrapAsAUV2::setupAudioBusses(const clap_plugin_t* plugin,
   auto numAudioInputs = audioports->count(plugin, true);
   auto numAudioOutputs = audioports->count(plugin, false);
 
-  LOGINFO("AUDIO in: {}, out: {}\n", (int)numAudioInputs, (int)numAudioOutputs);
+  LOGINFO("[clap-wrapper] Setup Busses: audio in: {}, out: {}", (int)numAudioInputs,
+          (int)numAudioOutputs);
 
   ausdk::AUBase::GetScope(kAudioUnitScope_Input).Initialize(this, kAudioUnitScope_Input, numAudioInputs);
 
@@ -583,7 +584,6 @@ OSStatus WrapAsAUV2::GetPropertyInfo(AudioUnitPropertyID inID, AudioUnitScope in
       case kAudioUnitProperty_CocoaUI:
         outWritable = false;
         outDataSize = sizeof(struct AudioUnitCocoaViewInfo);
-        LOGINFO("query Property Info: kAudioUnitProperty_CocoaUI");
         return noErr;
         break;
 #if 0
@@ -659,19 +659,18 @@ OSStatus WrapAsAUV2::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
         return noErr;
 
       case kAudioUnitProperty_CocoaUI:
-        LOGINFO("query Property: kAudioUnitProperty_CocoaUI {}", (_plugin) ? "plugin" : "no plugin");
+        LOGINFO("[clap-wrapper] Property: kAudioUnitProperty_CocoaUI {}",
+                (_plugin) ? "plugin" : "no plugin");
         if (_plugin &&
             (_plugin->_ext._gui->is_api_supported(_plugin->_plugin, CLAP_WINDOW_API_COCOA, false)))
         {
-          LOGINFO("now getting cocoa ui");
           fillAudioUnitCocoaView(((AudioUnitCocoaViewInfo*)outData), _plugin);
-          // *((AudioUnitCocoaViewInfo *)outData) = cocoaInfo;
-          LOGINFO("query Property: kAudioUnitProperty_CocoaUI complete");
+          LOGINFO("[clap-wrapper] kAudioUnitProperty_CocoaUI complete");
           return noErr;  // sizeof(AudioUnitCocoaViewInfo);
         }
         else
         {
-          LOGINFO("query Property: kAudioUnitProperty_CocoaUI although now plugin ext");
+          LOGINFO("[clap-wrapper] Mysterious: kAudioUnitProperty_CocoaUI although now plugin ext");
           fillAudioUnitCocoaView(((AudioUnitCocoaViewInfo*)outData), _plugin);
           return noErr;
         }
@@ -778,7 +777,7 @@ void WrapAsAUV2::tail_changed()
 void WrapAsAUV2::addAudioBusFrom(int bus, const clap_audio_port_info_t* info, bool is_input)
 {
   // add/set audio bus configuration from info to appropriate scope
-  LOGINFO("Add Bus {} {}", bus, is_input ? "IN" : "OUT");
+  LOGINFO("[clap-wrapper]     - add bus {} : {}", bus, is_input ? "In" : "Out");
   if (is_input)
   {
     addInputBus(bus, info);
@@ -1247,7 +1246,7 @@ void WrapAsAUV2::PostConstructor()
       Outputs().GetIOElement(i)->SetAudioChannelLayout(layout);
       */
     }
-    LOGINFO("PostConstructor: Ins={} Outs={}", numAudioInputs, numAudioOutputs);
+    LOGINFO("[clap-wrapper] PostConstructor: Ins={} Outs={}", numAudioInputs, numAudioOutputs);
   }
   // The else here would just set elements to 0,0 which is the default
   // therefore leave it un-elsed

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -511,7 +511,7 @@ OSStatus WrapAsAUV2::Stop()
 }
 void WrapAsAUV2::Cleanup()
 {
-  LOGINFO("Cleaning up Plugin");
+  LOGINFO("[clap-wrapper] Cleaning up Plugin");
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
   deactivateCLAP();
   Base::Cleanup();
@@ -1256,7 +1256,7 @@ UInt32 WrapAsAUV2::GetAudioChannelLayout(AudioUnitScope scope, AudioUnitElement 
                                          AudioChannelLayout* outLayoutPtr, bool& outWritable)
 {
   // TODO: This is never called so the layout is never found
-  LOGINFO("GetAudioChannelLayout");
+  LOGINFO("[clap-wrapper] GetAudioChannelLayout");
   return Base::GetAudioChannelLayout(scope, element, outLayoutPtr, outWritable);
 }
 


### PR DESCRIPTION
1. If the auv2 factor is implemented and if you return false from the get_auv2_info, the plugin is not expoerted, allowing you to do a partial export from a multi-plugin shell

2. Clean up the console output a bit so its clear what comes from where.