### PR TITLE
Correctly put the bundle version -> auv2 version

### DIFF
--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -33,8 +33,8 @@ function(target_add_auv2_wrapper)
     endif ()
 
     if (NOT DEFINED AUV2_BUNDLE_VERSION)
-        message(WARNING "clap-wrapper: bundle version not defined. Chosing 1")
-        set(AUV2_BUNDLE_VERSION 1)
+        message(WARNING "clap-wrapper: bundle version not defined. Chosing ${PROJECT_VERSION}")
+        set(AUV2_BUNDLE_VERSION ${PROJECT_VERSION})
     endif ()
 
     # We need a build helper which ejects our config code for info-plist and entry points
@@ -75,7 +75,7 @@ function(target_add_auv2_wrapper)
                 COMMAND codesign -s - -f "$<TARGET_FILE:${bhtg}>"
                 COMMAND $<TARGET_FILE:${bhtg}> --fromclap
                 "${AUV2_OUTPUT_NAME}"
-                "$<TARGET_FILE:${clpt}>"
+                "$<TARGET_FILE:${clpt}>" "${AUV2_BUNDLE_VERSION}"
                 "${AUV2_MANUFACTURER_CODE}" "${AUV2_MANUFACTURER_NAME}"
         )
     else ()


### PR DESCRIPTION
We have a couple of versions. BUNDLE_VERSION, PROJECR_VERSION and the version in the CLAP. BUNDLE_VERSION and PROJECT_VERSION are required to be digits as is the auv2 version. The clap version can be anything and may not be projectable to a 32 bit int.

So this makes two changes

1. The BUNDLE_VERSION defaults to the PROJECT_VERSION if not set.
2. The BUNDLE_VERSION becomes the version of the auv2 in the info.plist

We may want to further revisit this, but the hard coded '1' is the worst choice, so it improves that.