### PR TITLE
Fix null dereference

### DIFF
--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -195,11 +195,14 @@ tresult PLUGIN_API WrappedView::setFrame(IPlugFrame* frame)
   _plugFrame = frame;
 
 #if LIN
-  if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void**)&_runLoop) ==
-          Steinberg::kResultOk &&
-      _onRunLoopAvailable)
+  if (_plugFrame)
   {
-    _onRunLoopAvailable();
+    if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void**)&_runLoop) ==
+            Steinberg::kResultOk &&
+        _onRunLoopAvailable)
+    {
+      _onRunLoopAvailable();
+    }
   }
 #endif
 


### PR DESCRIPTION
Some hosts call setFrame with a null pointer, for example JUCE-based hosts: https://github.com/juce-framework/JUCE/blob/d054f0d14dcac387aebda44ce5d792b5e7a625b3/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp#L1540C15-L1540C15