### PR TITLE
updating to CLAP 1.2.0 - removing retired extension midimapping

### DIFF
--- a/cmake/base_sdks.cmake
+++ b/cmake/base_sdks.cmake
@@ -72,7 +72,7 @@ function(guarantee_clap)
         CPMAddPackage(
                 NAME "clap"
                 GITHUB_REPOSITORY "free-audio/clap"
-                GIT_TAG "1.1.8"
+                GIT_TAG "1.2.0"
                 EXCLUDE_FROM_ALL TRUE
                 DOWNLOAD_ONLY TRUE
                 SOURCE_DIR cpm/clap

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -190,7 +190,6 @@ void Plugin::connectClap(const clap_plugin_t* clap)
   getExtension(_plugin, _ext._params, CLAP_EXT_PARAMS);
   getExtension(_plugin, _ext._audioports, CLAP_EXT_AUDIO_PORTS);
   getExtension(_plugin, _ext._noteports, CLAP_EXT_NOTE_PORTS);
-  getExtension(_plugin, _ext._midimap, CLAP_EXT_MIDI_MAPPINGS);
   getExtension(_plugin, _ext._latency, CLAP_EXT_LATENCY);
   getExtension(_plugin, _ext._render, CLAP_EXT_RENDER);
   getExtension(_plugin, _ext._tail, CLAP_EXT_TAIL);

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -90,7 +90,6 @@ struct ClapPluginExtensions
   const clap_plugin_audio_ports_t* _audioports = nullptr;
   const clap_plugin_gui_t* _gui = nullptr;
   const clap_plugin_note_ports_t* _noteports = nullptr;
-  const clap_plugin_midi_mappings_t* _midimap = nullptr;
   const clap_plugin_latency_t* _latency = nullptr;
   const clap_plugin_render_t* _render = nullptr;
   const clap_plugin_tail_t* _tail = nullptr;

--- a/x
+++ b/x
@@ -1,4 +1,0 @@
-
-/Users/paul/dev/music/clap-projects/clap-wrapper/ignore/xcode/Debug/downloadplug_as_auv2-build-helper --explicit downloadplug 1 aumu gWrp clAd cleveraudio.org
-
-


### PR DESCRIPTION
Updates CPM to CLAP 1.2.0, removing an removed draft extension (midimapping)