### PR TITLE
Issue 215 fixing Bundle Identifier problem

### DIFF
--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -24,6 +24,7 @@ namespace fs = std::filesystem;
 namespace fs = ghc::filesystem;
 #endif
 #include <iostream>
+#include <dlfcn.h>
 
 namespace os
 {
@@ -110,17 +111,6 @@ void MacOSHelper::detach(IPlugObject* plugobject)
 
 }  // namespace os
 
-// the dummy class so we can use NSBundle bundleForClass
-@interface clapwrapper_dummy_object_to_trick_the_os : NSObject
-- (void)fun;
-@end
-
-@implementation clapwrapper_dummy_object_to_trick_the_os
-- (void)fun
-{
-}
-@end
-
 namespace os
 {
 // [UI Thread]
@@ -140,32 +130,26 @@ uint64_t getTickInMS()
   return (::clock() * 1000) / CLOCKS_PER_SEC;
 }
 
+fs::path getBundlePath()
+{
+    Dl_info info;
+    if (dladdr((void*)getBundlePath, &info))
+    {
+        fs::path binaryPath = info.dli_fname;
+        return binaryPath.parent_path().parent_path().parent_path();
+    }
+    
+    return {};
+}
+
 std::string getParentFolderName()
 {
-  NSString* identifier =
-      [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
-  fs::path n = [identifier UTF8String];
-  if (n.has_parent_path())
-  {
-    auto p = n.parent_path();
-    if (p.has_filename())
-    {
-      return p.filename().u8string();
-    }
-  }
-
-  return std::string();
+    return getBundlePath().parent_path().stem();
 }
 
 std::string getBinaryName()
 {
-  // this is useless
-  // NSString* identifier = [[NSBundle mainBundle] bundleIdentifier];
-
-  // this is needed:
-  NSString* identifier =
-      [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
-  fs::path k = [identifier UTF8String];
-  return k.stem();
+    return getBundlePath().stem();
 }
+
 }  // namespace os


### PR DESCRIPTION
Can use the same method as linux to find the correct dll/bundle. Will not work on iOS because of different bundle structure, but can be adapted easily.