### PR TITLE
0.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 #
 #	clap-wrapper project
 #
-#   Copyright (c) 2022 Timo Kaluza (defiantnerd)
-#					   Paul Walker (baconpaul)
+#   Copyright (c) 2022-2024 Timo Kaluza (defiantnerd)
+#                           Paul Walker (baconpaul)
 #
 # There are a variety of advanced options to configure and build this wrapper, but
 # for the simple case of single plugin in a single clap, here are some relevant

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(CLAP_WRAPPER_WINDOWS_SINGLE_FILE "Build a single fine (rather than folder
 
 project(clap-wrapper
 	LANGUAGES C CXX
-	VERSION 0.6.0
+	VERSION 0.7.0
 	DESCRIPTION "CLAP-as-X wrappers"
 )
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Our [wiki](https://github.com/free-audio/clap-wrapper/wiki) is the root of our d
 Since building a `clap-wrapper` involves several choices we
 strongly suggest you consult it first.
 
-The simplest form of a clap wraper, though, is a VST3
+The simplest form of a clap wrapper, though, is a VST3
 which dynamically loads a CLAP of the same name using your
 copy of the VST3 and CLAP SDK. To build this, you can use the
 simple CMake command

--- a/cmake/base_sdks.cmake
+++ b/cmake/base_sdks.cmake
@@ -72,7 +72,7 @@ function(guarantee_clap)
         CPMAddPackage(
                 NAME "clap"
                 GITHUB_REPOSITORY "free-audio/clap"
-                GIT_TAG "1.1.8"
+                GIT_TAG "1.2.0"
                 EXCLUDE_FROM_ALL TRUE
                 DOWNLOAD_ONLY TRUE
                 SOURCE_DIR cpm/clap

--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -33,8 +33,8 @@ function(target_add_auv2_wrapper)
     endif ()
 
     if (NOT DEFINED AUV2_BUNDLE_VERSION)
-        message(WARNING "clap-wrapper: bundle version not defined. Chosing 1")
-        set(AUV2_BUNDLE_VERSION 1)
+        message(WARNING "clap-wrapper: bundle version not defined. Chosing ${PROJECT_VERSION}")
+        set(AUV2_BUNDLE_VERSION ${PROJECT_VERSION})
     endif ()
 
     # We need a build helper which ejects our config code for info-plist and entry points
@@ -75,7 +75,7 @@ function(target_add_auv2_wrapper)
                 COMMAND codesign -s - -f "$<TARGET_FILE:${bhtg}>"
                 COMMAND $<TARGET_FILE:${bhtg}> --fromclap
                 "${AUV2_OUTPUT_NAME}"
-                "$<TARGET_FILE:${clpt}>"
+                "$<TARGET_FILE:${clpt}>" "${AUV2_BUNDLE_VERSION}"
                 "${AUV2_MANUFACTURER_CODE}" "${AUV2_MANUFACTURER_NAME}"
         )
     else ()

--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -172,7 +172,8 @@ function(target_add_auv2_wrapper)
             "-framework Foundation"
             "-framework CoreFoundation"
             "-framework AppKit"
-            "-framework AudioToolbox")
+            "-framework AudioToolbox"
+            "-framework CoreMIDI")
 
     set_target_properties(${AUV2_TARGET} PROPERTIES
             BUNDLE True

--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -96,14 +96,18 @@ function(target_add_standalone_wrapper)
                 MACOS_EMBEDDED_CLAP_LOCATION ${SA_MACOS_EMBEDDED_CLAP_LOCATION})
 
     elseif(WIN32 AND (CMAKE_CXX_COMPILER_ID MATCHES "MSVC" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-        target_sources(${SA_TARGET} PRIVATE
-            ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/wrapasstandalone.cpp
-            ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/windows/winutils.cpp
+        set_target_properties(${SA_TARGET} PROPERTIES
+            WIN32_EXECUTABLE TRUE
             )
 
-        target_compile_definitions(${SA_TARGET} PRIVATE
+        target_sources(${SA_TARGET} PRIVATE
+            ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/windows/winutils.cpp
+            ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/windows/win32.manifest
+            )
+
+        target_compile_definitions(${salib} PUBLIC
             CLAP_WRAPPER_HAS_WIN32
-            WIN32_TITLE="${SA_OUTPUT_NAME}"
+            WIN32_NAME="${SA_OUTPUT_NAME}"
             )
 
     elseif(UNIX)

--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -141,7 +141,6 @@ function(target_add_standalone_wrapper)
 
     target_link_libraries(${SA_TARGET} PRIVATE
             clap-wrapper-compile-options
-            clap-wrapper-shared-detail
             ${salib}
             )
 endfunction(target_add_standalone_wrapper)

--- a/include/clapwrapper/auv2.h
+++ b/include/clapwrapper/auv2.h
@@ -18,7 +18,9 @@ typedef struct clap_plugin_factory_as_auv2
   const char *manufacturer_code;  // your 'manu' field
   const char *manufacturer_name;  // your manufacturer display name
 
-  // populate information about this particular auv2. Return false if we cannot.
+  // populate information about this particular auv2. If this method returns
+  // false, the CLAP Plugin at the given index will not be exported into the
+  // resulting AUv2
   bool(CLAP_ABI *get_auv2_info)(const clap_plugin_factory_as_auv2 *factory, uint32_t index,
                                 clap_plugin_info_as_auv2_t *info);
 } clap_plugin_factory_as_auv2_t;

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -155,7 +155,7 @@ std::shared_ptr<Plugin> Plugin::createInstance(Clap::Library& library, size_t in
 Plugin::Plugin(IHost* host)
   : _host{CLAP_VERSION,
           this,
-          "Clap-As-VST3-Wrapper",
+          host->host_get_name(),
           "defiant nerd",
           "https://www.defiantnerd.com",
           "0.0.1",

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -190,7 +190,6 @@ void Plugin::connectClap(const clap_plugin_t* clap)
   getExtension(_plugin, _ext._params, CLAP_EXT_PARAMS);
   getExtension(_plugin, _ext._audioports, CLAP_EXT_AUDIO_PORTS);
   getExtension(_plugin, _ext._noteports, CLAP_EXT_NOTE_PORTS);
-  getExtension(_plugin, _ext._midimap, CLAP_EXT_MIDI_MAPPINGS);
   getExtension(_plugin, _ext._latency, CLAP_EXT_LATENCY);
   getExtension(_plugin, _ext._render, CLAP_EXT_RENDER);
   getExtension(_plugin, _ext._tail, CLAP_EXT_TAIL);

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -67,6 +67,8 @@ class IHost
   virtual bool register_timer(uint32_t period_ms, clap_id* timer_id) = 0;
   virtual bool unregister_timer(clap_id timer_id) = 0;
 
+  virtual const char* host_get_name() = 0;
+
 #if LIN
   virtual bool register_fd(int fd, clap_posix_fd_flags_t flags) = 0;
   virtual bool modify_fd(int fd, clap_posix_fd_flags_t flags) = 0;

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -90,7 +90,6 @@ struct ClapPluginExtensions
   const clap_plugin_audio_ports_t* _audioports = nullptr;
   const clap_plugin_gui_t* _gui = nullptr;
   const clap_plugin_note_ports_t* _noteports = nullptr;
-  const clap_plugin_midi_mappings_t* _midimap = nullptr;
   const clap_plugin_latency_t* _latency = nullptr;
   const clap_plugin_render_t* _render = nullptr;
   const clap_plugin_tail_t* _tail = nullptr;

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -148,6 +148,10 @@ class Plugin
   bool initialize();
   void terminate();
   void setSampleRate(double sampleRate);
+  double getSampleRate() const
+  {
+    return _audioSetup.sampleRate;
+  }
   void setBlockSizes(uint32_t minFrames, uint32_t maxFrames);
 
   bool load(const clap_istream_t* stream) const;

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -423,6 +423,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
     return false;
   }
 
+  const char* host_get_name() override
+  {
+    return "Clap-As-AUV2-Wrapper";
+  }
+
   // --------------- IAutomation
   void onBeginEdit(clap_id id) override;
   void onPerformEdit(const clap_event_param_value_t* value) override;

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -95,6 +95,48 @@ class ValueEvent : public queueEvent
   }
 };
 
+class Clumps
+{
+ public:
+  void reset();
+  UInt32 addClump(const char* fullpath);
+  const char* getClump(UInt32 id);
+
+ private:
+  UInt32 _lastclump = 0;
+  std::map<std::string, UInt32> _clumps;
+};
+
+void Clumps::reset()
+{
+  _clumps.clear();
+  _lastclump = 0;
+}
+
+const char* Clumps::getClump(UInt32 id)
+{
+  for (const auto& c : _clumps)
+  {
+    if (c.second == id)
+    {
+      return c.first.c_str();
+    }
+  }
+  return nullptr;
+}
+
+UInt32 Clumps::addClump(const char* fullpath)
+{
+  auto r = _clumps.find(fullpath);
+  if (r == _clumps.end())
+  {
+    _clumps[fullpath] = ++_lastclump;
+    return _lastclump;
+  }
+
+  return r->second;
+}
+
 class WrapAsAUV2 : public ausdk::AUBase,
                    public Clap::IHost,
                    public Clap::IAutomation,
@@ -227,6 +269,9 @@ class WrapAsAUV2 : public ausdk::AUBase,
   OSStatus SetParameter(AudioUnitParameterID inID, AudioUnitScope inScope, AudioUnitElement inElement,
                         AudioUnitParameterValue inValue, UInt32 /*inBufferOffsetInFrames*/) override;
 
+  OSStatus CopyClumpName(AudioUnitScope inScope, UInt32 inClumpID, UInt32 inDesiredNameLength,
+                         CFStringRef* outClumpName) override;
+
   // ---------------- Clap::IHost
   void mark_dirty() override
   {
@@ -335,6 +380,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
   bool _midi_dualscheduling_mode = false;
 #endif
   std::map<uint32_t, std::unique_ptr<Clap::AUv2::Parameter>> _parametertree;
+  Clumps _clumps;
 
   CFStringRef _current_program_name = 0;
 

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -87,7 +87,7 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
                         std::string &manuName, std::vector<auInfo> &units)
 {
   Clap::Library loader;
-  if (!loader.load(clapfile.c_str()))
+  if (!loader.load(clapfile))
   {
     std::cout << "[ERROR] library.load of clapfile failed" << std::endl;
     return false;

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -82,13 +82,15 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
   {
     manu = loader._pluginFactoryAUv2Info->manufacturer_code;
     manuName = loader._pluginFactoryAUv2Info->manufacturer_name;
-    std::cout << "  - using factor manufacturer '" << manuName << "' (" << manu << ")" << std::endl;
+    std::cout << "  - using factory manufacturer '" << manuName << "' (" << manu << ")" << std::endl;
   }
 
   static const char *encoder = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
   for (const auto *clapPlug : loader.plugins)
   {
     auto u = auInfo();
+    bool doExport = true;
+
     u.name = clapPlug->name;
     u.clapname = clapname;
     u.clapid = clapPlug->id;
@@ -145,9 +147,17 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
           u.subt = v2inf.au_subt;
         }
       }
+      else
+      {
+        doExport = false;
+        std::cout << "  - Skipping Audio Unit Export for index " << idx << "/" << u.clapid << std::endl;
+      }
     }
 
-    units.push_back(u);
+    if (doExport)
+    {
+      units.push_back(u);
+    }
     idx++;
   }
   return true;

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -249,7 +249,7 @@ void ProcessAdapter::process(ProcessData& data)
   // output handling
   for (uint32_t i = 0; i < _numOutputs; i++)
   {
-    auto& m = static_cast<ausdk::AUOutputElement&>(*_audioOutputScope->SafeGetElement(0));
+    auto& m = static_cast<ausdk::AUOutputElement&>(*_audioOutputScope->SafeGetElement(i));
     AudioBufferList& myOutBuffers = m.PrepareBuffer(data.numSamples);
     auto num = myOutBuffers.mNumberBuffers;
     this->_output_ports[i].channel_count = num;

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -125,6 +125,10 @@ void ProcessAdapter::setupProcessing(ausdk::AUScope& audioInputs, ausdk::AUScope
   _processData.in_events = &_in_events;
   _processData.out_events = &_out_events;
 
+  _transport.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+  _transport.header.type = CLAP_EVENT_TRANSPORT;
+  _transport.header.time = 0;
+  _transport.header.size = sizeof(clap_event_transport_t);
   _processData.transport = &_transport;
 
   _in_events.ctx = this;

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -183,8 +183,7 @@ void ProcessAdapter::process(ProcessData& data)
     _transport.loop_end_beats = data._cycleStart;
     _transport.loop_end_beats = data._cycleEnd;
 
-    // I think this is wrong - current song pos is samples
-    _transport.song_pos_seconds = doubleToSecTime(data._currentSongPos);
+    _transport.song_pos_seconds = doubleToSecTime(data._currentSongPosInSeconds);
     _transport.flags |= CLAP_TRANSPORT_HAS_SECONDS_TIMELINE;
   }
   if (data._AUbeatAndTempoValid)
@@ -205,6 +204,7 @@ void ProcessAdapter::process(ProcessData& data)
     _transport.flags |= CLAP_TRANSPORT_HAS_TIME_SIGNATURE;
     _transport.tsig_denom = data._musicalDenominator;
     _transport.tsig_num = data._musicalNumerator;
+    _transport.bar_start = data._currentDownBeat * CLAP_BEATTIME_FACTOR;
   }
 
   if (_numInputs)

--- a/src/detail/auv2/process.h
+++ b/src/detail/auv2/process.h
@@ -69,24 +69,30 @@ struct ProcessData
   Float64 _currentDownBeat;
 };
 
+typedef union clap_multi_event
+{
+  clap_event_header_t header;
+  clap_event_note_t note;
+  clap_event_midi_t midi;
+  clap_event_midi_sysex_t sysex;
+  clap_event_param_value_t param;
+  clap_event_note_expression_t noteexpression;
+} clap_multi_event_t;
+
+class IMIDIOutputs
+{
+ public:
+  virtual ~IMIDIOutputs(){};
+  virtual void send(const clap_multi_event_t& event) = 0;
+};
+
 class ProcessAdapter
 {
  public:
-  typedef union clap_multi_event
-  {
-    clap_event_header_t header;
-    clap_event_note_t note;
-    clap_event_midi_t midi;
-    clap_event_midi_sysex_t sysex;
-    clap_event_param_value_t param;
-    clap_event_note_expression_t noteexpression;
-  } clap_multi_event_t;
-
   void setupProcessing(ausdk::AUScope& audioInputs, ausdk::AUScope& audioOutputs,
                        const clap_plugin_t* plugin, const clap_plugin_params_t* ext_params,
                        Clap::IAutomation* automationInterface, ParameterTree* parameters,
-
-                       uint32_t numMaxSamples, uint32_t preferredMIDIDialect);
+                       IMIDIOutputs* midiouts, uint32_t numMaxSamples, uint32_t preferredMIDIDialect);
 
   void process(ProcessData& data);  // AU Data
   void flush();
@@ -156,6 +162,8 @@ class ProcessAdapter
 
   Clap::IAutomation* _automation = nullptr;
   ParameterTree* _parameters = nullptr;
+
+  IMIDIOutputs* _midiouts = nullptr;
 
   // AU Process Data?
   ausdk::AUScope* _audioInputScope = nullptr;

--- a/src/detail/auv2/process.h
+++ b/src/detail/auv2/process.h
@@ -48,7 +48,7 @@ struct ProcessData
   // information from the AU Host
   Float64 _cycleStart;
   Float64 _cycleEnd;
-  Float64 _currentSongPos;  // outCurrentSampleInTimeLine
+  Float64 _currentSongPosInSeconds;  // outCurrentSampleInTimeLine
 
   Boolean _isPlaying;
   Boolean _transportChanged;

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -83,7 +83,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (id)initWithAUv2:(free_audio::auv2_wrapper::ui_connection *)cont preferredSize:(NSSize)size
 {
-  LOGINFO("[clap-wrapper] create NS View begin");
+  LOGINFO("[clap-wrapper] creating NSView");
 
   ui = *cont;
   ui._plugin->_ext._gui->create(ui._plugin->_plugin, CLAP_WINDOW_API_COCOA, false);
@@ -110,7 +110,8 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
   gui->set_parent(ui._plugin->_plugin, &m);
   gui->set_scale(ui._plugin->_plugin, 1.0);
-  gui->set_size(ui._plugin->_plugin, size.width, size.height);
+
+  if (gui->can_resize(ui._plugin->_plugin)) gui->set_size(ui._plugin->_plugin, size.width, size.height);
 
   idleTimer = nil;
   CFTimeInterval TIMER_INTERVAL = .05;  // In SurgeGUISynthesizer.h it uses 50 ms
@@ -120,7 +121,6 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
                                    CLAP_WRAPPER_TIMER_CALLBACK, &TimerContext);
   if (idleTimer) CFRunLoopAddTimer(CFRunLoopGetMain(), idleTimer, kCFRunLoopCommonModes);
 
-  LOGINFO("[clap-wrapper] create NS View end");
   return self;
 }
 
@@ -159,7 +159,6 @@ bool CLAP_WRAPPER_FILL_AUCV(AudioUnitCocoaViewInfo *viewInfo)
   // now we are in m&m land..
   auto bundle = [NSBundle bundleForClass:[CLAP_WRAPPER_COCOA_CLASS class]];
 
-  LOGINFO("[clap-wrapper] fill AudioUnitCocoaViewInfo {}", __func__);
   if (bundle)
   {
     // Get the URL for the main bundle
@@ -174,10 +173,10 @@ bool CLAP_WRAPPER_FILL_AUCV(AudioUnitCocoaViewInfo *viewInfo)
 #undef ascf
 
     *viewInfo = {cfUrl, {className}};
-    LOGINFO("[clap-wrapper] fill AudioUnitCocoaViewInfo: - class is \"{}\"",
+    LOGINFO("[clap-wrapper] created AudioUnitCocoaView: - class is \"{}\"",
             CFStringGetCStringPtr(className, kCFStringEncodingUTF8));
     return true;
   }
-  LOGINFO("[clap-wrapper] fill AudioUnitCocoaViewInfo: FAILED");
+  LOGINFO("[clap-wrapper] create AudioUnitCocoaView failed: {}", __func__);
   return false;
 }

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -29,30 +29,29 @@
 namespace Clap
 {
 #if WIN
-fs::path windows_path(const KNOWNFOLDERID &id)
+fs::path get_known_folder(const KNOWNFOLDERID &id)
 {
-  std::wstring path;
-  wchar_t *buffer;
+  wchar_t *buffer{nullptr};
 
   if (SUCCEEDED(SHGetKnownFolderPath(id, 0, nullptr, &buffer)))
   {
-    fs::path data = std::wstring(buffer);
+    fs::path data{std::wstring(buffer)};
     CoTaskMemFree(buffer);
 
     return data;
   }
 
   else
-    return fs::path{};
+    return {};
 }
 
-std::vector<std::wstring> split_clap_path(const std::wstring &in, const std::wstring &sep)
+std::vector<std::string> split_clap_path(const std::string &in)
 {
-  std::vector<std::wstring> res;
-  std::wstringstream ss(in);
-  std::wstring item;
+  std::vector<std::string> res;
+  std::stringstream ss(in);
+  std::string item;
 
-  while (std::getline(ss, item, L';')) res.push_back(item);
+  while (std::getline(ss, item, ';')) res.push_back(item);
 
   return res;
 }
@@ -74,20 +73,20 @@ std::vector<fs::path> getValidCLAPSearchPaths()
 #endif
 
 #if WIN
-  auto p{windows_path(FOLDERID_ProgramFilesCommon)};
+  auto p{get_known_folder(FOLDERID_ProgramFilesCommon)};
   if (fs::exists(p)) res.emplace_back(p / "CLAP");
 
-  auto q{windows_path(FOLDERID_LocalAppData)};
+  auto q{get_known_folder(FOLDERID_LocalAppData)};
   if (fs::exists(q)) res.emplace_back(q / "Programs" / "Common" / "CLAP");
 
-  std::wstring cp;
-  auto len{::GetEnvironmentVariableW(L"CLAP_PATH", NULL, 0)};
+  std::string cp;
+  auto len{::GetEnvironmentVariable("CLAP_PATH", nullptr, 0)};
 
   if (len > 0)
   {
     cp.resize(len);
-    cp.resize(::GetEnvironmentVariableW(L"CLAP_PATH", &cp[0], len));
-    auto paths{split_clap_path(cp, L";")};
+    cp.resize(::GetEnvironmentVariable("CLAP_PATH", &cp[0], len));
+    auto paths{split_clap_path(cp)};
 
     for (const auto &path : paths)
     {

--- a/src/detail/clap/fsutil.h
+++ b/src/detail/clap/fsutil.h
@@ -49,7 +49,7 @@ class Library
  public:
   Library();
   ~Library();
-  bool load(const char* name);
+  bool load(const fs::path&);
 
   const clap_plugin_entry_t* _pluginEntry = nullptr;
   const clap_plugin_factory_t* _pluginFactory = nullptr;

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -24,6 +24,7 @@ namespace fs = std::filesystem;
 namespace fs = ghc::filesystem;
 #endif
 #include <iostream>
+#include <dlfcn.h>
 
 namespace os
 {
@@ -110,17 +111,6 @@ void MacOSHelper::detach(IPlugObject* plugobject)
 
 }  // namespace os
 
-// the dummy class so we can use NSBundle bundleForClass
-@interface clapwrapper_dummy_object_to_trick_the_os : NSObject
-- (void)fun;
-@end
-
-@implementation clapwrapper_dummy_object_to_trick_the_os
-- (void)fun
-{
-}
-@end
-
 namespace os
 {
 // [UI Thread]
@@ -140,32 +130,26 @@ uint64_t getTickInMS()
   return (::clock() * 1000) / CLOCKS_PER_SEC;
 }
 
+fs::path getBundlePath()
+{
+    Dl_info info;
+    if (dladdr((void*)getBundlePath, &info))
+    {
+        fs::path binaryPath = info.dli_fname;
+        return binaryPath.parent_path().parent_path().parent_path();
+    }
+    
+    return {};
+}
+
 std::string getParentFolderName()
 {
-  NSString* identifier =
-      [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
-  fs::path n = [identifier UTF8String];
-  if (n.has_parent_path())
-  {
-    auto p = n.parent_path();
-    if (p.has_filename())
-    {
-      return p.filename().u8string();
-    }
-  }
-
-  return std::string();
+    return getBundlePath().parent_path().stem();
 }
 
 std::string getBinaryName()
 {
-  // this is useless
-  // NSString* identifier = [[NSBundle mainBundle] bundleIdentifier];
-
-  // this is needed:
-  NSString* identifier =
-      [[NSBundle bundleForClass:[clapwrapper_dummy_object_to_trick_the_os class]] bundlePath];
-  fs::path k = [identifier UTF8String];
-  return k.stem();
+    return getBundlePath().stem();
 }
+
 }  // namespace os

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -132,24 +132,24 @@ uint64_t getTickInMS()
 
 fs::path getBundlePath()
 {
-    Dl_info info;
-    if (dladdr((void*)getBundlePath, &info))
-    {
-        fs::path binaryPath = info.dli_fname;
-        return binaryPath.parent_path().parent_path().parent_path();
-    }
-    
-    return {};
+  Dl_info info;
+  if (dladdr((void*)getBundlePath, &info))
+  {
+    fs::path binaryPath = info.dli_fname;
+    return binaryPath.parent_path().parent_path().parent_path();
+  }
+
+  return {};
 }
 
 std::string getParentFolderName()
 {
-    return getBundlePath().parent_path().stem();
+  return getBundlePath().parent_path().stem();
 }
 
 std::string getBinaryName()
 {
-    return getBundlePath().stem();
+  return getBundlePath().stem();
 }
 
 }  // namespace os

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -4,6 +4,7 @@
 
 #include "detail/standalone/entry.h"
 #include "detail/standalone/standalone_details.h"
+#include "detail/standalone/standalone_host.h"
 
 #include "detail/clap/fsutil.h"
 
@@ -102,6 +103,15 @@
     ui->show(p);
   }
 
+  freeaudio::clap_wrapper::standalone::getStandaloneHost()->onRequestResize =
+      [self](uint32_t w, uint32_t h)
+  {
+    NSSize sz;
+    sz.width = w;
+    sz.height = h;
+    [[self window] setContentSize:sz];
+    return false;
+  };
   freeaudio::clap_wrapper::standalone::mainStartAudio();
 }
 

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -39,7 +39,7 @@
 
     if (fs::is_directory(clapPath) && !entry)
     {
-      lib.load(clapPath.u8string().c_str());
+      lib.load(clapPath);
       entry = lib._pluginEntry;
     }
   }

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -238,6 +238,11 @@ bool StandaloneHost::gui_request_resize(uint32_t width, uint32_t height)
   return false;
 }
 
+const char *StandaloneHost::host_get_name()
+{
+  return "CLAP-Wrapper-As-Standalone";
+}
+
 #if LIN
 
 bool StandaloneHost::register_timer(uint32_t period_ms, clap_id *timer_id)

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -20,11 +20,10 @@
 namespace freeaudio::clap_wrapper::standalone
 {
 
-#if CLAP_WRAPPER_HAS_WIN32
+#if WIN && CLAP_WRAPPER_HAS_WIN32
 std::optional<fs::path> getStandaloneSettingsPath()
 {
-  std::wstring path;
-  wchar_t *buffer;
+  wchar_t *buffer{nullptr};
 
   if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &buffer)))
   {

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -61,7 +61,7 @@ void StandaloneHost::setupAudioBusses(const clap_plugin_t *plugin,
   for (auto i = 0U; i < numAudioInputs; ++i)
   {
     audioports->get(plugin, i, true, &info);
-    LOG << "  - input " << i << " " << info.name << std::endl;
+    // LOG << "  - input " << i << " " << info.name << std::endl;
     inputChannelByBus.push_back(info.channel_count);
     totalInputChannels += info.channel_count;
     if (info.flags & CLAP_AUDIO_PORT_IS_MAIN) mainInput = i;
@@ -69,7 +69,7 @@ void StandaloneHost::setupAudioBusses(const clap_plugin_t *plugin,
   for (auto i = 0U; i < numAudioOutputs; ++i)
   {
     audioports->get(plugin, i, false, &info);
-    LOG << "  - output " << i << " " << info.name << std::endl;
+    // LOG << "  - output " << i << " " << info.name << std::endl;
     outputChannelByBus.push_back(info.channel_count);
     totalOutputChannels += info.channel_count;
     if (info.flags & CLAP_AUDIO_PORT_IS_MAIN) mainOutput = i;
@@ -216,6 +216,26 @@ void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t fra
     f[2 * i] = utilityBuffer[mainOutIdx][i];
     f[2 * i + 1] = utilityBuffer[mainOutIdx + 1][i];
   }
+}
+
+bool StandaloneHost::gui_can_resize()
+{
+  if (!clapPlugin) return false;
+
+  auto g = clapPlugin->_ext._gui;
+  if (!g) return false;
+
+  auto res = g->can_resize(clapPlugin->_plugin);
+  return res;
+}
+
+bool StandaloneHost::gui_request_resize(uint32_t width, uint32_t height)
+{
+  if (onRequestResize)
+  {
+    return onRequestResize(width, height);
+  }
+  return false;
 }
 
 #if LIN

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -163,16 +163,12 @@ struct StandaloneHost : Clap::IHost
   void param_request_flush() override
   {
   }
-  bool gui_can_resize() override
-  {
-    TRACE;
-    return false;
-  }
-  bool gui_request_resize(uint32_t width, uint32_t height) override
-  {
-    TRACE;
-    return false;
-  }
+
+  bool gui_can_resize() override;
+
+  std::function<bool(uint32_t, uint32_t)> onRequestResize = [](auto, auto) { return false; };
+  bool gui_request_resize(uint32_t width, uint32_t height) override;
+
   bool gui_request_show() override
   {
     TRACE;

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -194,6 +194,9 @@ struct StandaloneHost : Clap::IHost
 
   bool register_timer(uint32_t period_ms, clap_id *timer_id) override;
   bool unregister_timer(clap_id timer_id) override;
+
+  const char *host_get_name() override;
+
 #if LIN
   bool register_fd(int fd, clap_posix_fd_flags_t flags) override;
   bool modify_fd(int fd, clap_posix_fd_flags_t flags) override;

--- a/src/detail/standalone/windows/helper.h
+++ b/src/detail/standalone/windows/helper.h
@@ -1,12 +1,49 @@
 #if CLAP_WRAPPER_HAS_WIN32
 
+#ifdef UNICODE
+#undef UNICODE
+#endif
+
 #include <Windows.h>
+#include <dwmapi.h>
 
 #include <string>
 #include <random>
 
-namespace freeaudio::clap_wrapper::standalone::windows::helper
+#pragma comment(lib, "dwmapi")
+
+#define IDM_SETTINGS 1001
+#define IDM_SAVE_STATE 1002
+#define IDM_LOAD_STATE 1003
+#define IDM_RESET_STATE 1004
+
+namespace freeaudio::clap_wrapper::standalone::windows
 {
+struct Window
+{
+  Window();
+  ~Window();
+
+  static LRESULT CALLBACK WndProc(HWND, UINT, WPARAM, LPARAM);
+  virtual int OnClose(HWND, UINT, WPARAM, LPARAM);
+  virtual int OnDestroy(HWND, UINT, WPARAM, LPARAM);
+  virtual int OnDpiChanged(HWND, UINT, WPARAM, LPARAM);
+  virtual int OnKeyDown(HWND, UINT, WPARAM, LPARAM);
+  virtual int OnWindowPosChanged(HWND, UINT, WPARAM, LPARAM);
+
+  bool fullscreen();
+
+  HWND m_hwnd;
+  bool isConsoleAttached{false};
+};
+
+struct Console
+{
+  Console();
+  ~Console();
+  FILE* f;
+};
+
 template <class T, HWND(T::*m_hwnd)>
 T* InstanceFromWndProc(HWND hwnd, UINT umsg, LPARAM lparam)
 {
@@ -16,13 +53,12 @@ T* InstanceFromWndProc(HWND hwnd, UINT umsg, LPARAM lparam)
   {
     LPCREATESTRUCT pCreateStruct{reinterpret_cast<LPCREATESTRUCT>(lparam)};
     pInstance = reinterpret_cast<T*>(pCreateStruct->lpCreateParams);
-    ::SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pInstance));
+    ::SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pInstance));
     pInstance->*m_hwnd = hwnd;
-    ::ShowWindow(::GetConsoleWindow(), SW_HIDE);
   }
 
   else
-    pInstance = reinterpret_cast<T*>(::GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+    pInstance = reinterpret_cast<T*>(::GetWindowLongPtr(hwnd, GWLP_USERDATA));
 
   return pInstance;
 }
@@ -72,34 +108,227 @@ std::wstring widen(std::string in)
   return {};
 }
 
-std::wstring randomize(std::wstring in)
+std::string randomize(std::string in)
 {
   std::random_device rd;
   std::mt19937 mt(rd());
   std::uniform_real_distribution<double> dist(1.0, 10.0);
   auto randomDouble{dist(mt)};
-  auto randomNumber{std::to_wstring(randomDouble)};
+  auto randomNumber{std::to_string(randomDouble)};
   randomNumber.erase(remove(randomNumber.begin(), randomNumber.end(), '.'), randomNumber.end());
 
   return (in + randomNumber);
 }
 
-bool fullscreen(HWND hwnd)
+Window::Window()
 {
+  std::string clapName{WIN32_NAME};
+  std::string randomName{randomize(clapName)};
+
+  WNDCLASSEX wcex{sizeof(WNDCLASSEX)};
+  wcex.lpszClassName = randomName.c_str();
+  wcex.lpszMenuName = randomName.c_str();
+  wcex.lpfnWndProc = Window::WndProc;
+  wcex.style = 0;
+  wcex.cbClsExtra = 0;
+  wcex.cbWndExtra = 0;
+  wcex.hInstance = ::GetModuleHandle(nullptr);
+  wcex.hbrBackground = reinterpret_cast<HBRUSH>(::GetStockObject(BLACK_BRUSH));
+  wcex.hCursor = reinterpret_cast<HCURSOR>(::LoadImage(nullptr, reinterpret_cast<LPCSTR>(IDC_ARROW),
+                                                       IMAGE_CURSOR, 0, 0, LR_SHARED | LR_DEFAULTSIZE));
+  wcex.hIcon =
+      reinterpret_cast<HICON>(::LoadImage(nullptr, reinterpret_cast<LPCSTR>(IDI_APPLICATION), IMAGE_ICON,
+                                          0, 0, LR_DEFAULTCOLOR | LR_DEFAULTSIZE | LR_SHARED));
+  wcex.hIconSm =
+      reinterpret_cast<HICON>(::LoadImage(nullptr, reinterpret_cast<LPCSTR>(IDI_APPLICATION), IMAGE_ICON,
+                                          0, 0, LR_DEFAULTCOLOR | LR_DEFAULTSIZE | LR_SHARED));
+
+  ::RegisterClassEx(&wcex);
+
+  ::CreateWindowEx(0, randomName.c_str(), clapName.c_str(), WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
+                   CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, nullptr, nullptr,
+                   ::GetModuleHandle(nullptr), this);
+
+  auto hMenu{::GetSystemMenu(m_hwnd, FALSE)};
+
+  MENUITEMINFO seperator{sizeof(MENUITEMINFO)};
+  seperator.fMask = MIIM_FTYPE;
+  seperator.fType = MFT_SEPARATOR;
+
+  MENUITEMINFO audioIn{sizeof(MENUITEMINFO)};
+  audioIn.fMask = MIIM_STRING | MIIM_ID;
+  audioIn.wID = IDM_SETTINGS;
+  audioIn.dwTypeData = const_cast<LPSTR>("Settings");
+
+  MENUITEMINFO saveState{sizeof(MENUITEMINFO)};
+  saveState.fMask = MIIM_STRING | MIIM_ID;
+  saveState.wID = IDM_SAVE_STATE;
+  saveState.dwTypeData = const_cast<LPSTR>("Save state...");
+
+  MENUITEMINFO loadState{sizeof(MENUITEMINFO)};
+  loadState.fMask = MIIM_STRING | MIIM_ID;
+  loadState.wID = IDM_LOAD_STATE;
+  loadState.dwTypeData = const_cast<LPSTR>("Load state...");
+
+  MENUITEMINFO resetState{sizeof(MENUITEMINFO)};
+  resetState.fMask = MIIM_STRING | MIIM_ID;
+  resetState.wID = IDM_RESET_STATE;
+  resetState.dwTypeData = const_cast<LPSTR>("Reset state...");
+
+  if (hMenu != INVALID_HANDLE_VALUE)
+  {
+    ::InsertMenuItem(hMenu, 1, TRUE, &seperator);
+    ::InsertMenuItem(hMenu, 2, TRUE, &audioIn);
+    ::InsertMenuItem(hMenu, 3, TRUE, &seperator);
+    ::InsertMenuItem(hMenu, 4, TRUE, &saveState);
+    ::InsertMenuItem(hMenu, 5, TRUE, &loadState);
+    ::InsertMenuItem(hMenu, 6, TRUE, &resetState);
+    ::InsertMenuItem(hMenu, 7, TRUE, &seperator);
+  }
+}
+
+Window::~Window()
+{
+}
+
+LRESULT CALLBACK Window::WndProc(HWND h, UINT m, WPARAM w, LPARAM l)
+{
+  Window* pWindow = InstanceFromWndProc<Window, &Window::m_hwnd>(h, m, l);
+
+  if (pWindow)
+  {
+    switch (m)
+    {
+      case WM_CLOSE:
+        return pWindow->OnClose(h, m, w, l);
+      case WM_DESTROY:
+        return pWindow->OnDestroy(h, m, w, l);
+      case WM_DPICHANGED:
+        return pWindow->OnDpiChanged(h, m, w, l);
+      case WM_KEYDOWN:
+        return pWindow->OnKeyDown(h, m, w, l);
+      case WM_WINDOWPOSCHANGED:
+        return pWindow->OnWindowPosChanged(h, m, w, l);
+    }
+  }
+
+  return ::DefWindowProc(h, m, w, l);
+}
+
+int Window::OnClose(HWND h, UINT m, WPARAM w, LPARAM l)
+{
+  ::DestroyWindow(h);
+
+  return 0;
+}
+
+int Window::OnDestroy(HWND h, UINT m, WPARAM w, LPARAM l)
+{
+  auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
+
+  if (plugin && plugin->_ext._gui)
+  {
+    plugin->_ext._gui->hide(plugin->_plugin);
+    plugin->_ext._gui->destroy(plugin->_plugin);
+  }
+
+  ::PostQuitMessage(0);
+
+  return 0;
+}
+
+int Window::OnDpiChanged(HWND h, UINT m, WPARAM w, LPARAM l)
+{
+  auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
+  auto ui{plugin->_ext._gui};
+  auto p{plugin->_plugin};
+
+  auto dpi{::GetDpiForWindow(h)};
+  auto scaleFactor{static_cast<float>(dpi) / static_cast<float>(USER_DEFAULT_SCREEN_DPI)};
+
+  ui->set_scale(p, scaleFactor);
+
+  auto bounds{(RECT*)l};
+  ::SetWindowPos(h, nullptr, bounds->left, bounds->top, (bounds->right - bounds->left),
+                 (bounds->bottom - bounds->top), SWP_NOZORDER | SWP_NOACTIVATE);
+
+  return 0;
+}
+
+int Window::OnKeyDown(HWND h, UINT m, WPARAM w, LPARAM l)
+{
+  auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
+  auto ui{plugin->_ext._gui};
+  auto p{plugin->_plugin};
+
+  switch (w)
+  {
+    case VK_F11:
+    {
+      if (ui->can_resize(p)) fullscreen();
+
+      break;
+    }
+
+    default:
+      return 0;
+  }
+
+  return 0;
+}
+
+int Window::OnWindowPosChanged(HWND h, UINT m, WPARAM w, LPARAM l)
+{
+  auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
+  auto ui{plugin->_ext._gui};
+  auto p{plugin->_plugin};
+
+  auto dpi{::GetDpiForWindow(h)};
+  auto scaleFactor{static_cast<float>(dpi) / static_cast<float>(USER_DEFAULT_SCREEN_DPI)};
+
+  if (ui->can_resize(p))
+  {
+    RECT r{0, 0, 0, 0};
+    ::GetClientRect(h, &r);
+    uint32_t w = (r.right - r.left);
+    uint32_t h = (r.bottom - r.top);
+    ui->adjust_size(p, &w, &h);
+    ui->set_size(p, w, h);
+  }
+
+#ifdef _DEBUG
+  if (isConsoleAttached)
+  {
+    RECT wr{0, 0, 0, 0};
+    ::GetWindowRect(h, &wr);
+    ::SetWindowPos(::GetConsoleWindow(), nullptr, wr.left, wr.bottom, (wr.right - wr.left), 200,
+                   SWP_NOZORDER | SWP_ASYNCWINDOWPOS);
+  }
+#endif
+
+  return 0;
+}
+
+bool Window::fullscreen()
+{
+  auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
+  auto ui{plugin->_ext._gui};
+  auto p{plugin->_plugin};
+
   static RECT pos;
 
-  auto style{GetWindowLongPtrW(hwnd, GWL_STYLE)};
+  auto style{::GetWindowLongPtr(m_hwnd, GWL_STYLE)};
 
   if (style & WS_OVERLAPPEDWINDOW)
   {
     MONITORINFO mi = {sizeof(mi)};
-    GetWindowRect(hwnd, &pos);
-    if (GetMonitorInfoW(MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST), &mi))
+    ::GetWindowRect(m_hwnd, &pos);
+    if (::GetMonitorInfo(::MonitorFromWindow(m_hwnd, MONITOR_DEFAULTTONEAREST), &mi))
     {
-      SetWindowLongPtrW(hwnd, GWL_STYLE, style & ~WS_OVERLAPPEDWINDOW);
-      SetWindowPos(hwnd, HWND_TOP, mi.rcMonitor.left, mi.rcMonitor.top,
-                   mi.rcMonitor.right - mi.rcMonitor.left, mi.rcMonitor.bottom - mi.rcMonitor.top,
-                   SWP_FRAMECHANGED);
+      ::SetWindowLongPtr(m_hwnd, GWL_STYLE, style & ~WS_OVERLAPPEDWINDOW);
+      ::SetWindowPos(m_hwnd, HWND_TOP, mi.rcMonitor.left, mi.rcMonitor.top,
+                     mi.rcMonitor.right - mi.rcMonitor.left, mi.rcMonitor.bottom - mi.rcMonitor.top,
+                     SWP_FRAMECHANGED);
     }
 
     return true;
@@ -107,14 +336,33 @@ bool fullscreen(HWND hwnd)
 
   else
   {
-    SetWindowLongPtrW(hwnd, GWL_STYLE, style | WS_OVERLAPPEDWINDOW);
-    SetWindowPos(hwnd, nullptr, pos.left, pos.top, (pos.right - pos.left), (pos.bottom - pos.top),
-                 SWP_FRAMECHANGED);
+    ::SetWindowLongPtr(m_hwnd, GWL_STYLE, style | WS_OVERLAPPEDWINDOW);
+    ::SetWindowPos(m_hwnd, nullptr, pos.left, pos.top, (pos.right - pos.left), (pos.bottom - pos.top),
+                   SWP_FRAMECHANGED);
 
     return false;
   }
 }
 
-}  // namespace freeaudio::clap_wrapper::standalone::windows::helper
+Console::Console()
+{
+  ::AllocConsole();
+  ::EnableMenuItem(::GetSystemMenu(::GetConsoleWindow(), FALSE), SC_CLOSE,
+                   MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
+  ::freopen_s(&f, "CONOUT$", "w", stdout);
+  ::freopen_s(&f, "CONOUT$", "w", stderr);
+  ::freopen_s(&f, "CONIN$", "r", stdin);
+  std::cout.clear();
+  std::clog.clear();
+  std::cerr.clear();
+  std::cin.clear();
+}
+
+Console::~Console()
+{
+  ::fclose(f);
+  ::FreeConsole();
+}
+}  // namespace freeaudio::clap_wrapper::standalone::windows
 
 #endif

--- a/src/detail/standalone/windows/win32.manifest
+++ b/src/detail/standalone/windows/win32.manifest
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"
+    xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls"
+                version="6.0.0.0"
+                processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+        </dependentAssembly>
+    </dependency>
+
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity type="win32" name="Microsoft.Windows.Gdiplus"
+                version="1.1.0.0"
+                processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+        </dependentAssembly>
+    </dependency>
+
+    <asmv3:application>
+        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <dpiAwareness>PerMonitorV2</dpiAwareness>
+            <longPathAware>true</longPathAware>
+        </asmv3:windowsSettings>
+        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
+            <activeCodePage>UTF-8</activeCodePage>
+        </asmv3:windowsSettings>
+        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">
+            <heapType>SegmentHeap</heapType>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>

--- a/src/detail/standalone/windows/winutils.cpp
+++ b/src/detail/standalone/windows/winutils.cpp
@@ -1,6 +1,9 @@
 #if CLAP_WRAPPER_HAS_WIN32
 
-#include <string>
+#ifdef UNICODE
+#undef UNICODE
+#endif
+
 #include <Windows.h>
 
 #include "../entry.h"
@@ -10,184 +13,61 @@
 #include "winutils.h"
 #include "helper.h"
 
-namespace freeaudio::clap_wrapper::standalone::windows
+int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine, int nCmdShow)
 {
-struct Window
-{
-  Window();
-  ~Window();
+#ifdef _DEBUG
+  freeaudio::clap_wrapper::standalone::windows::Console console;
+#endif
 
-  static LRESULT CALLBACK WndProc(HWND, UINT, WPARAM, LPARAM);
-  virtual int _OnClose(HWND, UINT, WPARAM, LPARAM);
-  virtual int _OnDestroy(HWND, UINT, WPARAM, LPARAM);
-  virtual int _OnDpiChanged(HWND, UINT, WPARAM, LPARAM);
-  virtual int _OnKeyDown(HWND, UINT, WPARAM, LPARAM);
-  virtual int _OnSize(HWND, UINT, WPARAM, LPARAM);
+  const clap_plugin_entry* entry{nullptr};
 
-  HWND m_hwnd;
-  bool fullscreen;
-};
+#ifdef STATICALLY_LINKED_CLAP_ENTRY
+  extern const clap_plugin_entry clap_entry;
+  entry = &clap_entry;
+#else
+  std::string clapName{HOSTED_CLAP_NAME};
 
-Window::Window()
-{
-  ::SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+  auto searchPaths{Clap::getValidCLAPSearchPaths()};
 
-  std::wstring clapName{helper::widen(WIN32_TITLE)};
-  std::wstring randomName{helper::randomize(clapName)};
+  auto lib{Clap::Library()};
 
-  WNDCLASSEXW wcex{sizeof(WNDCLASSEX)};
-  wcex.lpszClassName = randomName.c_str();
-  wcex.lpszMenuName = randomName.c_str();
-  wcex.lpfnWndProc = Window::WndProc;
-  wcex.style = 0;
-  wcex.cbClsExtra = 0;
-  wcex.cbWndExtra = 0;
-  wcex.hInstance = ::GetModuleHandleW(nullptr);
-  wcex.hbrBackground = reinterpret_cast<HBRUSH>(::GetStockObject(LTGRAY_BRUSH));
-  wcex.hCursor = (HCURSOR)::LoadImageW(nullptr, (LPCWSTR)IDC_ARROW, IMAGE_CURSOR, 0, 0, LR_SHARED);
-  wcex.hIcon = (HICON)::LoadImageW(nullptr, (LPCWSTR)IDI_APPLICATION, IMAGE_ICON, 0, 0,
-                                   LR_DEFAULTCOLOR | LR_DEFAULTSIZE | LR_SHARED);
-  wcex.hIconSm = (HICON)::LoadImageW(nullptr, (LPCWSTR)IDI_APPLICATION, IMAGE_ICON, 0, 0,
-                                     LR_DEFAULTCOLOR | LR_DEFAULTSIZE | LR_SHARED);
-
-  ::RegisterClassExW(&wcex);
-
-  ::CreateWindowExW(0, randomName.c_str(), clapName.c_str(), WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
-                    CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, nullptr, nullptr,
-                    ::GetModuleHandleW(nullptr), this);
-}
-
-Window::~Window()
-{
-}
-
-LRESULT CALLBACK Window::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-  Window* pWindow = helper::InstanceFromWndProc<Window, &Window::m_hwnd>(hWnd, uMsg, lParam);
-
-  if (pWindow)
+  for (const auto& searchPath : searchPaths)
   {
-    switch (uMsg)
+    auto clapPath = searchPath / (clapName + ".clap");
+
+    if (fs::exists(clapPath) && !entry)
     {
-      case WM_CLOSE:
-        return pWindow->_OnClose(hWnd, uMsg, wParam, lParam);
-      case WM_DESTROY:
-        return pWindow->_OnDestroy(hWnd, uMsg, wParam, lParam);
-      case WM_DPICHANGED:
-        return pWindow->_OnDpiChanged(hWnd, uMsg, wParam, lParam);
-      case WM_KEYDOWN:
-        return pWindow->_OnKeyDown(hWnd, uMsg, wParam, lParam);
-      case WM_SIZE:
-        return pWindow->_OnSize(hWnd, uMsg, wParam, lParam);
+      lib.load(clapPath.u8string().c_str());
+      entry = lib._pluginEntry;
     }
   }
+#endif
 
-  return ::DefWindowProcW(hWnd, uMsg, wParam, lParam);
-}
+  if (!entry) return 0;
 
-int Window::_OnClose(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-  auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
+  std::string pid{PLUGIN_ID};
+  int pindex{PLUGIN_INDEX};
 
-  if (plugin && plugin->_ext._gui)
-  {
-    plugin->_ext._gui->hide(plugin->_plugin);
-    plugin->_ext._gui->destroy(plugin->_plugin);
-  }
+  auto plugin{freeaudio::clap_wrapper::standalone::mainCreatePlugin(entry, pid, pindex, 1, __argv)};
 
-  ::DestroyWindow(m_hwnd);
+  freeaudio::clap_wrapper::standalone::mainStartAudio();
 
-  return 0;
-}
+  freeaudio::clap_wrapper::standalone::windows::Win32Gui win32Gui{};
 
-int Window::_OnDestroy(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-  freeaudio::clap_wrapper::standalone::mainFinish();
-  ::PostQuitMessage(0);
+  auto sah{freeaudio::clap_wrapper::standalone::getStandaloneHost()};
 
-  return 0;
-}
+  sah->win32Gui = &win32Gui;
 
-int Window::_OnDpiChanged(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-  auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
-  auto ui{plugin->_ext._gui};
-  auto p{plugin->_plugin};
+  win32Gui.plugin = plugin;
 
-  auto dpi{::GetDpiForWindow(hWnd)};
-  auto scaleFactor{static_cast<float>(dpi) / static_cast<float>(USER_DEFAULT_SCREEN_DPI)};
-
-  ui->set_scale(p, scaleFactor);
-
-  auto bounds{(RECT*)lParam};
-  SetWindowPos(hWnd, nullptr, bounds->left, bounds->top, (bounds->right - bounds->left),
-               (bounds->bottom - bounds->top), SWP_NOZORDER | SWP_NOACTIVATE);
-
-  return 0;
-}
-
-int Window::_OnKeyDown(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-  switch (wParam)
-  {
-    case VK_F11:
-    {
-      fullscreen = helper::fullscreen(m_hwnd);
-
-      break;
-    }
-
-    default:
-      return 0;
-  }
-
-  return 0;
-}
-
-int Window::_OnSize(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
-{
-  auto plugin{freeaudio::clap_wrapper::standalone::getMainPlugin()};
-  auto ui{plugin->_ext._gui};
-  auto p{plugin->_plugin};
-
-  auto dpi{::GetDpiForWindow(hWnd)};
-  auto scaleFactor{static_cast<float>(dpi) / static_cast<float>(USER_DEFAULT_SCREEN_DPI)};
-
-  if (ui->can_resize(p))
-  {
-    RECT r{0, 0, 0, 0};
-    ::GetClientRect(hWnd, &r);
-    uint32_t w = (r.right - r.left);
-    uint32_t h = (r.bottom - r.top);
-    ui->adjust_size(p, &w, &h);
-    ui->set_size(p, w, h);
-  }
-
-  return 0;
-}
-
-void Win32Gui::initialize(freeaudio::clap_wrapper::standalone::StandaloneHost* sah)
-{
-  sah->win32Gui = this;
-}
-
-void Win32Gui::setPlugin(std::shared_ptr<Clap::Plugin> p)
-{
-  plugin = p;
-}
-
-void Win32Gui::run()
-{
   if (plugin->_ext._gui)
   {
     auto ui{plugin->_ext._gui};
     auto p{plugin->_plugin};
 
-    if (!ui->is_api_supported(p, CLAP_WINDOW_API_WIN32, false)) LOG << "NO WIN32 " << std::endl;
-
     ui->create(p, CLAP_WINDOW_API_WIN32, false);
 
-    Window window;
+    freeaudio::clap_wrapper::standalone::windows::Window window;
 
     auto dpi{::GetDpiForWindow(window.m_hwnd)};
     auto scaleFactor{static_cast<float>(dpi) / static_cast<float>(USER_DEFAULT_SCREEN_DPI)};
@@ -198,8 +78,8 @@ void Win32Gui::run()
       // We can check here if we had a previous size but we aren't saving state yet
     }
 
-    uint32_t w;
-    uint32_t h;
+    uint32_t w{0};
+    uint32_t h{0};
     ui->get_size(p, &w, &h);
 
     RECT r{0, 0, 0, 0};
@@ -208,30 +88,45 @@ void Win32Gui::run()
     ::AdjustWindowRectExForDpi(&r, WS_OVERLAPPEDWINDOW, 0, 0, dpi);
     ::SetWindowPos(window.m_hwnd, nullptr, 0, 0, (r.right - r.left), (r.bottom - r.top), SWP_NOMOVE);
 
+    if (!ui->can_resize(p))
+    {
+      ::SetWindowLongPtr(window.m_hwnd, GWL_STYLE,
+                         ::GetWindowLongPtr(window.m_hwnd, GWL_STYLE) & ~WS_OVERLAPPEDWINDOW |
+                             WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX);
+    }
+
     clap_window win;
     win.api = CLAP_WINDOW_API_WIN32;
     win.win32 = (void*)window.m_hwnd;
     ui->set_parent(p, &win);
 
     ui->show(p);
+
     ::ShowWindow(window.m_hwnd, SW_SHOWDEFAULT);
   }
 
-  MSG msg;
-  int r;
+  MSG msg{};
+  int r{0};
 
-  while ((r = ::GetMessageW(&msg, nullptr, 0, 0)) != 0)
+  while ((r = ::GetMessage(&msg, nullptr, 0, 0)) != 0)
   {
     if (r == -1)
-      return;
+      return 0;
 
     else
     {
       ::TranslateMessage(&msg);
-      ::DispatchMessageW(&msg);
+      ::DispatchMessage(&msg);
     }
   }
+
+  win32Gui.plugin = nullptr;
+
+  plugin = nullptr;
+
+  freeaudio::clap_wrapper::standalone::mainFinish();
+
+  return 0;
 }
-}  // namespace freeaudio::clap_wrapper::standalone::windows
 
 #endif

--- a/src/detail/standalone/windows/winutils.cpp
+++ b/src/detail/standalone/windows/winutils.cpp
@@ -37,7 +37,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR pCmdLine
 
     if (fs::exists(clapPath) && !entry)
     {
-      lib.load(clapPath.u8string().c_str());
+      lib.load(clapPath);
       entry = lib._pluginEntry;
     }
   }

--- a/src/detail/standalone/windows/winutils.h
+++ b/src/detail/standalone/windows/winutils.h
@@ -8,9 +8,5 @@ namespace freeaudio::clap_wrapper::standalone::windows
 struct Win32Gui
 {
   std::shared_ptr<Clap::Plugin> plugin;
-
-  void initialize(freeaudio::clap_wrapper::standalone::StandaloneHost *);
-  void setPlugin(std::shared_ptr<Clap::Plugin>);
-  void run();
 };
 }  // namespace freeaudio::clap_wrapper::standalone::windows

--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -195,11 +195,14 @@ tresult PLUGIN_API WrappedView::setFrame(IPlugFrame* frame)
   _plugFrame = frame;
 
 #if LIN
-  if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void**)&_runLoop) ==
-          Steinberg::kResultOk &&
-      _onRunLoopAvailable)
+  if (_plugFrame)
   {
-    _onRunLoopAvailable();
+    if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void**)&_runLoop) ==
+            Steinberg::kResultOk &&
+        _onRunLoopAvailable)
+    {
+      _onRunLoopAvailable();
+    }
   }
 #endif
 

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1348,12 +1348,13 @@ UInt32 WrapAsAUV2::GetAudioChannelLayout(AudioUnitScope scope, AudioUnitElement 
 
 void WrapAsAUV2::send(const Clap::AUv2::clap_multi_event_t& event)
 {
+  // port index maps back to MIDI out
   auto type = event.header.type;
   switch (type)
   {
     case CLAP_EVENT_NOTE_ON:
     {
-      auto portid = 1;  // event.note.port_index;
+      auto portid = event.note.port_index;
       for (auto& i : _midi_outports)
       {
         if (i->_info.id == portid)
@@ -1366,7 +1367,7 @@ void WrapAsAUV2::send(const Clap::AUv2::clap_multi_event_t& event)
     break;
     case CLAP_EVENT_NOTE_OFF:
     {
-      auto portid = 1;  // event.note.port_index;
+      auto portid = event.note.port_index;
       for (auto& i : _midi_outports)
       {
         if (i->_info.id == portid)

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -66,7 +66,7 @@ bool WrapAsAUV2::initializeClapDesc()
                            [this](const auto& cs)
                            {
                              auto fp = cs / (_clapname + ".clap");
-                             return fs::is_directory(fp) && _library.load(fp.u8string().c_str());
+                             return fs::is_directory(fp) && _library.load(fp);
                            });
 
     if (it != csp.end())

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -51,7 +51,7 @@ void pffffrzz()
 
 bool WrapAsAUV2::initializeClapDesc()
 {
-  LOGINFO("[clap-wrapper auv2: id={} index: {}\n", _clapid, _idx);
+  LOGINFO("[clap-wrapper] auv2: id={} index: {}", _clapid, _idx);
 
   if (!_library.hasEntryPoint())
   {
@@ -250,7 +250,8 @@ void WrapAsAUV2::setupAudioBusses(const clap_plugin_t* plugin,
   auto numAudioInputs = audioports->count(plugin, true);
   auto numAudioOutputs = audioports->count(plugin, false);
 
-  LOGINFO("AUDIO in: {}, out: {}\n", (int)numAudioInputs, (int)numAudioOutputs);
+  LOGINFO("[clap-wrapper] Setup Busses: audio in: {}, out: {}", (int)numAudioInputs,
+          (int)numAudioOutputs);
 
   ausdk::AUBase::GetScope(kAudioUnitScope_Input).Initialize(this, kAudioUnitScope_Input, numAudioInputs);
 
@@ -510,7 +511,7 @@ OSStatus WrapAsAUV2::Stop()
 }
 void WrapAsAUV2::Cleanup()
 {
-  LOGINFO("Cleaning up Plugin");
+  LOGINFO("[clap-wrapper] Cleaning up Plugin");
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
   deactivateCLAP();
   Base::Cleanup();
@@ -583,7 +584,6 @@ OSStatus WrapAsAUV2::GetPropertyInfo(AudioUnitPropertyID inID, AudioUnitScope in
       case kAudioUnitProperty_CocoaUI:
         outWritable = false;
         outDataSize = sizeof(struct AudioUnitCocoaViewInfo);
-        LOGINFO("query Property Info: kAudioUnitProperty_CocoaUI");
         return noErr;
         break;
 #if 0
@@ -659,19 +659,18 @@ OSStatus WrapAsAUV2::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
         return noErr;
 
       case kAudioUnitProperty_CocoaUI:
-        LOGINFO("query Property: kAudioUnitProperty_CocoaUI {}", (_plugin) ? "plugin" : "no plugin");
+        LOGINFO("[clap-wrapper] Property: kAudioUnitProperty_CocoaUI {}",
+                (_plugin) ? "plugin" : "no plugin");
         if (_plugin &&
             (_plugin->_ext._gui->is_api_supported(_plugin->_plugin, CLAP_WINDOW_API_COCOA, false)))
         {
-          LOGINFO("now getting cocoa ui");
           fillAudioUnitCocoaView(((AudioUnitCocoaViewInfo*)outData), _plugin);
-          // *((AudioUnitCocoaViewInfo *)outData) = cocoaInfo;
-          LOGINFO("query Property: kAudioUnitProperty_CocoaUI complete");
+          LOGINFO("[clap-wrapper] kAudioUnitProperty_CocoaUI complete");
           return noErr;  // sizeof(AudioUnitCocoaViewInfo);
         }
         else
         {
-          LOGINFO("query Property: kAudioUnitProperty_CocoaUI although now plugin ext");
+          LOGINFO("[clap-wrapper] Mysterious: kAudioUnitProperty_CocoaUI although now plugin ext");
           fillAudioUnitCocoaView(((AudioUnitCocoaViewInfo*)outData), _plugin);
           return noErr;
         }
@@ -778,7 +777,7 @@ void WrapAsAUV2::tail_changed()
 void WrapAsAUV2::addAudioBusFrom(int bus, const clap_audio_port_info_t* info, bool is_input)
 {
   // add/set audio bus configuration from info to appropriate scope
-  LOGINFO("Add Bus {} {}", bus, is_input ? "IN" : "OUT");
+  LOGINFO("[clap-wrapper]     - add bus {} : {}", bus, is_input ? "In" : "Out");
   if (is_input)
   {
     addInputBus(bus, info);
@@ -1247,7 +1246,7 @@ void WrapAsAUV2::PostConstructor()
       Outputs().GetIOElement(i)->SetAudioChannelLayout(layout);
       */
     }
-    LOGINFO("PostConstructor: Ins={} Outs={}", numAudioInputs, numAudioOutputs);
+    LOGINFO("[clap-wrapper] PostConstructor: Ins={} Outs={}", numAudioInputs, numAudioOutputs);
   }
   // The else here would just set elements to 0,0 which is the default
   // therefore leave it un-elsed
@@ -1257,7 +1256,7 @@ UInt32 WrapAsAUV2::GetAudioChannelLayout(AudioUnitScope scope, AudioUnitElement 
                                          AudioChannelLayout* outLayoutPtr, bool& outWritable)
 {
   // TODO: This is never called so the layout is never found
-  LOGINFO("GetAudioChannelLayout");
+  LOGINFO("[clap-wrapper] GetAudioChannelLayout");
   return Base::GetAudioChannelLayout(scope, element, outLayoutPtr, outWritable);
 }
 

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -859,9 +859,11 @@ OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags& inFlags, const AudioTime
     // TODO: clarify how we can get transportStateProc2
     // mHostCallbackInfo.transportStateProc2
 #if 1
-    data._AUtransportValid = (noErr == CallHostTransportState(&data._isPlaying, &data._transportChanged,
-                                                              &data._currentSongPos, &data._isLooping,
-                                                              &data._cycleStart, &data._cycleEnd));
+    data._AUtransportValid =
+        (noErr == CallHostTransportState(&data._isPlaying, &data._transportChanged,
+                                         &data._currentSongPosInSeconds, &data._isLooping,
+                                         &data._cycleStart, &data._cycleEnd));
+    data._currentSongPosInSeconds /= std::max(_plugin->getSampleRate(), 1.0);  // just in case
     data._AUbeatAndTempoValid = (noErr == CallHostBeatAndTempo(&data._beat, &data._tempo));
     data._AUmusicalTimeValid =
         (noErr == CallHostMusicalTimeLocation(&data._offsetToNextBeat, &data._musicalNumerator,

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -334,6 +334,8 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
 {
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
   // creating parameters.
+
+  _clumps.reset();
   auto* p = _plugin->_ext._params;
   if (p)
   {
@@ -469,6 +471,13 @@ OSStatus WrapAsAUV2::GetParameterInfo(AudioUnitScope inScope, AudioUnitParameter
       {
         outParameterInfo.defaultValue = 0.0;
       }
+
+      // adding the clump information
+      if (info.module[0] != 0)
+      {
+        outParameterInfo.flags |= kAudioUnitParameterFlag_HasClump;
+        outParameterInfo.clumpID = _clumps.addClump(info.module);
+      }
       return noErr;
     }
   }
@@ -494,6 +503,21 @@ OSStatus WrapAsAUV2::SetParameter(AudioUnitParameterID inID, AudioUnitScope inSc
     }
   }
   return AUBase::SetParameter(inID, inScope, inElement, inValue, inBufferOffsetInFrames);
+}
+
+OSStatus WrapAsAUV2::CopyClumpName(AudioUnitScope inScope, UInt32 inClumpID, UInt32 inDesiredNameLength,
+                                   CFStringRef* outClumpName)
+{
+  if (inScope == kAudioUnitScope_Global)
+  {
+    auto p = _clumps.getClump(inClumpID);
+    if (p)
+    {
+      *outClumpName = CFStringCreateWithCString(NULL, p, kCFStringEncodingUTF8);
+      return noErr;
+    }
+  }
+  return kAudioUnitErr_InvalidProperty;
 }
 
 OSStatus WrapAsAUV2::Start()
@@ -1099,6 +1123,10 @@ bool WrapAsAUV2::ValidFormat(AudioUnitScope inScope, AudioUnitElement inElement,
   {
     return false;
   }
+
+  // Logic Pro does not call this in the main thread - so we just pretend..
+  auto guarantee_mainthread = _plugin->AlwaysMainThread();
+
   auto ap = _plugin->_ext._audioports;
   auto pl = _plugin->_plugin;
 

--- a/src/wrapasstandalone.cpp
+++ b/src/wrapasstandalone.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
 
     if (fs::exists(clapPath) && !entry)
     {
-      lib.load(clapPath.u8string().c_str());
+      lib.load(clapPath);
       entry = lib._pluginEntry;
     }
   }

--- a/src/wrapasstandalone.cpp
+++ b/src/wrapasstandalone.cpp
@@ -9,12 +9,6 @@
 #endif
 #endif
 
-#if WIN
-#if CLAP_WRAPPER_HAS_WIN32
-#include "detail/standalone/windows/winutils.h"
-#endif
-#endif
-
 // For now just a simple main. In the future this will branch out to
 // an [NSApplicationMain ] and so on depending on platform
 int main(int argc, char **argv)
@@ -70,19 +64,6 @@ int main(int argc, char **argv)
 #else
   freeaudio::clap_wrapper::standalone::mainWait();
 #endif
-
-#elif WIN
-#if CLAP_WRAPPER_HAS_WIN32
-  freeaudio::clap_wrapper::standalone::windows::Win32Gui win32Gui{};
-
-  win32Gui.initialize(freeaudio::clap_wrapper::standalone::getStandaloneHost());
-  win32Gui.setPlugin(plugin);
-  win32Gui.run();
-  win32Gui.setPlugin(nullptr);
-#else
-  freeaudio::clap_wrapper::standalone::mainWait();
-#endif
-
 #else
   freeaudio::clap_wrapper::standalone::mainWait();
 #endif

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -841,6 +841,11 @@ bool ClapAsVst3::unregister_timer(clap_id timer_id)
   return false;
 }
 
+const char* ClapAsVst3::host_get_name()
+{
+  return "Clap-As-VST3-Wrapper";
+}
+
 void ClapAsVst3::onIdle()
 {
   // handling queued events

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -213,6 +213,8 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   bool register_timer(uint32_t period_ms, clap_id* timer_id) override;
   bool unregister_timer(clap_id timer_id) override;
 
+  const char* host_get_name() override;
+
 #if LIN
   bool register_fd(int fd, clap_posix_fd_flags_t flags) override;
   bool modify_fd(int fd, clap_posix_fd_flags_t flags) override;

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -84,7 +84,7 @@ bool findPlugin(Clap::Library& lib, const std::string& pluginfilename)
 
     if (fs::exists(k1))
     {
-      if (lib.load(k1.u8string().c_str()))
+      if (lib.load(k1))
       {
         return true;
       }
@@ -95,7 +95,7 @@ bool findPlugin(Clap::Library& lib, const std::string& pluginfilename)
     LOGDETAIL("scanning for binary: {}", k2.u8string().c_str());
     if (fs::exists(k2))
     {
-      if (lib.load(k2.u8string().c_str()))
+      if (lib.load(k2))
       {
         return true;
       }
@@ -108,7 +108,7 @@ bool findPlugin(Clap::Library& lib, const std::string& pluginfilename)
       LOGDETAIL("scanning for binary: {}", k3.u8string().c_str());
       if (fs::exists(k3))
       {
-        if (lib.load(k3.u8string().c_str()))
+        if (lib.load(k3))
         {
           return true;
         }

--- a/x
+++ b/x
@@ -1,4 +1,0 @@
-
-/Users/paul/dev/music/clap-projects/clap-wrapper/ignore/xcode/Debug/downloadplug_as_auv2-build-helper --explicit downloadplug 1 aumu gWrp clAd cleveraudio.org
-
-


### PR DESCRIPTION
* pushed to CLAP 1.2.0
* completed AUv2 wrapper
  * MIDI Out
  * Correct timing
  * Parameter Clumps
* improved standalone wrapper
* improvements regarding sizability and resize request on macOS
* fsutil: use fs::path for loading libraries to fix win32 unicode paths
* fixed host names for wrapper flavors
* removed dependency to removed CLAP_EXT_MIDI_MAPPINGS