### PR TITLE
fix: IMIDIMapping wasn't used correctly in VST3 wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(CLAP_WRAPPER_WINDOWS_SINGLE_FILE "Build a single fine (rather than folder
 
 project(clap-wrapper
 	LANGUAGES C CXX
-	VERSION 0.7.0
+	VERSION 0.7.1
 	DESCRIPTION "CLAP-as-X wrappers"
 )
 

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -235,6 +235,10 @@ void Plugin::schnick()
 
 bool Plugin::initialize()
 {
+  // first check for specifics, so they are present in the
+  // setup of busses
+  _parentHost->setupWrapperSpecifics(_plugin);
+
   if (_ext._audioports)
   {
     _parentHost->setupAudioBusses(_plugin, _ext._audioports);
@@ -248,7 +252,6 @@ bool Plugin::initialize()
     _parentHost->setupParameters(_plugin, _ext._params);
   }
 
-  _parentHost->setupWrapperSpecifics(_plugin);
   return true;
 }
 

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -49,10 +49,6 @@ tresult PLUGIN_API ClapAsVst3::initialize(FUnknown* context)
       _plugin = Clap::Plugin::createInstance(*_library, _libraryIndex, this);
     }
     result = (_plugin->initialize()) ? kResultOk : kResultFalse;
-    if (result)
-    {
-      _useIMidiMapping = checkMIDIDialectSupport();
-    }
   }
 
   return result;
@@ -488,6 +484,8 @@ Vst::UnitID ClapAsVst3::getOrCreateUnitInfo(const char* modulename)
 
 void ClapAsVst3::setupWrapperSpecifics(const clap_plugin_t* plugin)
 {
+  _useIMidiMapping = checkMIDIDialectSupport();
+
   _vst3specifics = (clap_plugin_as_vst3_t*)plugin->get_extension(plugin, CLAP_PLUGIN_AS_VST3);
   if (_vst3specifics)
   {


### PR DESCRIPTION
the init order was wrong, now the wrapper specifics get determined before setting up audio and MIDI busses and parameters.
Since it is a hot fix, the version is being bumped to 0.7.1 and PR goes directly to main.
