### PR TITLE
Demonstrate how CMake Version can get to C++

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -133,6 +133,10 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Apt Update
+        if: ${{ matrix.run_aptget }}
+        run: sudo apt-get update
+
       - name: Get Deps
         if: ${{ matrix.run_aptget }}
         run: sudo apt-get install -y alsa alsa-tools libasound2-dev libjack-dev libgtk-3-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ project(clap-wrapper
 	VERSION 0.7.1
 	DESCRIPTION "CLAP-as-X wrappers"
 )
+set(CLAP_WRAPPER_VERSION "${CMAKE_PROJECT_VERSION}" CACHE STRING "Version of the wrapper project")
 
 if (APPLE)
 	enable_language(OBJC)

--- a/cmake/shared_prologue.cmake
+++ b/cmake/shared_prologue.cmake
@@ -36,7 +36,7 @@ endif()
 add_library(clap-wrapper-compile-options INTERFACE)
 add_library(clap-wrapper-sanitizer-options INTERFACE)
 
-target_compile_options(clap-wrapper-compile-options INTERFACE -D${CLAP_WRAPPER_PLATFORM}=1)
+target_compile_options(clap-wrapper-compile-options INTERFACE -D${CLAP_WRAPPER_PLATFORM}=1 -DCLAP_WRAPPER_VERSION="${CLAP_WRAPPER_VERSION}")
 if (APPLE)
     target_link_libraries(clap-wrapper-compile-options INTERFACE macos_filesystem_support)
 endif()

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -158,7 +158,7 @@ Plugin::Plugin(IHost* host)
           host->host_get_name(),
           "defiant nerd",
           "https://www.defiantnerd.com",
-          "0.0.1",
+          CLAP_WRAPPER_VERSION,
           Plugin::clapExtension,
           Plugin::clapRequestRestart,
           Plugin::clapRequestProcess,


### PR DESCRIPTION
Here we replace the host version in the clap host proxy startup with the CMake version from the CMake Project list