### PR TITLE
Check active state before querying latency. Fixes #229

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -59,6 +59,10 @@ tresult PLUGIN_API ClapAsVst3::terminate()
   if (_plugin)
   {
     _os_attached.off();  // ensure we are detached
+    if (_active)
+    {
+      _plugin->deactivate();
+    }
     _plugin->terminate();
     _plugin.reset();
   }
@@ -111,6 +115,11 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
 
 tresult PLUGIN_API ClapAsVst3::process(Vst::ProcessData& data)
 {
+  if (!_active || !_processing)
+  {
+    return kNotInitialized;
+  }
+
   auto thisFn = _plugin->AlwaysAudioThread();
   this->_processAdapter->process(data);
   return kResultOk;

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -773,7 +773,9 @@ void ClapAsVst3::request_callback()
 
 void ClapAsVst3::restartPlugin()
 {
-  if (componentHandler) componentHandler->restartComponent(Vst::RestartFlags::kReloadComponent);
+  if (componentHandler)
+    componentHandler->restartComponent(Vst::RestartFlags::kIoChanged |
+                                       Vst::RestartFlags::kLatencyChanged);
 }
 
 void ClapAsVst3::onBeginEdit(clap_id id)

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -87,6 +87,11 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
         _expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_TUNING);
     updateAudioBusses();
 
+    if (_missedLatencyRequest)
+    {
+      latency_changed();
+    }
+
     _os_attached.on();
   }
   if (!state)
@@ -132,11 +137,19 @@ tresult PLUGIN_API ClapAsVst3::getState(IBStream* state)
 
 uint32 PLUGIN_API ClapAsVst3::getLatencySamples()
 {
-  if (_plugin->_ext._latency && _active)
+  if (!_plugin->_ext._latency)
   {
-    return _plugin->_ext._latency->get(_plugin->_plugin);
+    return 0;
   }
-  return 0;
+
+  if (!_active)
+  {
+    _missedLatencyRequest = true;
+    return 0;
+  }
+
+  _missedLatencyRequest = false;
+  return _plugin->_ext._latency->get(_plugin->_plugin);
 }
 
 uint32 PLUGIN_API ClapAsVst3::getTailSamples()

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -897,12 +897,13 @@ void ClapAsVst3::onIdle()
     std::lock_guard lock(_processingLock);
 
     _requestedFlush = false;
-    if (!_processing)
+    if (!_active)
     {
       // setup a ProcessAdapter just for flush with no audio
       Clap::ProcessAdapter pa;
       pa.setupProcessing(_plugin->_plugin, _plugin->_ext._params, audioInputs, audioOutputs, 0, 0, 0,
                          this->parameters, componentHandler, nullptr, false, false);
+      auto thisFn = _plugin->AlwaysMainThread();
       pa.flush();
     }
   }

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -132,7 +132,7 @@ tresult PLUGIN_API ClapAsVst3::getState(IBStream* state)
 
 uint32 PLUGIN_API ClapAsVst3::getLatencySamples()
 {
-  if (_plugin->_ext._latency)
+  if (_plugin->_ext._latency && _active)
   {
     return _plugin->_ext._latency->get(_plugin->_plugin);
   }

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -259,6 +259,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   std::mutex _processingLock;
   std::atomic_bool _requestedFlush = false;
   std::atomic_bool _requestUICallback = false;
+  bool _missedLatencyRequest = false;
 
   // the queue from audiothread to UI thread
   ClapWrapper::detail::shared::fixedqueue<queueEvent, 8192> _queueToUI;


### PR DESCRIPTION
The VST3 wrapper simply forwards the host's latency request without checking whether the plugin is active. This causes a misbehaving host log when using the CLAP helpers (and is not allowed by CLAP's specs). 

This PR fixes that problem by checking the plugin's active state before getting its latency. This PR also fixes #229.