### PR TITLE
0.7.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(CLAP_WRAPPER_WINDOWS_SINGLE_FILE "Build a single fine (rather than folder
 
 project(clap-wrapper
 	LANGUAGES C CXX
-	VERSION 0.7.1
+	VERSION 0.7.2
 	DESCRIPTION "CLAP-as-X wrappers"
 )
 set(CLAP_WRAPPER_VERSION "${CMAKE_PROJECT_VERSION}" CACHE STRING "Version of the wrapper project")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(CLAP_WRAPPER_WINDOWS_SINGLE_FILE "Build a single fine (rather than folder
 
 project(clap-wrapper
 	LANGUAGES C CXX
-	VERSION 0.7.2
+	VERSION 0.7.3
 	DESCRIPTION "CLAP-as-X wrappers"
 )
 set(CLAP_WRAPPER_VERSION "${CMAKE_PROJECT_VERSION}" CACHE STRING "Version of the wrapper project")

--- a/include/clapwrapper/vst3.h
+++ b/include/clapwrapper/vst3.h
@@ -16,11 +16,10 @@
 #endif
 
 // the factory extension
-static const CLAP_CONSTEXPR char CLAP_PLUGIN_FACTORY_INFO_VST3[] =
-    "clap.plugin-factory-info-as-vst3.draft0";
+static const CLAP_CONSTEXPR char CLAP_PLUGIN_FACTORY_INFO_VST3[] = "clap.plugin-factory-info-as-vst3/0";
 
 // the plugin extension
-static const CLAP_CONSTEXPR char CLAP_PLUGIN_AS_VST3[] = "clap.plugin-info-as-vst3.draft0";
+static const CLAP_CONSTEXPR char CLAP_PLUGIN_AS_VST3[] = "clap.plugin-info-as-vst3/0";
 
 typedef uint8_t array_of_16_bytes[16];
 
@@ -77,6 +76,8 @@ typedef uint8_t array_of_16_bytes[16];
 
   all members are optional when set to nullptr
   if not provided, the wrapper code will use/generate appropriate values
+
+  this struct is being returned by the plugin in clap_plugin_factory_as_vst3_t::get_vst3_info()
 */
 
 typedef struct clap_plugin_info_as_vst3
@@ -92,7 +93,7 @@ typedef struct clap_plugin_info_as_vst3
   all members are optional and can be set to nullptr
   if not provided, the wrapper code will use/generate appropriate values
 
-  retrieved when asking for factory CLAP_PLUGIN_FACTORY_INFO_VST3
+  retrieved when asking for factory CLAP_PLUGIN_FACTORY_INFO_VST3 by clap_entry::get_factory()
 */
 
 typedef struct clap_plugin_factory_as_vst3
@@ -125,6 +126,8 @@ enum clap_supported_note_expressions
 /*
   retrieve additional information for the plugin itself, if note expressions are being supported and if there
   is a limit in MIDI channels (to reduce the offered controllers etc. in the VST3 host)
+
+  This extension is optionally returned by the plugin when asked for extension CLAP_PLUGIN_AS_VST3
 */
 typedef struct clap_plugin_as_vst3
 {

--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -52,11 +52,6 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
 
   inline double asClapValue(double vst3value) const
   {
-    auto& info = this->getInfo();
-    if (info.stepCount > 0)
-    {
-      return (vst3value * float(info.stepCount)) + min_value;
-    }
     return (vst3value * (max_value - min_value)) + min_value;
   }
   inline double asVst3Value(double clapvalue) const


### PR DESCRIPTION
- restartPlugin does not lead to kReloadComponent anymore, suits better the semantics of restart_plugin
- ensure param->flush() being called from main_thread
- more documentation on vst3 specific extensions

