### PR TITLE
MacOS Standalone Wrapper Improvements

### DIFF
--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -35,6 +35,8 @@ class Raise;
 class IHost
 {
  public:
+  virtual ~IHost() = default;
+
   virtual void mark_dirty() = 0;
   virtual void restartPlugin() = 0;
   virtual void request_callback() = 0;

--- a/src/detail/standalone/macos/AppDelegate.h
+++ b/src/detail/standalone/macos/AppDelegate.h
@@ -1,5 +1,13 @@
 #import <Cocoa/Cocoa.h>
 
-@interface AppDelegate : NSObject <NSApplicationDelegate>
+// @class AudioSettingsWindowDelegate;
+
+@interface AppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+{
+  // AudioSettingsWindowDelegate *audioSettingsWindowDelegate;
+}
+@property(assign) IBOutlet NSWindow *window;
+
+- (IBAction)openAudioSettingsWindow:(id)sender;
 
 @end

--- a/src/detail/standalone/macos/Info.plist.in
+++ b/src/detail/standalone/macos/Info.plist.in
@@ -12,7 +12,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>org.cmake.CocoaExample</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}.standalone</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/src/detail/standalone/macos/MainMenu.xib
+++ b/src/detail/standalone/macos/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,6 +31,12 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                            <menuItem title="Audio/MIDI Settings" id="6kV-Vb-QxS">
+                                <connections>
+                                    <action selector="openAudioSettingsWindow:" target="Voe-Tx-rLC" id="3a0-x6-H3R"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="kCx-OF-vgT"/>
                             <menuItem title="Hide ${SA_OUTPUT_NAME}" keyEquivalent="h" id="Olw-nP-bQN">
                                 <connections>
                                     <action selector="hide:" target="-1" id="PnN-Uc-m68"/>
@@ -66,25 +72,14 @@
                                     <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Open Recent" id="tXI-mr-wws">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
-                                    <items>
-                                        <menuItem title="Clear Menu" id="vNY-rz-j42">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="clearRecentDocuments:" target="-1" id="Daa-9d-B3U"/>
-                                            </connections>
-                                        </menuItem>
-                                    </items>
-                                </menu>
-                            </menuItem>
+                            <!--
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
                             <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
                                 <connections>
                                     <action selector="saveDocument:" target="-1" id="teZ-XB-qJY"/>
                                 </connections>
                             </menuItem>
+                            -->
                             <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
                                 <connections>
                                     <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
@@ -121,7 +116,7 @@
             </items>
             <point key="canvasLocation" x="-69" y="65"/>
         </menu>
-        <window title="${SA_OUTPUT_NAME}" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+        <window title="${SA_OUTPUT_NAME}" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>


### PR DESCRIPTION
- If the input channels dont' match 2, standalone would fail to start.
  Now we bind to min of 2 and available in default.
- Allow the NSWindow to default destroy when closed, avoiding
  a Root Leak
- UI Resizing drag works properly
- Save and Load for your session on a menu
- A hint at at audio settings menu but no implementation
- Cleanup the xib
- Add a virtual destructor to IHost
