### PR TITLE
Pass IHostApplication host name

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -42,6 +42,7 @@ struct ClapHostExtensions
 tresult PLUGIN_API ClapAsVst3::initialize(FUnknown* context)
 {
   auto result = super::initialize(context);
+  context->queryInterface(Vst::IHostApplication::iid, (void**)&vst3HostApplication);
   if (result == kResultOk)
   {
     if (!_plugin)
@@ -165,13 +166,16 @@ uint32 PLUGIN_API ClapAsVst3::getLatencySamples()
 uint32 PLUGIN_API ClapAsVst3::getTailSamples()
 {
   // options would be kNoTail, number of samples or kInfiniteTail
-  if (this->_plugin->_ext._tail)
+  if (this->_active)
   {
-    auto tailsize = this->_plugin->_ext._tail->get(_plugin->_plugin);
+    if (this->_plugin->_ext._tail)
+    {
+      auto tailsize = this->_plugin->_ext._tail->get(_plugin->_plugin);
 
-    // Any value greater or equal to INT32_MAX implies infinite tail.
-    if (tailsize >= INT32_MAX) return Vst::kInfiniteTail;
-    return tailsize;
+      // Any value greater or equal to INT32_MAX implies infinite tail.
+      if (tailsize >= INT32_MAX) return Vst::kInfiniteTail;
+      return tailsize;
+    }
   }
   return super::getTailSamples();
 }
@@ -271,9 +275,11 @@ tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::Param
 
   if (param->getInfo().flags & Vst::ParameterInfo::kIsProgramChange)
   {
+    std::string program("Program ");
+    program.append(std::to_string((int)val));
     UString wrapper(&string[0], str16BufferSize(Steinberg::Vst::String128));
 
-    wrapper.assign("Program", 8);
+    wrapper.assign(program.c_str(), (Steinberg::int32)(program.size() + 1));
     return kResultOk;
   }
 
@@ -326,6 +332,7 @@ tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirectio
 
 tresult PLUGIN_API ClapAsVst3::setComponentHandler(Vst::IComponentHandler* handler)
 {
+  vst3HostApplication.reset();
   componentHandler3.reset();
 
   // the base class extracts IComponentHandler and IComponentHandler2
@@ -334,6 +341,7 @@ tresult PLUGIN_API ClapAsVst3::setComponentHandler(Vst::IComponentHandler* handl
   if (componentHandler && result == kResultOk)
   {
     this->componentHandler->queryInterface(Vst::IComponentHandler3::iid, (void**)&componentHandler3);
+    this->componentHandler->queryInterface(Vst::IHostApplication::iid, (void**)&vst3HostApplication);
   }
 
   return result;
@@ -983,7 +991,16 @@ bool ClapAsVst3::unregister_timer(clap_id timer_id)
 
 const char* ClapAsVst3::host_get_name()
 {
-  return "Clap-As-VST3-Wrapper";
+  if (vst3HostApplication)
+  {
+    Steinberg::Vst::String128 res;
+    if (kResultOk == vst3HostApplication->getName(res))
+    {
+      wrapper_hostname = VST3::StringConvert::convert(res);
+      wrapper_hostname.append(" (CLAP-as-VST3-wrapper)");
+    }
+  }
+  return wrapper_hostname.c_str();
 }
 
 void ClapAsVst3::onIdle()

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -235,6 +235,8 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   IPtr<Steinberg::Vst::IComponentHandler3> componentHandler3 = nullptr;
   IPtr<Steinberg::Vst::IContextMenu> vst3ContextMenu = nullptr;
+  IPtr<Steinberg::Vst::IHostApplication> vst3HostApplication = nullptr;
+  std::string wrapper_hostname = "CLAP-As-VST3-Wrapper";
   std::vector<wrapper_context_menu_item> contextmenuitems;
   uint32_t vst3ContextMenuParamID = 0;
 


### PR DESCRIPTION
When the CLAP retrieves the host name from the wrapper, the name of the original VST3 host is being passed through, in case the host provides an `IHostApplication` interface.