### PR TITLE
Allow child NSView to resize the wrapper NSView in Audio Units.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(CLAP_WRAPPER_WINDOWS_SINGLE_FILE "Build a single fine (rather than folder
 
 project(clap-wrapper
 	LANGUAGES C CXX
-	VERSION 0.8.0
+	VERSION 0.9.0
 	DESCRIPTION "CLAP-as-X wrappers"
 )
 set(CLAP_WRAPPER_VERSION "${CMAKE_PROJECT_VERSION}" CACHE STRING "Version of the wrapper project")

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -35,6 +35,8 @@ class Raise;
 class IHost
 {
  public:
+  virtual ~IHost() = default;
+
   virtual void mark_dirty() = 0;
   virtual void restartPlugin() = 0;
   virtual void request_callback() = 0;

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -71,6 +71,38 @@ class IHost
 
   virtual const char* host_get_name() = 0;
 
+  // context menu
+
+  // actually, everything here should be virtual only, but until all wrappers are updated,
+  // IHost provides default implementations.
+
+  virtual bool supportsContextMenu() const
+  {
+    return false;
+  }
+
+  virtual bool context_menu_populate(const clap_context_menu_target_t* target,
+                                     const clap_context_menu_builder_t* builder)
+  {
+    return false;
+  }
+
+  virtual bool context_menu_perform(const clap_context_menu_target_t* target, clap_id action_id)
+  {
+    return false;
+  }
+
+  virtual bool context_menu_can_popup()
+  {
+    return false;
+  }
+
+  virtual bool context_menu_popup(const clap_context_menu_target_t* target, int32_t screen_index,
+                                  int32_t x, int32_t y)
+  {
+    return false;
+  }
+
 #if LIN
   virtual bool register_fd(int fd, clap_posix_fd_flags_t flags) = 0;
   virtual bool modify_fd(int fd, clap_posix_fd_flags_t flags) = 0;
@@ -98,6 +130,7 @@ struct ClapPluginExtensions
   const clap_plugin_render_t* _render = nullptr;
   const clap_plugin_tail_t* _tail = nullptr;
   const clap_plugin_timer_support_t* _timer = nullptr;
+  const clap_plugin_context_menu_t* _contextmenu = nullptr;
 #if LIN
   const clap_plugin_posix_fd_support* _posixfd = nullptr;
 #endif
@@ -179,11 +212,22 @@ class Plugin
   void param_clear(clap_id param, clap_param_clear_flags flags);
   void param_request_flush();
 
+  // state
+  void mark_dirty();
+
   // latency
   void latency_changed();
 
   // tail
   void tail_changed();
+
+  // context_menu
+  bool context_menu_populate(const clap_context_menu_target_t* target,
+                             const clap_context_menu_builder_t* builder);
+  bool context_menu_perform(const clap_context_menu_target_t* target, clap_id action_id);
+  bool context_menu_can_popup();
+  bool context_menu_popup(const clap_context_menu_target_t* target, int32_t screen_index, int32_t x,
+                          int32_t y);
 
   // hostgui
   void resize_hints_changed()

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -111,7 +111,20 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   gui->set_parent(ui._plugin->_plugin, &m);
   gui->set_scale(ui._plugin->_plugin, 1.0);
 
-  if (gui->can_resize(ui._plugin->_plugin)) gui->set_size(ui._plugin->_plugin, size.width, size.height);
+  if (gui->can_resize(ui._plugin->_plugin))
+  {
+    clap_gui_resize_hints_t *resize_hints = nullptr;
+    gui->get_resize_hints(ui._plugin->_plugin, resize_hints);
+    NSAutoresizingMaskOptions mask = 0;
+    if (resize_hints)
+    {
+      if (resize_hints->can_resize_horizontally) mask |= NSViewWidthSizable;
+      if (resize_hints->can_resize_vertically) mask |= NSViewHeightSizable;
+    }
+
+    [self setAutoresizingMask:mask];
+    gui->set_size(ui._plugin->_plugin, size.width, size.height);
+  }
 
   idleTimer = nil;
   CFTimeInterval TIMER_INTERVAL = .05;  // In SurgeGUISynthesizer.h it uses 50 ms

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -113,14 +113,11 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
   if (gui->can_resize(ui._plugin->_plugin))
   {
-    clap_gui_resize_hints_t *resize_hints = nullptr;
-    gui->get_resize_hints(ui._plugin->_plugin, resize_hints);
+    clap_gui_resize_hints_t resize_hints;
+    gui->get_resize_hints(ui._plugin->_plugin, &resize_hints);
     NSAutoresizingMaskOptions mask = 0;
-    if (resize_hints)
-    {
-      if (resize_hints->can_resize_horizontally) mask |= NSViewWidthSizable;
-      if (resize_hints->can_resize_vertically) mask |= NSViewHeightSizable;
-    }
+    if (resize_hints.can_resize_horizontally) mask |= NSViewWidthSizable;
+    if (resize_hints.can_resize_vertically) mask |= NSViewHeightSizable;
 
     [self setAutoresizingMask:mask];
     gui->set_size(ui._plugin->_plugin, size.width, size.height);

--- a/src/detail/standalone/entry.cpp
+++ b/src/detail/standalone/entry.cpp
@@ -70,12 +70,6 @@ std::shared_ptr<Clap::Plugin> mainCreatePlugin(const clap_plugin_entry *ee, cons
     }
   }
 
-  plugin->setSampleRate(48000);
-  plugin->setBlockSizes(32, 1024);
-  plugin->activate();
-
-  plugin->start_processing();
-
   return plugin;
 }
 

--- a/src/detail/standalone/entry.cpp
+++ b/src/detail/standalone/entry.cpp
@@ -29,7 +29,10 @@ std::shared_ptr<Clap::Plugin> mainCreatePlugin(const clap_plugin_entry *ee, cons
     return nullptr;
   }
 
-  standaloneHost = std::make_unique<StandaloneHost>();
+  if (!standaloneHost)
+  {
+    standaloneHost = std::make_unique<StandaloneHost>();
+  }
 
   if (clapId.empty())
   {
@@ -86,6 +89,10 @@ std::shared_ptr<Clap::Plugin> getMainPlugin()
 
 StandaloneHost *getStandaloneHost()
 {
+  if (!standaloneHost)
+  {
+    standaloneHost = std::make_unique<StandaloneHost>();
+  }
   return standaloneHost.get();
 }
 

--- a/src/detail/standalone/linux/gtkutils.cpp
+++ b/src/detail/standalone/linux/gtkutils.cpp
@@ -7,16 +7,68 @@
 
 #include "gtkutils.h"
 #include "detail/standalone/standalone_details.h"
+#include "detail/standalone/standalone_host.h"
+#include "detail/standalone/entry.h"
 
 #include <cassert>
 
-namespace freeaudio::clap_wrapper::standalone::linux
+namespace freeaudio::clap_wrapper::standalone::linux_standalone
 {
 
 static void activate(GtkApplication *app, gpointer user_data)
 {
+  GdkDisplay *display = gdk_display_get_default();
+
+  if (!GDK_IS_X11_DISPLAY(display))
+  {
+    std::cout << "clap-wrapper standalone requires GDK X11 backend" << std::endl;
+    std::terminate();
+  }
+
   auto g = (GtkGui *)user_data;
   g->setupPlugin(app);
+}
+
+static gboolean onResize(GtkWidget *wid, GdkEventConfigure *event, gpointer user_data)
+{
+  auto g = (GtkGui *)user_data;
+  return g->resizePlugin(wid, event->width, event->height);
+}
+
+bool GtkGui::resizePlugin(GtkWidget *wid, uint32_t w, uint32_t h)
+{
+  if (plugin->_ext._gui)
+  {
+    auto gui = plugin->_ext._gui;
+    auto p = plugin->_plugin;
+
+    if (!gui->can_resize(p))
+    {
+      gui->get_size(p, &w, &h);
+      gtk_window_resize(GTK_WINDOW(wid), w, h);
+      return TRUE;
+    }
+
+#if 1
+    gui->set_size(p, w, h);
+#else
+    // For some reason, this freaks out with drags in surge on gtk on linux.
+    auto adj = false;
+    auto aw = w, ah = h;
+    gui->adjust_size(p, &aw, &ah);
+    gui->set_size(p, aw, ah);
+
+    if (aw != w || ah != h) adj = true;
+
+    w = aw;
+    h = ah;
+
+    gtk_window_resize(GTK_WINDOW(wid), w, h);
+
+    return adj;
+#endif
+  }
+  return FALSE;
 }
 
 void GtkGui::setupPlugin(_GtkApplication *app)
@@ -34,15 +86,27 @@ void GtkGui::setupPlugin(_GtkApplication *app)
 
     uint32_t w, h;
     ui->get_size(p, &w, &h);
+    ui->adjust_size(p, &w, &h);
 
     window = gtk_application_window_new(app);
-    gtk_window_set_title(GTK_WINDOW(window), "Standalone Window");
+    gtk_window_set_title(GTK_WINDOW(window), p->desc->name);
     gtk_window_set_default_size(GTK_WINDOW(window), w, h);
+
+    GtkWidget *vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+    gtk_container_add(GTK_CONTAINER(window), vbox);
+
+    // Create the 'inner window'
+    GtkWidget *frame = gtk_frame_new("Inner 'Window'");
+    gtk_widget_set_size_request(frame, w, h);
+    gtk_box_pack_start(GTK_BOX(vbox), frame, TRUE, TRUE, 0);
+
+    g_signal_connect(window, "configure-event", G_CALLBACK(onResize), this);
+
     gtk_widget_show_all(window);
 
     clap_window win;
     win.api = CLAP_WINDOW_API_X11;
-    auto gw = gtk_widget_get_window(GTK_WIDGET(window));
+    auto gw = gtk_widget_get_window(GTK_WIDGET(frame));
     win.x11 = GDK_WINDOW_XID(gw);
     ui->set_parent(p, &win);
     ui->show(p);
@@ -162,6 +226,73 @@ int GtkGui::runFD(int fd, clap_posix_fd_flags_t flags)
   return true;
 }
 
-}  // namespace freeaudio::clap_wrapper::standalone::linux
+bool GtkGui::parseCommandLine(int argc, char **argv)
+{
+  auto sah = freeaudio::clap_wrapper::standalone::getStandaloneHost();
+
+  auto [i, o, s] = sah->getDefaultAudioInOutSampleRate();
+
+  bool list_devices{false};
+  int sampleRate{s};
+  unsigned int inId{i}, outId{o};
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored \
+    "-Wmissing-field-initializers"  // other peoples errors are outside my scope
+#endif
+  const GOptionEntry entries[] = {
+      {"list-devices", 'l', 0, G_OPTION_ARG_NONE, &list_devices, "List Input Output and MIDI Devices",
+       nullptr},
+      {"sample-rate", 's', 0, G_OPTION_ARG_INT, &sampleRate, "Sample Rate", nullptr},
+      {"input-device", 'i', 0, G_OPTION_ARG_INT, &inId, "Input Device (0 for no input)", nullptr},
+      {"output-device", 'o', 0, G_OPTION_ARG_INT, &outId, "Output Device (0 for no input)", nullptr},
+      {NULL}};
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+  GOptionContext *context;
+  GError *error = nullptr;
+
+  context = g_option_context_new("Clap Wrapper Standalone");
+  g_option_context_add_main_entries(context, entries, NULL);
+
+  g_option_context_add_group(context, gtk_get_option_group(TRUE));
+  if (!g_option_context_parse(context, &argc, &argv, &error))
+  {
+    g_print("Failed to parse options: %s\n", error->message);
+    g_error_free(error);
+    return false;
+  }
+
+  if (list_devices)
+  {
+    std::cout << "\n\nAvailable Audio Interfaces:\n\nOutput:\n";
+    auto outD = sah->getOutputAudioDevices();
+    for (auto &d : outD)
+    {
+      std::cout << "  - " << d.name << " (id=" << d.ID << " channels=" << d.outputChannels << ")"
+                << std::endl;
+    }
+
+    std::cout << "\nInput:\n";
+    auto inD = sah->getInputAudioDevices();
+    for (auto &d : inD)
+    {
+      std::cout << "  - " << d.name << " (id=" << d.ID << " channels=" << d.outputChannels << ")"
+                << std::endl;
+    }
+    return false;
+  }
+
+  LOG << "Post Argument Parse: inId=" << inId << " outId=" << outId << " sampleRate=" << sampleRate
+      << std::endl;
+  sah->setStartupAudio(inId, outId, sampleRate);
+
+  return true;
+}
+
+}  // namespace freeaudio::clap_wrapper::standalone::linux_standalone
 
 #endif

--- a/src/detail/standalone/linux/gtkutils.h
+++ b/src/detail/standalone/linux/gtkutils.h
@@ -5,12 +5,16 @@
 #include "detail/standalone/standalone_host.h"
 
 struct _GtkApplication;  // sigh their typedef screws up forward decls
-namespace freeaudio::clap_wrapper::standalone::linux
+struct _GtkWidget;
+
+namespace freeaudio::clap_wrapper::standalone::linux_standalone
 {
 struct GtkGui
 {
   _GtkApplication *app{nullptr};
   std::shared_ptr<Clap::Plugin> plugin;
+
+  bool parseCommandLine(int argc, char **argv);
 
   void initialize(freeaudio::clap_wrapper::standalone::StandaloneHost *);
   void setPlugin(std::shared_ptr<Clap::Plugin>);
@@ -18,9 +22,10 @@ struct GtkGui
   void shutdown();
 
   void setupPlugin(_GtkApplication *app);
+  bool resizePlugin(_GtkWidget *wid, uint32_t w, uint32_t h);
 
   clap_id currTimer{8675309};
-  std::mutex cbMutex;
+  std::mutex cbMutex{};
 
   struct TimerCB
   {
@@ -47,4 +52,4 @@ struct GtkGui
   bool unregister_fd(int fd);
   int runFD(int fd, clap_posix_fd_flags_t flags);
 };
-}  // namespace freeaudio::clap_wrapper::standalone::linux
+}  // namespace freeaudio::clap_wrapper::standalone::linux_standalone

--- a/src/detail/standalone/macos/AppDelegate.h
+++ b/src/detail/standalone/macos/AppDelegate.h
@@ -10,4 +10,7 @@
 
 - (IBAction)openAudioSettingsWindow:(id)sender;
 
+- (IBAction)streamWrapperFileAs:(id)sender;
+- (IBAction)openWrapperFile:(id)sender;
+
 @end

--- a/src/detail/standalone/macos/AppDelegate.h
+++ b/src/detail/standalone/macos/AppDelegate.h
@@ -1,5 +1,13 @@
 #import <Cocoa/Cocoa.h>
 
-@interface AppDelegate : NSObject <NSApplicationDelegate>
+// @class AudioSettingsWindowDelegate;
+
+@interface AppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+{
+  // AudioSettingsWindowDelegate *audioSettingsWindowDelegate;
+}
+@property(assign) IBOutlet NSWindow *window;
+
+- (IBAction)openAudioSettingsWindow:(id)sender;
 
 @end

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -324,8 +324,6 @@
     // Create the button
     NSButton *okButton = [[NSButton alloc] initWithFrame:NSMakeRect(400 - 80 - 80, 0, 80, 30)];
     [okButton setTitle:@"OK"];
-    [okButton setButtonType:NSMomentaryLightButton];  // Set the button type
-    [okButton setBezelStyle:NSRoundedBezelStyle];
     [okButton setTarget:self];
     [okButton setAction:@selector(okButtonPressed:)];
 
@@ -333,8 +331,6 @@
 
     NSButton *cancelButton = [[NSButton alloc] initWithFrame:NSMakeRect(400 - 80, 0, 80, 30)];
     [cancelButton setTitle:@"Cancel"];
-    [cancelButton setButtonType:NSMomentaryLightButton];  // Set the button type
-    [cancelButton setBezelStyle:NSRoundedBezelStyle];
     [cancelButton setTarget:self];
     [cancelButton setAction:@selector(cancelButtonPressed:)];
 
@@ -349,8 +345,6 @@
 
     NSButton *defaultButton = [[NSButton alloc] initWithFrame:NSMakeRect(95, 215, 300, 30)];
     [defaultButton setTitle:@"Reset to System Default"];
-    [defaultButton setButtonType:NSMomentaryLightButton];  // Set the button type
-    [defaultButton setBezelStyle:NSRoundedBezelStyle];
     [defaultButton setTarget:self];
     [defaultButton setAction:@selector(defaultButtonPressed:)];
     [[self contentView] addSubview:defaultButton];
@@ -475,9 +469,8 @@
     const auto sri = [[item title] integerValue];
     if ((int)sr == (int)sri)
     {
-      [sampleRateSelection selectItem: item];
+      [sampleRateSelection selectItem:item];
     }
-
   }
 }
 

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -2,6 +2,8 @@
 
 #include <AVFoundation/AVFoundation.h>
 
+#include <map>
+
 #include "detail/standalone/entry.h"
 #include "detail/standalone/standalone_details.h"
 #include "detail/standalone/standalone_host.h"
@@ -9,6 +11,17 @@
 #include "detail/clap/fsutil.h"
 
 @interface AppDelegate ()
+
+@end
+
+@interface AudioSettingsWindow : NSWindow
+{
+  NSPopUpButton *outputSelection, *inputSelection, *sampleRateSelection;
+  std::vector<RtAudio::DeviceInfo> outDevices, inDevices;
+}
+
+- (void)setupContents;
+- (void)resetSampleRateSelection;
 
 @end
 
@@ -116,12 +129,28 @@
     [[self window] setContentSize:sz];
     return false;
   };
+
+  freeaudio::clap_wrapper::standalone::getStandaloneHost()->displayAudioError = [](auto &s)
+  {
+    NSLog(@"Error Reported: %s", s.c_str());
+    @autoreleasepool
+    {
+      NSAlert *alert = [[NSAlert alloc] init];
+      [alert setMessageText:@"Unable to configure audio"];
+      [alert setInformativeText:[[NSString alloc] initWithUTF8String:s.c_str()]];
+      [alert addButtonWithTitle:@"OK"];
+      [alert runModal];
+    }
+  };
   freeaudio::clap_wrapper::standalone::mainStartAudio();
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification
 {
   LOG << "applicationWillTerminate shutdown" << std::endl;
+  freeaudio::clap_wrapper::standalone::getStandaloneHost()->displayAudioError = nullptr;
+  freeaudio::clap_wrapper::standalone::getStandaloneHost()->onRequestResize = nullptr;
+
   auto plugin = freeaudio::clap_wrapper::standalone::getMainPlugin();
 
   if (plugin && plugin->_ext._gui)
@@ -130,13 +159,31 @@
     plugin->_ext._gui->destroy(plugin->_plugin);
   }
 
-  // Insert code here to tear down your application
+  [[self window] setDelegate:nil];
+  [[self window] release];
+
   freeaudio::clap_wrapper::standalone::mainFinish();
 }
 
 - (IBAction)openAudioSettingsWindow:(id)sender
 {
-  NSLog(@"openAudioSettingsWindow: Unimplemented");
+  @autoreleasepool
+  {
+    NSRect windowRect = NSMakeRect(0, 0, 400, 360);
+
+    auto *window = [[AudioSettingsWindow alloc]
+        initWithContentRect:windowRect
+                  styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
+                            NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable
+                    backing:NSBackingStoreBuffered
+                      defer:NO];
+
+    [window setupContents];
+
+    // Center the window and make it key window and front.
+    [window center];
+    [window makeKeyAndOrderFront:nil];
+  }
 }
 
 - (void)windowDidResize:(NSNotification *)notification
@@ -188,7 +235,7 @@
   return frameSize;
 }
 
-- (IBAction)saveDocumentAs:(id)sender
+- (IBAction)streamWrapperFileAs:(id)sender
 {
   NSSavePanel *savePanel = [NSSavePanel savePanel];
   [savePanel setNameFieldStringValue:@"Untitled"];  //
@@ -212,12 +259,11 @@
       [alert setInformativeText:[[NSString alloc] initWithUTF8String:e.what()]];
       [alert addButtonWithTitle:@"OK"];
       [alert runModal];
-
     }
   }
 }
 
-- (IBAction)openDocument:(id)sender
+- (IBAction)openWrapperFile:(id)sender
 {
   NSOpenPanel *openPanel = [NSOpenPanel openPanel];
   [openPanel setCanChooseFiles:YES];
@@ -246,6 +292,253 @@
       [alert runModal];
     }
   }
+}
+
+@end
+
+@implementation AudioSettingsWindow
+
+- (void)setupContents
+{
+  @autoreleasepool
+  {
+    auto addLabel = [](NSString *s, int x, int y)
+    {
+      NSTextField *label = [[NSTextField alloc] initWithFrame:NSMakeRect(x, y, 200, 30)];
+
+      // Set the text of the label
+      [label setStringValue:s];
+
+      // By default, NSTextField objects are editable. Make this one non-editable and non-selectable to act like a label
+      [label setEditable:NO];
+      [label setSelectable:NO];
+      [label setBezeled:NO];
+      [label setDrawsBackground:NO];
+
+      // Add the label to the window
+      return label;
+    };
+    // Set the window title
+    [self setTitle:@"Audio/MIDI Settings"];
+
+    // Create the button
+    NSButton *okButton = [[NSButton alloc] initWithFrame:NSMakeRect(400 - 80 - 80, 0, 80, 30)];
+    [okButton setTitle:@"OK"];
+    [okButton setButtonType:NSMomentaryLightButton];  // Set the button type
+    [okButton setBezelStyle:NSRoundedBezelStyle];
+    [okButton setTarget:self];
+    [okButton setAction:@selector(okButtonPressed:)];
+
+    [[self contentView] addSubview:okButton];
+
+    NSButton *cancelButton = [[NSButton alloc] initWithFrame:NSMakeRect(400 - 80, 0, 80, 30)];
+    [cancelButton setTitle:@"Cancel"];
+    [cancelButton setButtonType:NSMomentaryLightButton];  // Set the button type
+    [cancelButton setBezelStyle:NSRoundedBezelStyle];
+    [cancelButton setTarget:self];
+    [cancelButton setAction:@selector(cancelButtonPressed:)];
+
+    [[self contentView] addSubview:addLabel(@"Output", 10, 320)];
+    outputSelection = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(100, 320, 290, 30)];
+
+    [[self contentView] addSubview:addLabel(@"Sample Rate", 10, 285)];
+    sampleRateSelection = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(100, 285, 120, 30)];
+
+    [[self contentView] addSubview:addLabel(@"Input", 10, 250)];
+    inputSelection = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(100, 250, 290, 30)];
+
+    NSButton *defaultButton = [[NSButton alloc] initWithFrame:NSMakeRect(95, 215, 300, 30)];
+    [defaultButton setTitle:@"Reset to System Default"];
+    [defaultButton setButtonType:NSMomentaryLightButton];  // Set the button type
+    [defaultButton setBezelStyle:NSRoundedBezelStyle];
+    [defaultButton setTarget:self];
+    [defaultButton setAction:@selector(defaultButtonPressed:)];
+    [[self contentView] addSubview:defaultButton];
+
+    NSBox *horizontalRule = [[NSBox alloc] initWithFrame:NSMakeRect(10, 205, 380, 1)];
+    [horizontalRule setBoxType:NSBoxSeparator];
+    [[self contentView] addSubview:horizontalRule];
+
+    [[self contentView] addSubview:addLabel(@"MIDI", 10, 165)];
+    [[self contentView] addSubview:addLabel(@"Coming Soon", 100, 165)];
+
+    auto standaloneHost = freeaudio::clap_wrapper::standalone::getStandaloneHost();
+    outDevices = standaloneHost->getOutputAudioDevices();
+    // add items to menu
+    int selIdx{-1}, idx{0};
+    //[outputSelection addItemWithTitle:@"No Output"];
+
+    for (auto o : outDevices)
+    {
+      [outputSelection addItemWithTitle:[[NSString alloc] initWithUTF8String:o.name.c_str()]];
+      if (standaloneHost->audioOutputDeviceID == o.ID) selIdx = idx;
+      idx++;
+    }
+    if (selIdx >= 0)
+    {
+      [outputSelection selectItemAtIndex:selIdx];
+    }
+    [outputSelection setAction:@selector(onSourceMenuChanged:)];
+    [outputSelection setTarget:self];
+
+    inDevices = standaloneHost->getInputAudioDevices();
+    selIdx = -1;
+    idx = 1;
+    [inputSelection addItemWithTitle:@"No Input"];
+
+    for (auto i : inDevices)
+    {
+      [inputSelection addItemWithTitle:[[NSString alloc] initWithUTF8String:i.name.c_str()]];
+      if (standaloneHost->audioInputDeviceID == i.ID) selIdx = idx;
+      idx++;
+    }
+    if (selIdx >= 0)
+    {
+      [inputSelection selectItemAtIndex:selIdx];
+    }
+
+    [inputSelection setAction:@selector(onSourceMenuChanged:)];
+    [inputSelection setTarget:self];
+
+    [self resetSampleRateSelection];
+
+    // Add the outputSelection to the window's content view
+    [[self contentView] addSubview:outputSelection];
+    [[self contentView] addSubview:inputSelection];
+    [[self contentView] addSubview:sampleRateSelection];
+
+    // Add the button to the window's content view
+    [[self contentView] addSubview:cancelButton];
+  }
+}
+
+- (void)okButtonPressed:(id)sender
+{
+  @autoreleasepool
+  {
+    unsigned int outId{0}, inId{0};
+    bool useOut{false}, useIn{false};
+
+    auto oidx = [outputSelection indexOfSelectedItem];
+    if (oidx >= 0)  // modify this to > and add a -1 below if we add no out
+    {
+      const auto &oDev = outDevices[oidx];
+      outId = oDev.ID;
+      useOut = true;
+    }
+
+    auto iidx = [inputSelection indexOfSelectedItem];
+    if (iidx > 0)
+    {
+      const auto &iDev = inDevices[iidx - 1];
+      inId = iDev.ID;
+      useIn = true;
+    }
+
+    const auto sr = [[[sampleRateSelection selectedItem] title] integerValue];
+
+    auto standaloneHost = freeaudio::clap_wrapper::standalone::getStandaloneHost();
+    standaloneHost->startAudioThreadOn(inId, 2, useIn, outId, 2, useOut, (int32_t)sr);
+
+    [self close];
+  }
+}
+
+- (void)defaultButtonPressed:(id)sender
+{
+  auto standaloneHost = freeaudio::clap_wrapper::standalone::getStandaloneHost();
+  auto [in, out, sr] = standaloneHost->getDefaultAudioInOutSampleRate();
+  int idx = 1;
+  for (auto i : inDevices)
+  {
+    if ((int)i.ID == (int)in)
+    {
+      [inputSelection selectItemAtIndex:idx];
+    }
+    idx++;
+  }
+
+  idx = 0;
+  for (auto o : outDevices)
+  {
+    if ((int)o.ID == (int)out)
+    {
+      [outputSelection selectItemAtIndex:idx];
+    }
+    idx++;
+  }
+
+  [self resetSampleRateSelection];
+
+  for (NSMenuItem *item in [sampleRateSelection itemArray])
+  {
+    const auto sri = [[item title] integerValue];
+    if ((int)sr == (int)sri)
+    {
+      [sampleRateSelection selectItem: item];
+    }
+
+  }
+}
+
+- (void)cancelButtonPressed:(id)sender
+{
+  @autoreleasepool
+  {
+    [self close];
+  }
+}
+
+- (void)onSourceMenuChanged:(id)sender
+{
+  [self resetSampleRateSelection];
+}
+
+- (void)resetSampleRateSelection
+{
+  auto idx = [outputSelection indexOfSelectedItem];
+  const auto &oDev = outDevices[idx];
+
+  [sampleRateSelection removeAllItems];
+  auto csr = freeaudio::clap_wrapper::standalone::getStandaloneHost()->currentSampleRate;
+
+  std::map<int, int> srAvail;
+  for (auto sr : oDev.sampleRates)
+  {
+    srAvail[sr]++;
+  }
+
+  idx = [inputSelection indexOfSelectedItem];
+  if (idx > 0)
+  {
+    const auto &iDev = inDevices[idx - 1];
+
+    for (auto sr : iDev.sampleRates)
+    {
+      srAvail[sr]++;
+    }
+  }
+  else
+  {
+    // Just take the output rates
+    for (auto sr : oDev.sampleRates)
+    {
+      srAvail[sr]++;
+    }
+  }
+
+  int selIdx{-1}, sIdx{0};
+  for (auto [sr, ct] : srAvail)
+  {
+    if (ct == 2)
+    {
+      [sampleRateSelection addItemWithTitle:[NSString stringWithFormat:@"%d", sr]];
+      if ((int)sr == (int)csr) selIdx = sIdx;
+
+      sIdx++;
+    }
+  }
+  if (selIdx >= 0) [sampleRateSelection selectItemAtIndex:selIdx];
 }
 
 @end

--- a/src/detail/standalone/macos/Info.plist.in
+++ b/src/detail/standalone/macos/Info.plist.in
@@ -12,7 +12,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>org.cmake.CocoaExample</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}.standalone</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/src/detail/standalone/macos/MainMenu.xib
+++ b/src/detail/standalone/macos/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22689"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,6 +31,12 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                            <menuItem title="Audio/MIDI Settings" id="6kV-Vb-QxS">
+                                <connections>
+                                    <action selector="openAudioSettingsWindow:" target="Voe-Tx-rLC" id="3a0-x6-H3R"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="kCx-OF-vgT"/>
                             <menuItem title="Hide ${SA_OUTPUT_NAME}" keyEquivalent="h" id="Olw-nP-bQN">
                                 <connections>
                                     <action selector="hide:" target="-1" id="PnN-Uc-m68"/>
@@ -66,25 +72,14 @@
                                     <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Open Recent" id="tXI-mr-wws">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
-                                    <items>
-                                        <menuItem title="Clear Menu" id="vNY-rz-j42">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="clearRecentDocuments:" target="-1" id="Daa-9d-B3U"/>
-                                            </connections>
-                                        </menuItem>
-                                    </items>
-                                </menu>
-                            </menuItem>
+                            <!--
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
                             <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
                                 <connections>
                                     <action selector="saveDocument:" target="-1" id="teZ-XB-qJY"/>
                                 </connections>
                             </menuItem>
+                            -->
                             <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
                                 <connections>
                                     <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
@@ -121,7 +116,7 @@
             </items>
             <point key="canvasLocation" x="-69" y="65"/>
         </menu>
-        <window title="${SA_OUTPUT_NAME}" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
+        <window title="${SA_OUTPUT_NAME}" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>

--- a/src/detail/standalone/macos/MainMenu.xib
+++ b/src/detail/standalone/macos/MainMenu.xib
@@ -69,20 +69,12 @@
                         <items>
                             <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
                                 <connections>
-                                    <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
+                                    <action selector="openWrapperFile:" target="-1" id="bVn-NM-KNZ"/>
                                 </connections>
                             </menuItem>
-                            <!--
-                            <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
-                            <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
-                                <connections>
-                                    <action selector="saveDocument:" target="-1" id="teZ-XB-qJY"/>
-                                </connections>
-                            </menuItem>
-                            -->
                             <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
                                 <connections>
-                                    <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
+                                    <action selector="streamWrapperFileAs:" target="-1" id="mDf-zr-I0C"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -248,6 +248,7 @@ const char *StandaloneHost::host_get_name()
 bool StandaloneHost::register_timer(uint32_t period_ms, clap_id *timer_id)
 {
 #if LIN && CLAP_WRAPPER_HAS_GTK3
+  assert(gtkGui);
   return gtkGui->register_timer(period_ms, timer_id);
 #else
   return false;

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -364,4 +364,24 @@ bool StandaloneHost::tryLoadStandaloneAndPluginSettings(const fs::path &fromDir,
   return true;
 }
 
+void StandaloneHost::activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlock)
+{
+  if (isActive)
+  {
+    clapPlugin->stop_processing();
+    clapPlugin->deactivate();
+    isActive = false;
+  }
+
+  LOG << "Activating plugin : sampleRate=" << sr << " blockBounds=" << minBlock << " to " << maxBlock
+      << std::endl;
+  clapPlugin->setSampleRate(sr);
+  clapPlugin->setBlockSizes(minBlock, maxBlock);
+  clapPlugin->activate();
+
+  clapPlugin->start_processing();
+
+  isActive = true;
+}
+
 }  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -31,7 +31,7 @@ namespace freeaudio::clap_wrapper::standalone
 {
 #if LIN
 #if CLAP_WRAPPER_HAS_GTK3
-namespace linux
+namespace linux_standalone
 {
 struct GtkGui;
 }
@@ -183,7 +183,7 @@ struct StandaloneHost : Clap::IHost
 
 #if LIN
 #if CLAP_WRAPPER_HAS_GTK3
-  freeaudio::clap_wrapper::standalone::linux::GtkGui *gtkGui{nullptr};
+  freeaudio::clap_wrapper::standalone::linux_standalone::GtkGui *gtkGui{nullptr};
 #endif
 #endif
 
@@ -246,6 +246,17 @@ struct StandaloneHost : Clap::IHost
                           unsigned int outputDeviceID, uint32_t outputChannels, bool useOutput,
                           int32_t sampleRate);
   void stopAudioThread();
+
+  bool startupAudioSet{false};
+  unsigned int startAudioIn{0}, startAudioOut{0};
+  int startSampleRate{0};
+  void setStartupAudio(unsigned int in, unsigned int out, int sr)
+  {
+    startupAudioSet = true;
+    startAudioIn = in;
+    startAudioOut = out;
+    startSampleRate = sr;
+  }
 
   void activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlock);
   bool isActive{false};

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -6,6 +6,7 @@
 #include <thread>
 #include <mutex>
 #include <optional>
+#include <tuple>
 
 #include "standalone_details.h"
 
@@ -232,10 +233,25 @@ struct StandaloneHost : Clap::IHost
   // in standalone_host.cpp
   void clapProcess(void *pOutput, const void *pInoput, uint32_t frameCount);
 
-  // In standalone_host_audio.cpp
+  // Actual audio IO In standalone_host_audio.cpp
   std::unique_ptr<RtAudio> rtaDac;
+  std::function<void(const std::string &)> displayAudioError{nullptr};
+  unsigned int audioInputDeviceID{0}, audioOutputDeviceID{0};
+  bool audioInputUsed{true}, audioOutputUsed{true};
+  int32_t currentSampleRate{0};
+  void guaranteeRtAudioDAC();
+  std::tuple<unsigned int, unsigned int, int32_t> getDefaultAudioInOutSampleRate();
   void startAudioThread();
+  void startAudioThreadOn(unsigned int inputDeviceID, uint32_t inputChannels, bool useInput,
+                          unsigned int outputDeviceID, uint32_t outputChannels, bool useOutput,
+                          int32_t sampleRate);
   void stopAudioThread();
+
+  void activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlock);
+  bool isActive{false};
+
+  std::vector<RtAudio::DeviceInfo> getInputAudioDevices();
+  std::vector<RtAudio::DeviceInfo> getOutputAudioDevices();
 
   clap_input_events inputEvents{};
   clap_output_events outputEvents{};

--- a/src/detail/standalone/standalone_host_audio.cpp
+++ b/src/detail/standalone/standalone_host_audio.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include "standalone_host.h"
+#include "entry.h"
 
 namespace freeaudio::clap_wrapper::standalone
 {
@@ -32,60 +33,187 @@ int rtaCallback(void *outputBuffer, void *inputBuffer, unsigned int nBufferFrame
 void rtaErrorCallback(RtAudioErrorType, const std::string &errorText)
 {
   LOG << "[ERROR] RtAudio reports '" << errorText << "'" << std::endl;
+  auto ae = getStandaloneHost()->displayAudioError;
+  if (ae)
+  {
+    ae(errorText);
+  }
 }
 
+void StandaloneHost::guaranteeRtAudioDAC()
+{
+  if (!rtaDac)
+  {
+    LOG << "Creating RtAudio DAC" << std::endl;
+    rtaDac = std::make_unique<RtAudio>(RtAudio::UNSPECIFIED, &rtaErrorCallback);
+    rtaDac->showWarnings(true);
+  }
+}
+
+std::tuple<unsigned int, unsigned int, int32_t> StandaloneHost::getDefaultAudioInOutSampleRate()
+{
+  guaranteeRtAudioDAC();
+  auto iid = rtaDac->getDefaultInputDevice();
+  auto oid = rtaDac->getDefaultOutputDevice();
+  auto outInfo = rtaDac->getDeviceInfo(oid);
+  auto sr = outInfo.preferredSampleRate;
+
+  return {iid, oid, (int32_t)sr};
+}
 void StandaloneHost::startAudioThread()
 {
-  rtaDac = std::make_unique<RtAudio>(RtAudio::UNSPECIFIED, &rtaErrorCallback);
-  rtaDac->showWarnings(true);
+  guaranteeRtAudioDAC();
+
+  auto [in, out, sr] = getDefaultAudioInOutSampleRate();
+  startAudioThreadOn(in, 2, numAudioInputs > 0, out, 2, numAudioOutputs > 0, sr);
+}
+
+std::vector<RtAudio::DeviceInfo> filterDevicesBy(const std::unique_ptr<RtAudio> &rtaDac,
+                                                 std::function<bool(const RtAudio::DeviceInfo &)> f)
+{
+  std::vector<RtAudio::DeviceInfo> res;
+  auto dids = rtaDac->getDeviceIds();
+  auto dnms = rtaDac->getDeviceNames();
+  for (auto d : dids)
+  {
+    auto inf = rtaDac->getDeviceInfo(d);
+    if (f(inf))
+    {
+      res.push_back(inf);
+    }
+  }
+  return res;
+}
+
+std::vector<RtAudio::DeviceInfo> StandaloneHost::getInputAudioDevices()
+{
+  guaranteeRtAudioDAC();
+  return filterDevicesBy(rtaDac, [](auto &a) { return a.inputChannels > 0; });
+}
+
+std::vector<RtAudio::DeviceInfo> StandaloneHost::getOutputAudioDevices()
+{
+  guaranteeRtAudioDAC();
+  return filterDevicesBy(rtaDac, [](auto &a) { return a.outputChannels > 0; });
+}
+
+void StandaloneHost::startAudioThreadOn(unsigned int inputDeviceID, uint32_t inputChannels,
+                                        bool useInput, unsigned int outputDeviceID,
+                                        uint32_t outputChannels, bool useOutput, int32_t reqSampleRate)
+{
+  guaranteeRtAudioDAC();
+
+  if (rtaDac->isStreamRunning())
+  {
+    stopAudioThread();
+    running = true;
+    finishedRunning = false;
+  }
+
+  audioInputDeviceID = inputDeviceID;
+  audioInputUsed = useInput;
+  audioOutputDeviceID = outputDeviceID;
+  audioOutputUsed = useOutput;
+
   auto dids = rtaDac->getDeviceIds();
   auto dnms = rtaDac->getDeviceNames();
 
   RtAudio::StreamParameters oParams;
-  oParams.deviceId = rtaDac->getDefaultOutputDevice();
-  auto outInfo = rtaDac->getDeviceInfo(oParams.deviceId);
-  oParams.nChannels = std::min(2U, outInfo.outputChannels);
-  oParams.firstChannel = 0;
+  int32_t sampleRate{reqSampleRate};
+
+  if (useOutput)
+  {
+    oParams.deviceId = outputDeviceID;
+    auto outInfo = rtaDac->getDeviceInfo(oParams.deviceId);
+    oParams.nChannels = std::min(outputChannels, outInfo.outputChannels);
+    oParams.firstChannel = 0;
+    if (sampleRate < 0)
+    {
+      sampleRate = outInfo.preferredSampleRate;
+    }
+    else
+    {
+      // Mkae sure this sample rate is available
+      bool isPossible{false};
+      for (auto sr : outInfo.sampleRates)
+      {
+        isPossible = isPossible || ((int)sr == (int)sampleRate);
+      }
+      if (!isPossible)
+      {
+        sampleRate = outInfo.preferredSampleRate;
+      }
+    }
+  }
 
   RtAudio::StreamParameters iParams;
-  iParams.deviceId = rtaDac->getDefaultInputDevice();
-  auto inInfo = rtaDac->getDeviceInfo(iParams.deviceId);
-  iParams.nChannels = std::min(2U, inInfo.inputChannels);
-  iParams.firstChannel = 0;
-
-  LOG << "RtAudio Attached Devices" << std::endl;
-  for (auto i = 0U; i < dids.size(); ++i)
+  if (useInput)
   {
-    if (oParams.deviceId == dids[i]) LOG << "  - Output : '" << dnms[i] << "'" << std::endl;
+    iParams.deviceId = inputDeviceID;
+    auto inInfo = rtaDac->getDeviceInfo(iParams.deviceId);
+    iParams.nChannels = std::min(inputChannels, inInfo.inputChannels);
+    iParams.firstChannel = 0;
+    if (sampleRate < 0) sampleRate = inInfo.preferredSampleRate;
   }
-  if (numAudioOutputs > 0)
-    for (auto i = 0U; i < dids.size(); ++i)
-    {
-      if (iParams.deviceId == dids[i]) LOG << "  - Input : '" << dnms[i] << "'" << std::endl;
-    }
+
+  if (sampleRate < 0)
+  {
+    LOG << "No preferred sample rate detected; using 48k" << std::endl;
+    sampleRate = 48000;
+  }
+
+  currentSampleRate = sampleRate;
 
   RtAudio::StreamOptions options;
   options.flags = RTAUDIO_SCHEDULE_REALTIME;
 
+  /*
+   * RTAudio doesn't tell you what the possible frame sizes are but instead
+   * just tells you to try open stream with power of twos you want. So leave
+   * this for now at 256 and return to it shortly.
+   */
+  LOG << "[WARNING] Hardcoding frame size to 256 samples for now" << std::endl;
   uint32_t bufferFrames{256};
-  if (rtaDac->openStream(&oParams, (numAudioInputs > 0) ? &iParams : nullptr, RTAUDIO_FLOAT32, 48000,
-                         &bufferFrames, &rtaCallback, (void *)this, &options))
+  if (rtaDac->openStream((useOutput) ? &oParams : nullptr, (useInput) ? &iParams : nullptr,
+                         RTAUDIO_FLOAT32, sampleRate, &bufferFrames, &rtaCallback, (void *)this,
+                         &options))
   {
     LOG << "[ERROR]" << rtaDac->getErrorText() << std::endl;
+    rtaDac->closeStream();
     return;
+  }
+
+  activatePlugin(sampleRate, 1, bufferFrames * 2);
+
+  LOG << "RtAudio Attached Devices" << std::endl;
+  if (useOutput)
+  {
+    for (auto i = 0U; i < dids.size(); ++i)
+    {
+      if (oParams.deviceId == dids[i]) LOG << "  - Output : '" << dnms[i] << "'" << std::endl;
+    }
+  }
+  if (useInput)
+  {
+    for (auto i = 0U; i < dids.size(); ++i)
+    {
+      if (iParams.deviceId == dids[i]) LOG << "  - Input : '" << dnms[i] << "'" << std::endl;
+    }
   }
 
   if (!rtaDac->isStreamOpen())
   {
+    LOG << "[ERROR] Stream failed to open : " << rtaDac->getErrorText() << std::endl;
     return;
   }
 
-  if (!rtaDac->startStream())
+  if (rtaDac->startStream())
   {
+    LOG << "[ERROR] startStream failed : " << rtaDac->getErrorText() << std::endl;
     return;
   }
 
-  LOG << "RTA Started Stream" << std::endl;
+  LOG << "RtAudio: Started Stream" << std::endl;
 }
 
 void StandaloneHost::stopAudioThread()
@@ -104,11 +232,14 @@ void StandaloneHost::stopAudioThread()
     {
       using namespace std::chrono_literals;
       std::this_thread::sleep_for(1ms);
-      // todo put a sleep here
     }
     LOG << "Audio Thread acknowledges shutdown" << std::endl;
 
-    if (rtaDac && rtaDac->isStreamRunning()) rtaDac->stopStream();
+    if (rtaDac && rtaDac->isStreamRunning())
+    {
+      rtaDac->stopStream();
+      rtaDac->closeStream();
+    }
     LOG << "RtAudio stream stopped" << std::endl;
   }
   return;

--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -45,7 +45,7 @@ Vst3Parameter::~Vst3Parameter() = default;
 
 bool Vst3Parameter::setNormalized(Steinberg::Vst::ParamValue v)
 {
-  if (isMidi && info.flags & Steinberg::Vst::ParameterInfo::kIsProgramChange)
+  if (isMidi && (info.flags & Steinberg::Vst::ParameterInfo::kIsProgramChange))
   {
     return true;
   }

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -18,7 +18,8 @@ using namespace Steinberg;
 class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
 {
  public:
-  WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui, std::function<void()> onDestroy,
+  WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui,
+              std::function<void()> onReleaseAdditionalReferences, std::function<void()> onDestroy,
               std::function<void()> onRunLoopAvailable);
   ~WrappedView();
 
@@ -90,9 +91,11 @@ class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
  private:
   void ensure_ui();
   void drop_ui();
+  void releaseAdditionalReferences();
   const clap_plugin_t* _plugin = nullptr;
   const clap_plugin_gui_t* _extgui = nullptr;
-  std::function<void()> _onDestroy = nullptr, _onRunLoopAvailable = nullptr;
+  std::function<void()> _onReleaseAdditionalReferences = nullptr, _onDestroy = nullptr,
+                        _onRunLoopAvailable = nullptr;
   clap_window_t _window = {nullptr, {nullptr}};
   IPlugFrame* _plugFrame = nullptr;
   ViewRect _rect = {0, 0, 0, 0};

--- a/src/wrapasstandalone.cpp
+++ b/src/wrapasstandalone.cpp
@@ -39,6 +39,18 @@ int main(int argc, char **argv)
 
 #endif
 
+#if LIN
+#if CLAP_WRAPPER_HAS_GTK3
+  freeaudio::clap_wrapper::standalone::linux_standalone::GtkGui gtkGui{};
+
+  if (!gtkGui.parseCommandLine(argc, argv))
+  {
+    return 1;
+  }
+  gtkGui.initialize(freeaudio::clap_wrapper::standalone::getStandaloneHost());
+#endif
+#endif
+
   if (!entry)
   {
     std::cerr << "Clap Standalone: No Entry as configured" << std::endl;
@@ -54,9 +66,6 @@ int main(int argc, char **argv)
 
 #if LIN
 #if CLAP_WRAPPER_HAS_GTK3
-  freeaudio::clap_wrapper::standalone::linux::GtkGui gtkGui{};
-
-  gtkGui.initialize(freeaudio::clap_wrapper::standalone::getStandaloneHost());
   gtkGui.setPlugin(plugin);
   gtkGui.runloop(argc, argv);
   gtkGui.shutdown();

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -798,6 +798,13 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
 
 void ClapAsVst3::param_clear(clap_id param, clap_param_clear_flags flags)
 {
+  auto vst3id = param & 0x7FFFFFFF;
+  // auto* p = (Vst3Parameter*)(parameters.getParameter(param & 0x7FFFFFFF));
+  if (flags & CLAP_PARAM_CLEAR_ALL)
+  {
+    this->parameters.removeParameter(vst3id);
+  }
+  // all other flags can not be really mapped to VST3 functions
 }
 
 // request_flush requests a defered call to flush if there is no processing

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -235,6 +235,8 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   IPtr<Steinberg::Vst::IComponentHandler3> componentHandler3 = nullptr;
   IPtr<Steinberg::Vst::IContextMenu> vst3ContextMenu = nullptr;
+  IPtr<Steinberg::Vst::IHostApplication> vst3HostApplication = nullptr;
+  std::string wrapper_hostname = "CLAP-As-VST3-Wrapper";
   std::vector<wrapper_context_menu_item> contextmenuitems;
   uint32_t vst3ContextMenuParamID = 0;
 


### PR DESCRIPTION
I was running into an issue where my child NSView would change size and the wrapper would not update its size. This patch addresses this by checking the resize hints provided by the CLAP plugin and setting the AutoresizingMask for the wrapper NSView.

I am quite new to all of this, but my understanding is that AUv2 cannot have a resizable window. Depending on the opinion of the maintainers if you'd prefer it to be consistent with the VST3 and CLAP versions I would be happy to spend the time to implement a listener for mouse events to hittest the edges of the wrapper view to simulate this behavior.