### PR TITLE
Handle AUv2 No UI case

### DIFF
--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -442,6 +442,7 @@ int main(int argc, char **argv)
         else
         {
           fillOSS << "\n  if (strcmp(_plugin->_plugin->desc->id,\"" << u.clapid << "\") == 0) {\n";
+          fillOSS << "    if (!_plugin->_ext._gui) return false;\n";
           fillOSS << "    return fillAUCV_" << on << "(viewInfo);\n";
           fillOSS << "  }\n";
         }

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -596,6 +596,8 @@ OSStatus WrapAsAUV2::GetPropertyInfo(AudioUnitPropertyID inID, AudioUnitScope in
         break;
 
       case kAudioUnitProperty_CocoaUI:
+        if (!_plugin->_ext._gui)
+          return kAudioUnitErr_InvalidProperty;
         outWritable = false;
         outDataSize = sizeof(struct AudioUnitCocoaViewInfo);
         return noErr;
@@ -676,7 +678,7 @@ OSStatus WrapAsAUV2::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
       case kAudioUnitProperty_CocoaUI:
         LOGINFO("[clap-wrapper] Property: kAudioUnitProperty_CocoaUI {}",
                 (_plugin) ? "plugin" : "no plugin");
-        if (_plugin &&
+        if (_plugin && _plugin->_ext._gui &&
             (_plugin->_ext._gui->is_api_supported(_plugin->_plugin, CLAP_WINDOW_API_COCOA, false)))
         {
           fillAudioUnitCocoaView(((AudioUnitCocoaViewInfo*)outData), _plugin);

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -596,7 +596,8 @@ OSStatus WrapAsAUV2::GetPropertyInfo(AudioUnitPropertyID inID, AudioUnitScope in
         break;
 
       case kAudioUnitProperty_CocoaUI:
-        if (!_plugin->_ext._gui)
+        if (!_plugin->_ext._gui) return kAudioUnitErr_InvalidProperty;
+        if (!_plugin->_ext._gui->is_api_supported(_plugin->_plugin, CLAP_WINDOW_API_COCOA, false))
           return kAudioUnitErr_InvalidProperty;
         outWritable = false;
         outDataSize = sizeof(struct AudioUnitCocoaViewInfo);


### PR DESCRIPTION
The AUV2 No UI case was still trying to construct a UI despite _ext._gui being null. Add the appropirate defenisve guards in three locations

Closes #257