### PR TITLE
Add build-time option to statically link to clap_entry

### DIFF
--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -26,6 +26,12 @@
 #include <iostream>
 #endif
 
+#include "../os/osutil.h"
+
+#if STATICALLY_LINKED_CLAP_ENTRY
+extern clap_plugin_entry_t const clap_entry;
+#endif
+
 namespace Clap
 {
 #if WIN
@@ -280,6 +286,14 @@ static void ffeomwe()
 
 Library::Library()
 {
+#if STATICALLY_LINKED_CLAP_ENTRY
+  _pluginEntry = &clap_entry;
+  _selfcontained = true;
+  std::string path = os::getModulePath();
+  setupPluginsFromPluginEntry(path.c_str());
+  return;
+#endif
+
 #if WIN
   fs::path modulename;
   HMODULE selfmodule;

--- a/src/detail/os/linux.cpp
+++ b/src/detail/os/linux.cpp
@@ -78,10 +78,10 @@ static Steinberg::ModuleTerminator dropMessageWindow([] { gLinuxHelper.terminate
 	}
 #endif
 
-static std::string getModuleName()
+std::string getModulePath()
 {
   Dl_info info;
-  if (dladdr((void*)getModuleName, &info))
+  if (dladdr((void*)getModulePath, &info))
   {
     return info.dli_fname;
   }
@@ -90,7 +90,7 @@ static std::string getModuleName()
 
 std::string getParentFolderName()
 {
-  std::filesystem::path n = getModuleName();
+  std::filesystem::path n = getModulePath();
   if (n.has_parent_path())
   {
     auto p = n.parent_path();
@@ -105,7 +105,7 @@ std::string getParentFolderName()
 
 std::string getBinaryName()
 {
-  std::filesystem::path n = getModuleName();
+  std::filesystem::path n = getModulePath();
   if (n.has_filename())
   {
     return n.stem().u8string();

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -142,6 +142,11 @@ fs::path getBundlePath()
   return {};
 }
 
+std::string getModulePath()
+{
+  return getBundlePath().string();
+}
+
 std::string getParentFolderName()
 {
   return getBundlePath().parent_path().stem();

--- a/src/detail/os/osutil.h
+++ b/src/detail/os/osutil.h
@@ -65,6 +65,7 @@ class IPlugObject
 void attach(IPlugObject* plugobject);
 void detach(IPlugObject* plugobject);
 uint64_t getTickInMS();
+std::string getModulePath();
 std::string getParentFolderName();
 std::string getBinaryName();
 

--- a/src/detail/os/windows.cpp
+++ b/src/detail/os/windows.cpp
@@ -46,18 +46,6 @@ class WindowsHelper
 static Steinberg::ModuleInitializer createMessageWindow([] { gWindowsHelper.init(); });
 static Steinberg::ModuleTerminator dropMessageWindow([] { gWindowsHelper.terminate(); });
 
-static char* getModuleNameA()
-{
-  static char modulename[2048];
-  HMODULE selfmodule;
-  if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCSTR)getModuleNameA, &selfmodule))
-  {
-    /* auto size = */
-    GetModuleFileNameA(selfmodule, modulename, 2048);
-  }
-  return modulename;
-}
-
 static TCHAR* getModuleName()
 {
   static TCHAR modulename[2048];
@@ -72,7 +60,7 @@ static TCHAR* getModuleName()
 
 std::string getParentFolderName()
 {
-  std::filesystem::path n = getModuleNameA();
+  std::filesystem::path n = getModuleName();
   if (n.has_parent_path())
   {
     auto p = n.parent_path();
@@ -87,7 +75,7 @@ std::string getParentFolderName()
 
 std::string getBinaryName()
 {
-  std::filesystem::path n = getModuleNameA();
+  std::filesystem::path n = getModuleName();
   if (n.has_filename())
   {
     return n.stem().u8string();

--- a/src/detail/os/windows.cpp
+++ b/src/detail/os/windows.cpp
@@ -58,6 +58,12 @@ static TCHAR* getModuleName()
   return modulename;
 }
 
+std::string getModulePath()
+{
+  std::filesystem::path path = getModuleName();
+  return path.u8string();
+}
+
 std::string getParentFolderName()
 {
   std::filesystem::path n = getModuleName();


### PR DESCRIPTION
Allows for avoiding having to dlopen()/LoadLibrary() on itself to find
'clap_entry'. Instead it can be done at link-time.

Useful if you are linking the clap-wrapper files to your clap plugin.
This way, we avoid the potential point-of-failure and slowness of doing
library loading and filesystem access.

Let me know if I'm missing anything. And I might need assistance regarding how this integrates with the cmake. I don't the cmake system for my projects.