### PR TITLE
Deal with user specified INSTRUMENT_TYPE

### DIFF
--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -331,13 +331,20 @@ int main(int argc, char **argv)
         {
           cppf << "AUV2_Type::aumu_musicdevice";
         }
-        if (u.type == "aumi")
+        else if (u.type == "aumi")
         {
           cppf << "AUV2_Type::aumi_noteeffect";
         }
-        if (u.type == "aufx")
+        else if (u.type == "aufx")
         {
           cppf << "AUV2_Type::aufx_effect";
+        }
+        else
+        {
+          std::cout << "   + WARNING: Unable to determine AUV2_Type for instrument type '" << u.type
+                    << "'" << std::endl;
+          std::cout << "     Defaulting to AUV2_Type::musicdevice" << std::endl;
+          cppf << "AUV2_Type::aumu_musicdevice";
         }
         cppf << "," << args << ", ci) {}"
              << "};\n"

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -341,9 +341,9 @@ int main(int argc, char **argv)
         }
         else
         {
-          std::cout << "   + WARNING: Unable to determine AUV2_Type for instrument type '" << u.type
-                    << "'" << std::endl;
-          std::cout << "     Defaulting to AUV2_Type::musicdevice" << std::endl;
+          std::cout << "    + WARNING: Unable to determine AUV2_Type for instrument type '" << u.type
+                    << "'\n"
+                    << "      Defaulting to AUV2_Type::musicdevice" << std::endl;
           cppf << "AUV2_Type::aumu_musicdevice";
         }
         cppf << "," << args << ", ci) {}"


### PR DESCRIPTION
We switch on INSTRUMENT_TYPE to set the internall wrapper handler. We actually only use this in one spot internally but we were failing to make a buildable wrapper if you set the type to something not in our list-of-three. So for now, warn and default out to internal instrument for the other types (which is probably the right behavior for aumf, which is what raised this issue in #271)