### PR TITLE
Fix VST3 wrapper in Ardour

### DIFF
--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -4,14 +4,14 @@
 
 WrappedView::WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui,
                          std::function<void()> onReleaseAdditionalReferences,
-                         std::function<void()> onDestroy, std::function<void()> onRunLoopAvailable)
+                         std::function<void(bool)> onDestroy, std::function<void()> onRunLoopAvailable)
   : IPlugView()
   , FObject()
   , _plugin(plugin)
   , _extgui(gui)
   , _onReleaseAdditionalReferences(onReleaseAdditionalReferences)
-  , _onDestroy(onDestroy)
   , _onRunLoopAvailable(onRunLoopAvailable)
+  , _onDestroy(onDestroy)
 {
 }
 
@@ -49,10 +49,17 @@ void WrappedView::drop_ui()
     _attached = false;
     if (_onDestroy)
     {
-      _onDestroy();
+      _onDestroy(true);
     }
     _extgui->destroy(_plugin);
     _created = false;
+  }
+  else
+  {
+    if (_onDestroy)
+    {
+      _onDestroy(false);
+    }
   }
 }
 

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -19,7 +19,7 @@ class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
 {
  public:
   WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui,
-              std::function<void()> onReleaseAdditionalReferences, std::function<void()> onDestroy,
+              std::function<void()> onReleaseAdditionalReferences, std::function<void(bool)> onDestroy,
               std::function<void()> onRunLoopAvailable);
   ~WrappedView();
 
@@ -94,8 +94,8 @@ class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
   void releaseAdditionalReferences();
   const clap_plugin_t* _plugin = nullptr;
   const clap_plugin_gui_t* _extgui = nullptr;
-  std::function<void()> _onReleaseAdditionalReferences = nullptr, _onDestroy = nullptr,
-                        _onRunLoopAvailable = nullptr;
+  std::function<void()> _onReleaseAdditionalReferences = nullptr, _onRunLoopAvailable = nullptr;
+  std::function<void(bool)> _onDestroy = nullptr;
   clap_window_t _window = {nullptr, {nullptr}};
   IPlugFrame* _plugFrame = nullptr;
   ViewRect _rect = {0, 0, 0, 0};

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -60,7 +60,6 @@ tresult PLUGIN_API ClapAsVst3::initialize(FUnknown* context)
 
 tresult PLUGIN_API ClapAsVst3::terminate()
 {
-  clearContextMenu();
   vst3HostApplication.reset();
 
   if (_plugin)
@@ -260,16 +259,19 @@ IPlugView* PLUGIN_API ClapAsVst3::createView(FIDString /*name*/)
     {
       _wrappedview = new WrappedView(
           _plugin->_plugin, _plugin->_ext._gui, [this]() { clearContextMenu(); },
-          [this]()
+          [this](bool everCreated)
           {
+            if (everCreated)
+            {
 #if LIN
-            // the host calls the destructor, the wrapper just removes its pointer
-            detachTimers(_wrappedview->getRunLoop());
-            detachPosixFD(_wrappedview->getRunLoop());
-            _iRunLoop = nullptr;
+              // the host calls the destructor, the wrapper just removes its pointer
+              detachTimers(_wrappedview->getRunLoop());
+              detachPosixFD(_wrappedview->getRunLoop());
+              _iRunLoop = nullptr;
 #endif
 
-            clearContextMenu();
+              clearContextMenu();
+            }
             this->_wrappedview = nullptr;
           },
           [this]()


### PR DESCRIPTION
Ardour creates and derefences an editor instance without ever showing or parenting it (for the reason of finding out if it supports the apu in VST#PI::has_editor). That's a bit odd, but it also meant that _onDestroy was never called, since that was guarded by _created.

So add an _onDestroy which knows if ever created and resets just the pointer if not, allowing windows to not crash in Ardour