### PR TITLE
Implement Steinberg::IPlugViewContentScaleSupport

### DIFF
--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -1,6 +1,7 @@
 #include "plugview.h"
 #include <clap/clap.h>
 #include <cassert>
+#include <iostream>
 
 WrappedView::WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui,
                          std::function<void()> onReleaseAdditionalReferences,
@@ -268,4 +269,13 @@ bool WrappedView::request_resize(uint32_t width, uint32_t height)
     return false;
   }
   return true;
+}
+tresult WrappedView::setContentScaleFactor(IPlugViewContentScaleSupport::ScaleFactor factor)
+{
+  ensure_ui();
+  if (_extgui->set_scale(_plugin, factor))
+  {
+    return kResultOk;
+  }
+  return kResultFalse;
 }

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -10,12 +10,15 @@
 
 #include "base/source/fobject.h"
 #include <pluginterfaces/gui/iplugview.h>
+#include <pluginterfaces/gui/iplugviewcontentscalesupport.h>
 #include <clap/clap.h>
 #include <functional>
 
 using namespace Steinberg;
 
-class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
+class WrappedView : public Steinberg::IPlugView,
+                    public Steinberg::IPlugViewContentScaleSupport,
+                    public Steinberg::FObject
 {
  public:
   WrappedView(const clap_plugin_t* plugin, const clap_plugin_gui_t* gui,
@@ -78,10 +81,13 @@ class WrappedView : public Steinberg::IPlugView, public Steinberg::FObject
 	 *	adjust the rect to the allowed size. */
   tresult PLUGIN_API checkSizeConstraint(ViewRect* rect) override;
 
+  tresult setContentScaleFactor(ScaleFactor factor) override;
+
   //---Interface------
   OBJ_METHODS(WrappedView, FObject)
   DEFINE_INTERFACES
   DEF_INTERFACE(IPlugView)
+  DEF_INTERFACE(IPlugViewContentScaleSupport)
   END_DEFINE_INTERFACES(FObject)
   REFCOUNT_METHODS(FObject)
 

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -955,7 +955,10 @@ bool ClapAsVst3::gui_can_resize()
 
 bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height)
 {
-  return _wrappedview->request_resize(width, height);
+  if (_wrappedview)
+    return _wrappedview->request_resize(width, height);
+  else
+    return false;
 }
 
 bool ClapAsVst3::gui_request_show()


### PR DESCRIPTION
This passes to gui.set_scale. It's pretty critical to make VST3 and CLAP work identicially on bitwig linux.