### PR TITLE
Implement SingleComponentEffect::getBusInfo and fix Ardour

### DIFF
--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -391,19 +391,27 @@ void ProcessAdapter::process(Steinberg::Vst::ProcessData& data)
     auto inbusses = _audioinputs->size();
     for (auto i = 0U; i < inbusses; ++i)
     {
-      if (_vstdata->inputs[i].numChannels > 0)
+      if (_vstdata->inputs[i].numChannels == (Steinberg::int32)_input_ports[i].channel_count)
+      {
         _input_ports[i].data32 = _vstdata->inputs[i].channelBuffers32;
+      }
       else
+      {
         doProcess = false;
+      }
     }
 
     auto outbusses = _audiooutputs->size();
     for (auto i = 0U; i < outbusses; ++i)
     {
-      if (_vstdata->outputs[i].numChannels > 0)
+      if (_vstdata->outputs[i].numChannels == (Steinberg::int32)_output_ports[i].channel_count)
+      {
         _output_ports[i].data32 = _vstdata->outputs[i].channelBuffers32;
+      }
       else
+      {
         doProcess = false;
+      }
     }
     if (doProcess)
       _plugin->process(_plugin, &_processData);

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -1483,3 +1483,33 @@ void ClapAsVst3::clearContextMenu()
   vst3ContextMenu.reset();
   contextmenuitems.clear();
 }
+
+tresult ClapAsVst3::getBusInfo(Vst::MediaType type, Vst::BusDirection dir, int32 index,
+                               Vst::BusInfo& bus)
+{
+  if (_plugin->_ext._audioports)
+  {
+    if (type == Vst::kAudio)
+    {
+      clap_audio_port_info_t info;
+      if (_plugin->_ext._audioports->get(_plugin->_plugin, (uint32_t)index, (dir == Vst::kInput), &info))
+      {
+        bus.mediaType = Vst::kAudio;
+        bus.channelCount = info.channel_count;
+        bus.direction = dir;
+        bus.busType = (info.flags & CLAP_AUDIO_PORT_IS_MAIN) ? Vst::kMain : Vst::kAux;
+        bus.flags = Vst::BusInfo::kDefaultActive;
+
+        UString wrapper(&bus.name[0], str16BufferSize(Steinberg::Vst::String128));
+        wrapper.assign(info.name, (Steinberg::int32)CLAP_NAME_SIZE);
+
+        return kResultOk;
+      }
+      else
+      {
+        return kResultFalse;
+      }
+    }
+  }
+  return SingleComponentEffect::getBusInfo(type, dir, index, bus);
+}

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -152,6 +152,8 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
                                         Vst::SpeakerArrangement* outputs, int32 numOuts) override;
   tresult PLUGIN_API getBusArrangement(Vst::BusDirection dir, int32 index,
                                        Vst::SpeakerArrangement& arr) override;
+  tresult PLUGIN_API getBusInfo(Vst::MediaType type, Vst::BusDirection dir, int32 index,
+                                Vst::BusInfo& bus) override;
   tresult PLUGIN_API activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index,
                                  TBool state) override;
 


### PR DESCRIPTION
Ardour uses getBusInfo to set up busses even though later we call setBusInfo, and so as a result didn't recieve the kDefaultActive flag we set when we setup processing.

This meant that Ardour would not activate auxilliary busses in multi-out effects so our process loop would find an invalid configuration and not call the clap.

Defacto this meant "no sound in shortcircuit xt in the wrapper in ardour". This imsplementation fixes the issue.