### PR TITLE
Fix gui_request_resize incorrectly checking can_resize

### DIFF
--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -217,12 +217,7 @@ class Plugin
   }
   bool request_resize(uint32_t width, uint32_t height)
   {
-    if (_parentHost->gui_can_resize())
-    {
-      _parentHost->gui_request_resize(width, height);
-      return true;
-    }
-    return false;
+    return _parentHost->gui_request_resize(width, height);
   }
   bool request_show()
   {


### PR DESCRIPTION
U-He plugins will request_resize when the user changes the scale from the menu. We check can_resize before we accept this request, but the [api](https://github.com/free-audio/clap/blob/c2c1dea9f72b38e23e285a9a10a5d936920895ab/include/clap/ext/gui.h#L32) shows that we should only check this when user drag is initiated (see 2nd resizing scenario)