### PR TITLE
VST3 rescans param names on params::request_rescan

### DIFF
--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -71,7 +71,9 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
                                std::function<Steinberg::Vst::UnitID(const char* modulepath)> getUnitId);
   static Vst3Parameter* create(uint8_t bus, uint8_t channel, uint8_t cc, Steinberg::Vst::ParamID id);
   // copies from the clap_param_info_t
+  uint32_t param_index_for_clap_get_info = 0;
   clap_id id = 0;
+
   void* cookie = nullptr;
   double min_value;  // minimum plain value
   double max_value;  // maximum plain value

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -782,6 +782,7 @@ void ClapAsVst3::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
       auto p = Vst3Parameter::create(
           &info, [&](const char* modstring) { return this->getOrCreateUnitInfo(modstring); });
       // auto p = Vst3Parameter::create(&info,nullptr);
+      p->param_index_for_clap_get_info = i;
       parameters.addParameter(p);
     }
   }
@@ -922,6 +923,17 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
         if (p->getNormalized() != newval)
         {
           p->setNormalized(newval);
+        }
+      }
+      if (flags & CLAP_PARAM_RESCAN_INFO)
+      {
+        // In this case, the name and module can also change.
+        // For now, don't rebuild the unit tree with modules but
+        // do rescan the name
+        clap_param_info_t info;
+        if (_plugin->_ext._params->get_info(_plugin->_plugin, p->param_index_for_clap_get_info, &info))
+        {
+          str8ToStr16(p->getInfo().title, info.name, str16BufferSize(p->getInfo().title));
         }
       }
     }


### PR DESCRIPTION
request_rescan with CLAP_PARAM_RESCAN_INFO may invalidate the name, module, or several other flags. The wrapper up until now just invalidated the value and re-ran the value to text.

Shortcircuit allows users to rename macros easily and the clap correctly calls params_rescan which results in bitwig re-displaying the clap name. The VST3 and AUv2 don't do this.

This commit fixes the VST3 with a partial correction and a comment. The partical correction is to re-acquire the parameter name in a RESCAN_INFO case. The comment explains that we do not re-acquire the module and build the entire tree.

Would appreciate careful review here. It fixes the shortcircuit bug but this is pretty fundamental code.