### PR TITLE
close app if window closed, macOS standalone

### DIFF
--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -145,6 +145,11 @@
   freeaudio::clap_wrapper::standalone::mainStartAudio();
 }
 
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender
+{
+  return true;
+}
+
 - (void)applicationWillTerminate:(NSNotification *)aNotification
 {
   LOG << "applicationWillTerminate shutdown" << std::endl;


### PR DESCRIPTION
Previously when closing the standalone window on macOS with the x button (as opposed to cmd+q) the app would continue running - this kills the app when the window closes. 