### PR TITLE
macOS standalone request_callback timer

### DIFF
--- a/src/detail/standalone/macos/AppDelegate.h
+++ b/src/detail/standalone/macos/AppDelegate.h
@@ -6,7 +6,9 @@
 {
   // AudioSettingsWindowDelegate *audioSettingsWindowDelegate;
 }
-@property(assign) IBOutlet NSWindow *window;
+
+@property(assign) NSTimer* requestCallbackTimer;
+@property(assign) IBOutlet NSWindow* window;
 
 - (IBAction)openAudioSettingsWindow:(id)sender;
 

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -117,9 +117,10 @@ struct StandaloneHost : Clap::IHost
   {
     TRACE;
   }
+  std::atomic<bool> callbackRequested{false};
   void request_callback() override
   {
-    TRACE;
+    callbackRequested = true;
   }
   void setupWrapperSpecifics(const clap_plugin_t *plugin) override
   {

--- a/src/detail/standalone/windows/helpers.cpp
+++ b/src/detail/standalone/windows/helpers.cpp
@@ -70,6 +70,16 @@ double getScale(::HWND window)
   return static_cast<double>(::GetDpiForWindow(window)) / static_cast<double>(USER_DEFAULT_SCREEN_DPI);
 }
 
+void startTimer(::HWND window, UINT_PTR timerId, UINT intervalMs)
+{
+  ::SetTimer(window, timerId, intervalMs, (::TIMERPROC)NULL);
+}
+
+void stopTimer(::HWND window, UINT_PTR timerId)
+{
+  ::KillTimer(window, timerId);
+}
+
 void abort(unsigned int exitCode)
 {
   ::ExitProcess(exitCode);

--- a/src/detail/standalone/windows/helpers.cpp
+++ b/src/detail/standalone/windows/helpers.cpp
@@ -70,14 +70,15 @@ double getScale(::HWND window)
   return static_cast<double>(::GetDpiForWindow(window)) / static_cast<double>(USER_DEFAULT_SCREEN_DPI);
 }
 
-void startTimer(::HWND window, UINT_PTR timerId, UINT intervalMs)
+bool startTimer(::HWND window, UINT_PTR timerId, UINT intervalMs)
 {
-  ::SetTimer(window, timerId, intervalMs, (::TIMERPROC)NULL);
+  const auto res = ::SetTimer(window, timerId, intervalMs, (::TIMERPROC)NULL);
+  return res != 0;
 }
 
-void stopTimer(::HWND window, UINT_PTR timerId)
+bool stopTimer(::HWND window, UINT_PTR timerId)
 {
-  ::KillTimer(window, timerId);
+  return ::KillTimer(window, timerId);
 }
 
 void abort(unsigned int exitCode)

--- a/src/detail/standalone/windows/helpers.h
+++ b/src/detail/standalone/windows/helpers.h
@@ -34,8 +34,8 @@ bool closeWindow(::HWND window);
 bool checkWindowVisibility(::HWND window);
 unsigned int getCurrentDpi(::HWND window);
 double getScale(::HWND window);
-void startTimer(::HWND window, UINT_PTR timerId, UINT intervalMs);
-void stopTimer(::HWND window, UINT_PTR timerId);
+bool startTimer(::HWND window, UINT_PTR timerId, UINT intervalMs);
+bool stopTimer(::HWND window, UINT_PTR timerId);
 
 void abort(unsigned int exitCode = EXIT_FAILURE);
 void quit(unsigned int exitCode = EXIT_SUCCESS);

--- a/src/detail/standalone/windows/helpers.h
+++ b/src/detail/standalone/windows/helpers.h
@@ -34,6 +34,8 @@ bool closeWindow(::HWND window);
 bool checkWindowVisibility(::HWND window);
 unsigned int getCurrentDpi(::HWND window);
 double getScale(::HWND window);
+void startTimer(::HWND window, UINT_PTR timerId, UINT intervalMs);
+void stopTimer(::HWND window, UINT_PTR timerId);
 
 void abort(unsigned int exitCode = EXIT_FAILURE);
 void quit(unsigned int exitCode = EXIT_SUCCESS);

--- a/src/detail/standalone/windows/host_window.h
+++ b/src/detail/standalone/windows/host_window.h
@@ -24,7 +24,7 @@ struct HostWindow
   int onWindowPosChanged(::LPARAM lParam);
   int onSysCommand(::HWND hWnd, ::UINT uMsg, ::WPARAM wParam, ::LPARAM lParam);
   int onDestroy();
-
+  int onTimerEvent(::WPARAM wParam);
   std::shared_ptr<Clap::Plugin> m_clapPlugin;
   const clap_plugin_t* m_plugin;
   const clap_plugin_gui_t* m_pluginGui;

--- a/src/detail/standalone/windows/host_window.h
+++ b/src/detail/standalone/windows/host_window.h
@@ -31,6 +31,7 @@ struct HostWindow
   const clap_plugin_state_t* m_pluginState;
   freeaudio::clap_wrapper::standalone::StandaloneHost* m_standaloneHost;
   std::vector<COMDLG_FILTERSPEC> m_fileTypes{{L"clapwrapper", L"*.clapwrapper"}};
+  bool m_isTimerRunning{false};
 
   // SettingsWindow m_settingsWindow;
   wil::unique_hwnd m_hWnd;


### PR DESCRIPTION
Does much the same as the windows PR, but with objc timers - objc isn't my strong suit, so any sanity checking appreciated. 

Also, my previous PR for the `applicationShouldTerminateAfterLastWindowClosed` implementation inadvertently led to a segfault on close, when we reached the section of `applicationWillTerminate` where the window stuff is freed. According to the [docs](https://developer.apple.com/documentation/appkit/nswindow/1419662-close), `[window close]` by default calls `[window release]`, so my working theory is that it was leading to a double free when closed that way. 
To fix it, I implemented `windowWillClose`, and set the window member to `nil` there. Then in `applicationWillTerminate`, I check if `self.window=nil`, and if it *isn't*, call `[[self window] release]`, and that seems to have fixed it!