### PR TITLE
off by one error in value conversion

### DIFF
--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -50,6 +50,10 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
   bool fromString(const Steinberg::Vst::TChar* string, Steinberg::Vst::ParamValue& valueNormalized) const override;
 #endif
 
+  // for asClapValue() and asVst3Value()
+  // regarding conversion and the meaning of stepCount take a look here:
+  // https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Parameters+Automation/Index.html#conversion-of-normalized-values
+
   inline double asClapValue(double vst3value) const
   {
     if (info.stepCount > 0)
@@ -63,7 +67,7 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
     auto& info = this->getInfo();
     if (info.stepCount > 0)
     {
-      return (clapvalue - min_value) / float(info.stepCount + 1);
+      return floor(clapvalue - min_value) / float(info.stepCount);
     }
     return (clapvalue - min_value) / (max_value - min_value);
   }

--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -26,6 +26,7 @@
 #include <clap/ext/params.h>
 #include <public.sdk/source/vst/vstparameters.h>
 #include <functional>
+#include <cmath>
 
 class Vst3Parameter : public Steinberg::Vst::Parameter
 {

--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -54,7 +54,7 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
   {
     if (info.stepCount > 0)
     {
-      return (vst3value * info.stepCount + 1) + min_value;
+      return (vst3value * info.stepCount) + min_value;
     }
     return (vst3value * (max_value - min_value)) + min_value;
   }


### PR DESCRIPTION
@baconpaul this is a fix for issue https://github.com/free-audio/clap-wrapper/issues/300

I wonder if the function below `inline double asVst3Value(double clapvalue) const` the `+1` needs to be removed, too.