### PR TITLE
If MACOSX_EMBEDDED is there, use it for plist

### DIFF
--- a/cmake/shared_prologue.cmake
+++ b/cmake/shared_prologue.cmake
@@ -190,8 +190,23 @@ endfunction(macos_bundle_flag)
 # location optionally. Called by the target_add_xyz_wrapper functions to allow self contained
 # non  relinked macos bundles
 function(macos_include_clap_in_bundle)
-    set(oneValueArgs TARGET MACOS_EMBEDDED_CLAP_LOCATION)
+    set(oneValueArgs
+            TARGET
+            MACOS_EMBEDDED_CLAP_LOCATION
+            MACOSX_EMBEDDED_CLAP_LOCATION
+    )
+
     cmake_parse_arguments(MBC "" "${oneValueArgs}" "" ${ARGN})
+
+    if (NOT DEFINED MBC_MACOS_EMBEDDED_CLAP_LOCATION AND DEFINED MBC_MACOSX_EMBEDDED_CLAP_LOCATION)
+        # resolve the alias
+        set(MBC_MACOS_EMBEDDED_CLAP_LOCATION ${MBC_MACOSX_EMBEDDED_CLAP_LOCATION})
+    endif()
+
+    if (NOT DEFINED MBC_MACOSX_EMBEDDED_CLAP_LOCATION AND DEFINED MBC_MACOS_EMBEDDED_CLAP_LOCATION)
+        # resolve the alias
+        set(MBC_MACOSX_EMBEDDED_CLAP_LOCATION ${MBC_MACOS_EMBEDDED_CLAP_LOCATION})
+    endif()
 
     if (NOT APPLE)
         message(WARNING "Calling macos_include_clap_in_bundle on non APPLE system. Is this intentional?")
@@ -199,7 +214,7 @@ function(macos_include_clap_in_bundle)
     endif()
 
     if (NOT ${MBC_MACOS_EMBEDDED_CLAP_LOCATION} STREQUAL "")
-        message(STATUS "clap-wraiier: including embedded clap in target ${MBC_TARGET}")
+        message(STATUS "clap-wrapper: including embedded clap in target ${MBC_TARGET}")
         add_custom_command(TARGET ${MBC_TARGET} PRE_BUILD
                 WORKING_DIRECTORY $<TARGET_PROPERTY:${MBC_TARGET},LIBRARY_OUTPUT_DIRECTORY>
                 COMMAND ${CMAKE_COMMAND} -E echo "Installing ${MBC_MACOS_EMBEDDED_CLAP_LOCATION} in $<TARGET_PROPERTY:${MBC_TARGET},MACOSX_BUNDLE_BUNDLE_NAME>.$<TARGET_PROPERTY:${MBC_TARGET},BUNDLE_EXTENSION>/Contents/PlugIns/$<TARGET_PROPERTY:${MBC_TARGET},MACOSX_BUNDLE_BUNDLE_NAME>.clap"

--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -90,6 +90,22 @@ function(target_add_auv2_wrapper)
                 "$<TARGET_FILE:${clpt}>" "${AUV2_BUNDLE_VERSION}"
                 "${AUV2_MANUFACTURER_CODE}" "${AUV2_MANUFACTURER_NAME}"
         )
+    elseif (DEFINED AUV2_MACOSX_EMBEDDED_CLAP_LOCATION)
+        message(STATUS "clap-wrapper: building auv2 based on clap ${AUV2_MACOSX_EMBEDDED_CLAP_LOCATION}")
+        set(AUV2_SUBTYPE_CODE "----")
+        set(AUV2_INSTRUMENT_TYPE "aumu")
+
+        add_custom_command(
+                TARGET ${bhtg}
+                POST_BUILD
+                WORKING_DIRECTORY ${bhtgoutdir}
+                BYPRODUCTS ${bhtgoutdir}/auv2_Info.plist ${bhtgoutdir}/generated_entrypoints.hxx
+                COMMAND codesign -s - -f "$<TARGET_FILE:${bhtg}>"
+                COMMAND $<TARGET_FILE:${bhtg}> --fromclap
+                "${AUV2_OUTPUT_NAME}"
+                "${AUV2_MACOSX_EMBEDDED_CLAP_LOCATION}" "${AUV2_BUNDLE_VERSION}"
+                "${AUV2_MANUFACTURER_CODE}" "${AUV2_MANUFACTURER_NAME}"
+        )
     else ()
         if (NOT DEFINED AUV2_OUTPUT_NAME)
             message(FATAL_ERROR "clap-wrapper: target_add_auv2_wrapper requires an output name")

--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -24,9 +24,23 @@ function(target_add_auv2_wrapper)
             # - JUCE (use the JUCE AUV2 default)
             DICTIONARY_STREAM_FORMAT
 
+            # These two are aliases of each other but the one without the X
+            # came first and doesn't match the rest of CMake naming standards
             MACOS_EMBEDDED_CLAP_LOCATION
+            MACOSX_EMBEDDED_CLAP_LOCATION
             )
     cmake_parse_arguments(AUV2 "" "${oneValueArgs}" "" ${ARGN})
+
+
+    if (NOT DEFINED AUV2_MACOS_EMBEDDED_CLAP_LOCATION AND DEFINED AUV2_MACOSX_EMBEDDED_CLAP_LOCATION)
+        # resolve the alias
+        set(AUV2_MACOS_EMBEDDED_CLAP_LOCATION ${AUV2_MACOSX_EMBEDDED_CLAP_LOCATION})
+    endif()
+
+    if (NOT DEFINED AUV2_MACOSX_EMBEDDED_CLAP_LOCATION AND DEFINED AUV2_MACOS_EMBEDDED_CLAP_LOCATION)
+        # resolve the alias
+        set(AUV2_MACOSX_EMBEDDED_CLAP_LOCATION ${AUV2_MACOS_EMBEDDED_CLAP_LOCATION})
+    endif()
 
     if (NOT APPLE)
         message(STATUS "clap-wrapper: auv2 is only available on macOS")
@@ -231,7 +245,7 @@ function(target_add_auv2_wrapper)
     set_target_properties(${AUV2_TARGET} PROPERTIES XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${AUV2_BUNDLE_IDENTIFIER}.component")
 
     macos_include_clap_in_bundle(TARGET ${AUV2_TARGET}
-            MACOS_EMBEDDED_CLAP_LOCATION ${AUV2_MACOS_EMBEDDED_CLAP_LOCATION})
+            MACOS_EMBEDDED_CLAP_LOCATION ${AUV2_MACOSX_EMBEDDED_CLAP_LOCATION})
     macos_bundle_flag(TARGET ${AUV2_TARGET})
 
     if (${CLAP_WRAPPER_COPY_AFTER_BUILD})

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -236,9 +236,17 @@ int main(int argc, char **argv)
     try
     {
       auto p = fs::path{clapfile};
-      // This is a hack for now - we get to the dll
-      p = p.parent_path().parent_path().parent_path();
-      clapfile = p.u8string();
+      if (fs::is_directory(p))
+      {
+        std::cout << "  - CLAP is a directory. Assuming bundle\n";
+      }
+      else
+      {
+        // This is a hack for now - we get to the dll
+        std::cout << "  - CLAP is a regular file. Assuming dll in bundle\n";
+        p = p.parent_path().parent_path().parent_path();
+        clapfile = p.u8string();
+      }
     }
     catch (const fs::filesystem_error &e)
     {


### PR DESCRIPTION
MACOSX_EMBEDDED_ allows you to embed a clap as a subordinate framework of your wrapped component, but we didn't use that handed in clap to generate the Plist. Fix that by using it if available.