### PR TITLE
AUV2 Param refresh

### DIFF
--- a/src/detail/auv2/parameter.cpp
+++ b/src/detail/auv2/parameter.cpp
@@ -10,6 +10,12 @@ Parameter::Parameter(clap_param_info_t &clap_param)
   _cfstring = CFStringCreateWithCString(NULL, _info.name, kCFStringEncodingUTF8);
 }
 
+void Parameter::resetInfo(const clap_param_info_t &i)
+{
+  _info = i;
+  CFRelease(_cfstring);
+  _cfstring = CFStringCreateWithCString(NULL, _info.name, kCFStringEncodingUTF8);
+}
 Parameter::~Parameter()
 {
   CFRelease(_cfstring);

--- a/src/detail/auv2/parameter.h
+++ b/src/detail/auv2/parameter.h
@@ -45,6 +45,8 @@ class Parameter
     return _cfstring;
   }
 
+  void resetInfo(const clap_param_info_t& i);
+
  private:
   clap_param_info_t _info;
   CFStringRef _cfstring;


### PR DESCRIPTION
AUV2 cached param info so the rescan messages were used by hosts who then got a stale cache. Fix this by rebuilding the info cache when a rescan occurs.