### PR TITLE
A tiny logic pro resize fix

### DIFF
--- a/src/detail/auv2/auv2_shared.mm
+++ b/src/detail/auv2/auv2_shared.mm
@@ -12,7 +12,7 @@ bool auv2shared_mm_request_resize(const clap_window_t* win, uint32_t w, uint32_t
   if (!win) return false;
 
   auto* nsv = (NSView*)win;
-  [nsv setFrameSize:NSMakeSize(w, h)];
+  [nsv setFrame:NSMakeRect(0, 0, w, h)];
 
   return false;
 }

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -157,8 +157,6 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 }
 - (void)setFrame:(NSRect)newSize
 {
-  LOGINFO("[clap-wrapper] new size");
-
   [super setFrame:newSize];
   auto gui = ui._plugin->_ext._gui;
   gui->set_scale(ui._plugin->_plugin, 1.0);


### PR DESCRIPTION
Rather than setSize we want setFrame(0,0,w,h) to avoid repositioning imporerly in the logic wrapped window with auv2 resize (small fix to bc32cb3e4eedc5806bc73a284c43f9e5aa24a87d)