### PR TITLE
Remove some unused bundle locating code

### DIFF
--- a/src/detail/clap/mac_helpers.mm
+++ b/src/detail/clap/mac_helpers.mm
@@ -22,27 +22,8 @@ namespace fs = ghc::filesystem;
 
 #include <Foundation/Foundation.h>
 
-@interface free_audio_clap_wrapper_ffowefe : NSObject
-- (void)foo;
-@end
-
-@implementation free_audio_clap_wrapper_ffowefe
-- (void)foo
-{
-}
-@end
-
 namespace Clap
 {
-/*
-    this could be anything apparantly
-*/
-
-NSBundle *getMyBundle()
-{
-  return [NSBundle bundleForClass:[free_audio_clap_wrapper_ffowefe class]];
-}
-
 fs::path sharedLibraryBundlePath()
 {
   Dl_info info;


### PR DESCRIPTION
We had unused bundle locating code which added an interface and although it wasn't used, it would create a warning at valudation in some circumstances