### PR TITLE
Windows standalone: Use default entry point, unicode argv

### DIFF
--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -144,20 +144,6 @@ function(target_add_standalone_wrapper)
             target_compile_definitions(${SA_TARGET} PRIVATE _SILENCE_CLANG_COROUTINE_MESSAGE)
         endif()
 
-        if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-            target_link_options(
-                ${SA_TARGET}
-                PRIVATE
-                /entry:mainCRTStartup
-                )
-        elseif(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
-            target_link_options(
-                ${SA_TARGET}
-                PRIVATE
-                -Wl,/entry:mainCRTStartup
-                )
-        endif()
-
         target_link_libraries(${SA_TARGET} PRIVATE base-sdk-wil ComCtl32.Lib)
 
     elseif(UNIX)

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -2,6 +2,22 @@
 
 namespace freeaudio::clap_wrapper::standalone::windows_standalone
 {
+std::pair<int, std::vector<std::string>> getArgs()
+{
+  int argc{0};
+  wil::unique_hlocal_ptr<wchar_t*[]> buffer;
+  buffer.reset(::CommandLineToArgvW(::GetCommandLineW(), &argc));
+
+  std::vector<std::string> argv;
+
+  for (int i = 0; i < argc; i++)
+  {
+    argv.emplace_back(toUTF8(buffer[i]));
+  }
+
+  return {argc, argv};
+}
+
 ::HMODULE getInstance()
 {
   ::HMODULE module;
@@ -591,11 +607,9 @@ void SystemMenu::populate(::HWND hwnd)
   }
 }
 
-Plugin::Plugin(const clap_plugin_entry* entry, int argc, char** argv)
+Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin)
 {
-  plugin.clap =
-      freeaudio::clap_wrapper::standalone::mainCreatePlugin(entry, PLUGIN_ID, PLUGIN_INDEX, argc, argv);
-
+  plugin.clap = clapPlugin;
   plugin.plugin = plugin.clap->_plugin;
   plugin.gui = plugin.clap->_ext._gui;
   plugin.state = plugin.clap->_ext._state;

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -2,7 +2,7 @@
 
 namespace freeaudio::clap_wrapper::standalone::windows_standalone
 {
-std::pair<int, std::vector<std::string>> getArgs()
+std::vector<std::string> getArgs()
 {
   int argc{0};
   wil::unique_hlocal_ptr<wchar_t*[]> buffer;
@@ -15,7 +15,7 @@ std::pair<int, std::vector<std::string>> getArgs()
     argv.emplace_back(toUTF8(buffer[i]));
   }
 
-  return {argc, argv};
+  return argv;
 }
 
 ::HMODULE getInstance()

--- a/src/detail/standalone/windows/windows_standalone.h
+++ b/src/detail/standalone/windows/windows_standalone.h
@@ -35,6 +35,7 @@ using namespace winrt::Windows::Data::Json;
 
 namespace freeaudio::clap_wrapper::standalone::windows_standalone
 {
+std::pair<int, std::vector<std::string>> getArgs();
 ::HMODULE getInstance();
 ::HFONT getFontFromSystem(int name = DEFAULT_GUI_FONT);
 ::HFONT getScaledFontFromSystem(double scale);
@@ -372,7 +373,7 @@ struct Plugin final : public Window
     const clap_plugin_state_t* state;
   };
 
-  explicit Plugin(const clap_plugin_entry* entry, int argc, char** argv);
+  explicit Plugin(std::shared_ptr<Clap::Plugin> clapPlugin);
 
   std::optional<clap_gui_resize_hints> getResizeHints();
   void refreshLayout();

--- a/src/detail/standalone/windows/windows_standalone.h
+++ b/src/detail/standalone/windows/windows_standalone.h
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <functional>
 #include <limits>
-#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -35,7 +34,7 @@ using namespace winrt::Windows::Data::Json;
 
 namespace freeaudio::clap_wrapper::standalone::windows_standalone
 {
-std::pair<int, std::vector<std::string>> getArgs();
+std::vector<std::string> getArgs();
 ::HMODULE getInstance();
 ::HFONT getFontFromSystem(int name = DEFAULT_GUI_FONT);
 ::HFONT getScaledFontFromSystem(double scale);

--- a/src/wrapasstandalone_windows.cpp
+++ b/src/wrapasstandalone_windows.cpp
@@ -1,6 +1,6 @@
 #include "detail/standalone/windows/windows_standalone.h"
 
-int main(int argc, char** argv)
+int wWinMain(::HINSTANCE, ::HINSTANCE, wchar_t*, int)
 {
   auto coUninitialize{wil::CoInitializeEx(COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)};
 
@@ -33,7 +33,19 @@ int main(int argc, char** argv)
     return 3;
   }
 
-  freeaudio::clap_wrapper::standalone::windows_standalone::Plugin plugin{entry, argc, argv};
+  auto args{freeaudio::clap_wrapper::standalone::windows_standalone::getArgs()};
+
+  std::vector<char*> argv;
+
+  for (int i = 0; i < args.first; i++)
+  {
+    argv.emplace_back(args.second[i].data());
+  }
+
+  auto clapPlugin{freeaudio::clap_wrapper::standalone::mainCreatePlugin(entry, PLUGIN_ID, PLUGIN_INDEX,
+                                                                        args.first, argv.data())};
+
+  freeaudio::clap_wrapper::standalone::windows_standalone::Plugin plugin{clapPlugin};
 
   return freeaudio::clap_wrapper::standalone::windows_standalone::run();
 }

--- a/src/wrapasstandalone_windows.cpp
+++ b/src/wrapasstandalone_windows.cpp
@@ -1,6 +1,7 @@
 #include "detail/standalone/windows/windows_standalone.h"
 
-int wWinMain(::HINSTANCE, ::HINSTANCE, wchar_t*, int)
+int WINAPI wWinMain(::HINSTANCE /* hInstance */, ::HINSTANCE /* hPrevInstance */, ::PWSTR /* pCmdLine */,
+                    int /* nCmdShow */)
 {
   auto coUninitialize{wil::CoInitializeEx(COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)};
 

--- a/src/wrapasstandalone_windows.cpp
+++ b/src/wrapasstandalone_windows.cpp
@@ -38,13 +38,13 @@ int WINAPI wWinMain(::HINSTANCE /* hInstance */, ::HINSTANCE /* hPrevInstance */
 
   std::vector<char*> argv;
 
-  for (int i = 0; i < args.first; i++)
+  for (auto i = 0; i < args.size(); i++)
   {
-    argv.emplace_back(args.second[i].data());
+    argv.emplace_back(args[i].data());
   }
 
   auto clapPlugin{freeaudio::clap_wrapper::standalone::mainCreatePlugin(entry, PLUGIN_ID, PLUGIN_INDEX,
-                                                                        args.first, argv.data())};
+                                                                        argv.size(), argv.data())};
 
   freeaudio::clap_wrapper::standalone::windows_standalone::Plugin plugin{clapPlugin};
 


### PR DESCRIPTION
Switches argv to unicode.

Main function is now the default, wWinMain (which is more correct and allows us to skip setting /ENTRY linker flags, reducing CMake complexity).