### PR TITLE
fixing issue #330, reset is not being called when vst3 stops processing

### DIFF
--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -338,6 +338,12 @@ void Plugin::stop_processing()
   _plugin->stop_processing(_plugin);
 }
 
+void Plugin::reset()
+{
+  auto thisFn = AlwaysAudioThread();
+  _plugin->reset(_plugin);
+}
+
 //void Plugin::process(const clap_process_t* data)
 //{
 //  auto thisFn = AlwaysAudioThread();

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -178,6 +178,7 @@ class Plugin
   void deactivate() const;
   bool start_processing();
   void stop_processing();
+  void reset();
   // void process(const clap_process_t* data);
   const clap_plugin_gui_t* getUI() const;
 

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -309,6 +309,10 @@ tresult PLUGIN_API ClapAsVst3::setProcessing(TBool state)
     {
       _processing = false;
       _plugin->stop_processing();
+
+      // VST3 has no specific reset - but it should happen when setprocessing is being called
+      // https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Workflow+Diagrams/Audio+Processor+Call+Sequence.html
+      _plugin->reset();
     }
   }
   return result;


### PR DESCRIPTION
adds a call to reset() when processing is set to false.