### PR TITLE
Partial fix to VST3 flush

### DIFF
--- a/src/detail/shared/spinlock.h
+++ b/src/detail/shared/spinlock.h
@@ -1,0 +1,41 @@
+
+#pragma once
+#include <atomic>
+namespace ClapWrapper::detail::shared
+{
+struct SpinLock
+{
+ private:
+  std::atomic<bool> locked_{false};
+
+ public:
+  SpinLock() : locked_(false)
+  {
+  }
+
+  void lock()
+  {
+    while (locked_.exchange(true, std::memory_order_acquire))
+    {
+    }
+  }
+
+  void unlock()
+  {
+    locked_.store(false, std::memory_order_release);
+  }
+};
+
+struct SpinLockGuard
+{
+  SpinLock &lock;
+  SpinLockGuard(SpinLock &l) : lock(l)
+  {
+    lock.lock();
+  };
+  ~SpinLockGuard()
+  {
+    lock.unlock();
+  }
+};
+}  // namespace ClapWrapper::detail::shared

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -720,7 +720,7 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t* event)
         if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), param_id) !=
             _gesturedParameters.end())
         {
-          _automation->onPerformEdit(ev);
+          if (_automation) _automation->onPerformEdit(ev);
         }
 
         // it also needs to be communicated to the audio thread,otherwise the parameter jumps back to the original value
@@ -730,7 +730,7 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t* event)
 
         // the vst3 validator from the VST3 SDK does not provide always an object to output parameters, probably other hosts won't to that, too
         // therefore we are cautious.
-        if (_vstdata->outputParameterChanges)
+        if (_vstdata && _vstdata->outputParameterChanges)
         {
           auto list = _vstdata->outputParameterChanges->addParameterData(param_id, index);
 
@@ -756,7 +756,7 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t* event)
       auto ev = (clap_event_param_gesture*)event;
       auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
       _gesturedParameters.push_back(param->getInfo().id);
-      _automation->onBeginEdit(param->getInfo().id);
+      if (_automation) _automation->onBeginEdit(param->getInfo().id);
     }
       return true;
 
@@ -770,7 +770,7 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t* event)
       if (n != _gesturedParameters.end())
       {
         _gesturedParameters.erase(n, _gesturedParameters.end());
-        _automation->onEndEdit(param->getInfo().id);
+        if (_automation) _automation->onEndEdit(param->getInfo().id);
       }
     }
       return true;

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -202,6 +202,9 @@ tresult PLUGIN_API ClapAsVst3::process(Vst::ProcessData& data)
   {
     return kNotInitialized;
   }
+
+  ClapWrapper::detail::shared::SpinLockGuard spinLock(_processOrFlushLock);
+
   auto thisFn = _plugin->AlwaysAudioThread();
 
   // FIXME: At this transition we probably need to be careful that we aren't in a flush
@@ -1221,6 +1224,9 @@ void ClapAsVst3::onIdle()
 
   if (_requestedFlush)
   {
+    // Lock against ::process with a spin lock
+    ClapWrapper::detail::shared::SpinLockGuard everLock(_processOrFlushLock);
+    // Lock against setProcess with a mutex
     std::lock_guard lock(_processingLock);
 
     _requestedFlush = false;

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -362,6 +362,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   bool _active = false;
   os::State _os_attached;
   bool _processing = false;
+  std::atomic<bool> _processEverCalled{false};
   std::mutex _processingLock;
   std::atomic_bool _requestedFlush = false;
   std::atomic_bool _requestUICallback = false;

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -36,6 +36,7 @@
 #include "detail/shared/fixedqueue.h"
 #include "detail/ara/ara.h"
 #include "detail/vst3/aravst3.h"
+#include "detail/shared/spinlock.h"
 #include <mutex>
 
 using namespace Steinberg;
@@ -362,9 +363,12 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   bool _active = false;
   os::State _os_attached;
   bool _processing = false;
+
   std::atomic<bool> _processEverCalled{false};
   std::mutex _processingLock;
   std::atomic_bool _requestedFlush = false;
+  ClapWrapper::detail::shared::SpinLock _processOrFlushLock;
+
   std::atomic_bool _requestUICallback = false;
   bool _missedLatencyRequest = false;
 


### PR DESCRIPTION
This is a partial fix to the VST3 flush issue we are facint.  #332. 

It is a partial fix for two reasons

1. The use of _processEverCalled doesn't preclude the race if we actually *are* flushing. We need antoerh atomic pair / spin lock Alas because of reaper we need that extra every called check since the prior check on _active was too conservative and a check just on _processing will blow up reaper

2. With this in place, we flush and don't crash, but don't send automation events. Compare the way deactivated six sines works in bitwig with and without this. The CLAP will send automatino events when deactivated and the VST3 wont. This is because of the lack of an _automation and _vstdata structure to generate events.

Maybe we merge this into next and work forward or maybe not but wanted to get this in place for reivew