### PR TITLE
Create portable CIDs on Mac/Lin

### DIFF
--- a/include/clapwrapper/vst3.h
+++ b/include/clapwrapper/vst3.h
@@ -24,9 +24,19 @@ static const CLAP_CONSTEXPR char CLAP_PLUGIN_AS_VST3[] = "clap.plugin-info-as-vs
 typedef uint8_t array_of_16_bytes[16];
 
 // clang-format off
-// VST3GUID allows you to provide the 4 uint32_t parts of the GUID and transforms them to the 16 byte array
-#if WIN
-#define VST3GUID(g1, g2, g3, g4) \
+// COMPONENT allows you to provide the 4 uint32_t parts of the GUID and transforms them to the 16 byte array
+// To use this to port an existing VST3
+// 1. Run the vst3 validator
+// 2. Find the line cid = 30D2C648CCAABA57976D20DEFF9B93C1 in the output
+// 3. Implement this extension to provide an info with (for example)
+//      static array_of_16_bytes cid COMPONENT_ID(0x30D2C648, 0xCCAABA57, 0x976D20DE, 0xFF9B93C1);
+//      static clap_plugin_info_as_vst3 info {
+//           "Vendor",
+//            &cid,
+//            ""
+//      };
+//      return &info;
+#define COMPONENT_ID(g1, g2, g3, g4) \
 {                                \
 (uint8_t)((g1 & 0x000000FF)      ),    \
 (uint8_t)((g1 & 0x0000FF00) >>  8),    \
@@ -45,29 +55,6 @@ typedef uint8_t array_of_16_bytes[16];
 (uint8_t)((g4 & 0x0000FF00) >>  8),    \
 (uint8_t)((g4 & 0x000000FF)      ),    \
 }
-
-#else
-#define VST3GUID(g1, g2, g3, g4) \
-{                                \
-(uint8_t)((g1 & 0xFF000000) >> 24),    \
-(uint8_t)((g1 & 0x00FF0000) >> 16),    \
-(uint8_t)((g1 & 0x0000FF00) >>  8),    \
-(uint8_t)((g1 & 0x000000FF)      ),    \
-(uint8_t)((g2 & 0xFF000000) >> 24),    \
-(uint8_t)((g2 & 0x00FF0000) >> 16),    \
-(uint8_t)((g2 & 0x0000FF00) >>  8),    \
-(uint8_t)((g2 & 0x000000FF)      ),    \
-(uint8_t)((g3 & 0xFF000000) >> 24),    \
-(uint8_t)((g3 & 0x00FF0000) >> 16),    \
-(uint8_t)((g3 & 0x0000FF00) >>  8),    \
-(uint8_t)((g3 & 0x000000FF)      ),    \
-(uint8_t)((g4 & 0xFF000000) >> 24),    \
-(uint8_t)((g4 & 0x00FF0000) >> 16),    \
-(uint8_t)((g4 & 0x0000FF00) >>  8),    \
-(uint8_t)((g4 & 0x000000FF)      ),    \
-}
-
-#endif
 
 // clang-format on
 

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -245,6 +245,23 @@ IPluginFactory* GetPluginFactoryEntryPoint()
         }
 
         memcpy(&lcid, &g, sizeof(TUID));
+
+#if !COM_COMPATIBLE
+        /*
+         * The steinberg APIs retain 'com compatability' by flipping the first pair of ints
+         * in the UID. That results in CID which are not compatbile across platforms and so
+         * mac won't load a win session etc.
+         *
+         * We apply that flip on MAC and LIN also in the wrapper here. The flip is: The first
+         * 8 bits endian, and then the pair of 4 bit endians
+         */
+
+        std::swap(lcid[0], lcid[3]);
+        std::swap(lcid[1], lcid[2]);
+
+        std::swap(lcid[4], lcid[5]);
+        std::swap(lcid[6], lcid[7]);
+#endif
       }
 
       // features ----------------------------------------


### PR DESCRIPTION
The automatic creation of CIDs using the VST3 SDK produced different GUID orders on MAC/LIN vs WIN (COM_COMPATBILE). Basically if COM_COMPATBILE the VSt3 SDK in absense of an explicit bit pattern onto the FUID would do an 8 bit endian then pair of 4 bit endian flips. This manifested in our vst3.h extension also.

So clean all this up. With this change setting an expilcit CID using CMake or the extension, or using the calculated one from the id with the hash, generates the same CID on mac/win/lin so load compatability across platforms is preserved.

This also means VST3 generated prior to this diff using the automatic mechanism will have their CID changed on macos and linux. Before we merge to Main we may want to allow a control that avoids this skip, or investigate whether a VSt3 can have two CIDs and then advertise both. But we should get this to next asap.