### PR TITLE
Remove an extra semicolon which trips up some gcc in pedantic mode

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -329,7 +329,7 @@ tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* input
                                                   Vst::SpeakerArrangement* outputs, int32 numOuts)
 {
   return super::setBusArrangements(inputs, numIns, outputs, numOuts);
-};
+}
 
 tresult PLUGIN_API ClapAsVst3::getBusArrangement(Vst::BusDirection dir, int32 index,
                                                  Vst::SpeakerArrangement& arr)


### PR DESCRIPTION
and which also isn't needed