### PR TITLE
Survive probing with bus layouts

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -328,6 +328,50 @@ tresult PLUGIN_API ClapAsVst3::setProcessing(TBool state)
 tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* inputs, int32 numIns,
                                                   Vst::SpeakerArrangement* outputs, int32 numOuts)
 {
+  if (!_plugin->_ext._audioports)
+  {
+    return kResultFalse;
+    ;
+  }
+
+  int32_t inc = _plugin->_ext._audioports->count(_plugin->_plugin, true);
+  int32_t ouc = _plugin->_ext._audioports->count(_plugin->_plugin, false);
+  if (inc != numIns || ouc != numOuts)
+  {
+    return kResultFalse;
+    ;
+  }
+
+  for (int i = 0; i < numIns; ++i)
+  {
+    clap_audio_port_info_t info;
+    _plugin->_ext._audioports->get(_plugin->_plugin, i, true, &info);
+    Vst::SpeakerArrangement sa{0};
+    for (auto c = 0U; c < info.channel_count; ++c)
+    {
+      sa = (sa << 1) + 1;
+    }
+    if (inputs[i] != sa)
+    {
+      return kResultFalse;
+    }
+  }
+
+  for (int i = 0; i < numOuts; ++i)
+  {
+    clap_audio_port_info_t info;
+    _plugin->_ext._audioports->get(_plugin->_plugin, i, false, &info);
+    Vst::SpeakerArrangement sa{0};
+    for (auto c = 0U; c < info.channel_count; ++c)
+    {
+      sa = (sa << 1) + 1;
+    }
+    if (outputs[i] != sa)
+    {
+      return kResultFalse;
+    }
+  }
+
   return super::setBusArrangements(inputs, numIns, outputs, numOuts);
 }
 

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -331,7 +331,6 @@ tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* input
   if (!_plugin->_ext._audioports)
   {
     return kResultFalse;
-    ;
   }
 
   int32_t inc = _plugin->_ext._audioports->count(_plugin->_plugin, true);
@@ -339,7 +338,6 @@ tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement* input
   if (inc != numIns || ouc != numOuts)
   {
     return kResultFalse;
-    ;
   }
 
   for (int i = 0; i < numIns; ++i)


### PR DESCRIPTION
We know our channel count; if we get asked for a bus layout in the VST3 with a different channel count, we should say no. So when we get a call to setBusArrangement, pull the bus info, construct a speaker arrangement (although probably some ambisonic work to do here in the future) and say no if i get a channel count i don't support

I think this will solve #326
I know it will solve https://forum.cockos.com/showthread.php?p=2840258#post2840258