### PR TITLE
Revert "Fix a win standalone HDPI resize bug (#345)"

### DIFF
--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -1104,7 +1104,7 @@ Plugin::Plugin(const clap_plugin_entry* entry, int argc, char** argv)
   {
     if (placement.showCmd != SW_MAXIMIZE)
     {
-      adjustSize(scale * width, scale * height);
+      adjustSize(width, height);
     }
 
     return true;


### PR DESCRIPTION
This commit put the scale in the wrong place