### PR TITLE
Fix a lifetime problem in parameter cfName when rescan happens

### DIFF
--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -466,7 +466,11 @@ OSStatus WrapAsAUV2::GetParameterInfo(AudioUnitScope inScope, AudioUnitParameter
         }
       }
 
-      flags |= kAudioUnitParameterFlag_HasCFNameString;
+      /*
+       * The CFString() used from the param can reset which releases it. So add a ref count
+       * and ask the param to release it too
+       */
+      flags |= kAudioUnitParameterFlag_HasCFNameString | kAudioUnitParameterFlag_CFNameRelease;
 
       outParameterInfo.flags = flags;
 
@@ -474,6 +478,7 @@ OSStatus WrapAsAUV2::GetParameterInfo(AudioUnitScope inScope, AudioUnitParameter
       // strcpy(outParameterInfo.name, info.name);
       memset(outParameterInfo.name, 0, sizeof(outParameterInfo.name));
 
+      CFRetain(f->CFString());
       outParameterInfo.cfNameString = f->CFString();
       outParameterInfo.minValue = info.min_value;
       outParameterInfo.maxValue = info.max_value;


### PR DESCRIPTION
Rescan resets info on the internal parameter which CFReleases the associated cfname. This only happens on rescan.

The parameter info has a cfNameString which is just a copy of that ref, unretained. The lifetime of that parameter cfstring needs to be the sweep

Therefore you can

1. Scan and reset the cfstring
2. Which is attached still to a parameter
3. And, occasionally, blammo memory corruption

So instead use the kAudioUnitParameterFlag_CFNameRelease option and retain the string so *both* the parameter and the AU parameter info need to be done with it.