### PR TITLE
Rename appDelegate class name

### DIFF
--- a/src/detail/standalone/macos/AppDelegate.h
+++ b/src/detail/standalone/macos/AppDelegate.h
@@ -2,7 +2,7 @@
 
 // @class AudioSettingsWindowDelegate;
 
-@interface AppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
+@interface ClapWrapperAppDelegate : NSObject <NSApplicationDelegate, NSWindowDelegate>
 {
   // AudioSettingsWindowDelegate *audioSettingsWindowDelegate;
 }

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -10,7 +10,7 @@
 
 #include "detail/clap/fsutil.h"
 
-@interface AppDelegate ()
+@interface ClapWrapperAppDelegate ()
 
 @end
 
@@ -25,7 +25,7 @@
 
 @end
 
-@implementation AppDelegate
+@implementation ClapWrapperAppDelegate
 
 - (void)timerCallback:(NSTimer *)instance
 {

--- a/src/detail/standalone/macos/MainMenu.xib
+++ b/src/detail/standalone/macos/MainMenu.xib
@@ -12,7 +12,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
+        <customObject id="Voe-Tx-rLC" customClass="ClapWrapperAppDelegate">
             <connections>
                 <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
             </connections>


### PR DESCRIPTION
theres a common practice to have a class called AppDelegate but if another windowing library decides to bake that in (which matt's visage does) you get a link conflict. So use ClapWrapperAppDelegate as the name isntead