### PR TITLE
Document and test new clap-first cmake api

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Build project
         run: |
           cmake -S . -B ./build ${{ matrix.cmakeargs }} -DCMAKE_BUILD_TYPE=Debug -DCLAP_WRAPPER_DOWNLOAD_DEPENDENCIES=TRUE -DCLAP_WRAPPER_BUILD_TESTS=TRUE
-          cmake --build ./build --config Debug --target clap-first-distortion_all_plugins
+          cmake --build ./build --config Debug --target clap-first-distortion_all
 
       - name: Show Build Results
         shell: bash

--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -1,30 +1,49 @@
-# This code is 'where we are going' but not 'where we are yet' way to make clap wrapped plugins
-# easily. Right now we are developing it and it is subject to change. When this message is replaced
-# with some basic documentation, you are probably safe, but until then, chat with baconpaul or timo
-# on discord before you use it ok?
+# The initial version of 'clap first' cmake support in a simple wrapper. This is subject
+# to some syntactic change as we move the wrapper ahead, but the semantics and actions are
+# stable.
+#
+# For examples see `tests/clap-first-example` or `https://github.com/baconpaul/six-sines`
+#
+
+
+
+# make_clapfirst_plugins assembles plugins in all formats - CLAP, VST3, AUv2, Standalone etc
+# from two assets you provide. The first is a static library which contains symbols for the
+# functions clap_init, clap_deinit, and clap_getfactory, named whatever you want. This is
+# where 99.99% of your development will be. The second is a single c++ file which generates
+# a clap_entry structure with the three functions provided in your static library.
+#
+# make_clap_first then assembles a clap, vst3, auv2 etc by recompiling the clap entry
+# tiny file for each plugin format and introducing it to the plugin protocl, either by
+# direct export with the clap or by other methods with the other formats. This assembled
+# wrapper then links to your static library for your functions.
+#
+# This means in practice you just write a clap, but write it as a static lib not a dynamic
+# lib, introduce a small fragment of c++ to make an export, and voila, you have all the formats
+# in self contained standalone assembled items.
 
 function(make_clapfirst_plugins)
     set(oneValueArgs
-            TARGET_NAME
-            IMPL_TARGET
+            TARGET_NAME   # name of the output target. It will be postpended _clap, _vst3, _all
+            IMPL_TARGET   # name of the target you set up with your static library
 
-            OUTPUT_NAME
+            OUTPUT_NAME   # output name of your CLAP, VST3, etc...
 
-            ENTRY_SOURCE
+            ENTRY_SOURCE  # source file of the small cpp with the export directives and link to init
 
-            BUNDLE_IDENTIFIER
+            BUNDLE_IDENTIFIER  # macos bundle identifier and builds
             BUNDLE_VERSION
 
-            COPY_AFTER_BUILD
+            COPY_AFTER_BUILD # If true, on mac and lin the clap/vst3/etc... will install locally
 
-            STANDALONE_MACOS_ICON
+            STANDALONE_MACOS_ICON # Icons for standalone
             STANDALONE_WINDOWS_ICON
 
             ASSET_OUTPUT_DIRECTORY
     )
     set(multiValueArgs
-            PLUGIN_FORMATS
-            STANDALONE_CONFIGURATIONS
+            PLUGIN_FORMATS   # A list of plugin formats, "CLAP" "VST3" "AUV2"
+            STANDALONE_CONFIGURATIONS # standalone configuration. This is a list of target names and clap ids
     )
     cmake_parse_arguments(C1ST "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 

--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -40,6 +40,11 @@ function(make_clapfirst_plugins)
             STANDALONE_WINDOWS_ICON
 
             ASSET_OUTPUT_DIRECTORY
+
+            AUV2_MANUFACTURER_NAME # The AUV2 info. If absent we will probe the CLAP for the
+            AUV2_MANUFACTURER_CODE # auv2 extension
+            AUV2_SUBTYPE_CODE
+            AUV2_INSTRUMENT_TYPE
     )
     set(multiValueArgs
             PLUGIN_FORMATS   # A list of plugin formats, "CLAP" "VST3" "AUV2"
@@ -149,14 +154,28 @@ function(make_clapfirst_plugins)
         add_library(${AUV2_TARGET} MODULE)
         target_sources(${AUV2_TARGET} PRIVATE ${C1ST_ENTRY_SOURCE})
         target_link_libraries(${AUV2_TARGET} PRIVATE ${C1ST_IMPL_TARGET})
-        target_add_auv2_wrapper(
-                TARGET ${AUV2_TARGET}
-                OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
-                BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.auv2"
-                BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
+        if (DEFINED C1ST_AUV2_MANUFACTURER_CODE)
+            target_add_auv2_wrapper(
+                    TARGET ${AUV2_TARGET}
+                    OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
+                    BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.auv2"
+                    BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
 
-                CLAP_TARGET_FOR_CONFIG "${CLAP_TARGET}"
-        )
+                    MANUFACTURER_NAME "${C1ST_AUV2_MANUFACTURER_NAME}"
+                    MANUFACTURER_CODE "${C1ST_AUV2_MANUFACTURER_CODE}"
+                    SUBTYPE_CODE "${C1ST_AUV2_SUBTYPE_CODE}"
+                    INSTRUMENT_TYPE "${C1ST_AUV2_INSTRUMENT_TYPE}"
+            )
+        else()
+            target_add_auv2_wrapper(
+                    TARGET ${AUV2_TARGET}
+                    OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
+                    BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.auv2"
+                    BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
+
+                    CLAP_TARGET_FOR_CONFIG "${CLAP_TARGET}"
+            )
+        endif()
 
         if (DEFINED C1ST_ASSET_OUTPUT_DIRECTORY)
             set_target_properties(${AUV2_TARGET} PROPERTIES

--- a/tests/clap-first-example/CMakeLists.txt
+++ b/tests/clap-first-example/CMakeLists.txt
@@ -35,6 +35,13 @@ make_clapfirst_plugins(
 
         ASSET_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}_assets
 
+        # You can set up the AUv2 for a single plugin here, or you can
+        # set it up with the auv2 extension in your clap
+        AUV2_MANUFACTURER_NAME "Free Audio"
+        AUV2_MANUFACTURER_CODE "FrAD"
+        AUV2_SUBTYPE_CODE "BdDt"
+        AUV2_INSTRUMENT_TYPE "aufx"
+
         # You can add a target-per-standalone you want. Syntax here is
         #   target-postfix output-name clap-id
         # This allows you to make multiple standalones from a multi-plugin clap

--- a/tests/clap-first-example/CMakeLists.txt
+++ b/tests/clap-first-example/CMakeLists.txt
@@ -1,103 +1,46 @@
+# This is a test of our clap-first makefiles we use in CI, and as such serves as
+# an example of doign this without helpers, with the absolute smalles cmake, and
+# so forth. A more fulsome example, using C++, setting up compiler options for
+# wider deployment, and so forth can be found at
+#
+# https://github.com/baconpaul/six-sines
+
 project(clap-first-distortion)
 
-# By A "Clap First" plugin, we mean a plugin which is *just* implmented as
-# CLAP and uses this wrapper to project into the various other platforms.
-#
-# One special form of clap first plugin does that by creating a
-# the platform plugins with the entire clap library built in. While there's
-# a few ways to do this the pattern which eemse to work best is
-#
-# 1. Write the etnire DSP, handling, etc... of your clap as a library without
-#    the clap entry
-# 2. Have a minimal clap entry c++ file which just exposes the entry points from
-#    that static library
-# 3. Make each of the clap, vst3, auv2 etc... link the static library from 1 but
-#    recomile the entry from 2, so the resulting plugin has the entry point exposed.
-#
-# We show an example of that here with a slightly modified version of the
-# basic c99 distortion plugin, here re-coded using a C++ compiler.
+set(PRODUCT_NAME "ClapFirst Bad Distortion")
 
-# So first make the actual plugin as a static library
-add_library(${PROJECT_NAME}_base STATIC distortion_clap.cpp)
-target_link_libraries(${PROJECT_NAME}_base PUBLIC clap)
+# Step one is to create a static 'impl' library which contains a static
+# implementation of clap_init, clap_deinit and clap_get_factor. Here those
+# are all in one cpp file, but a common idiom is to have an -entry-impl file
+# separate from the rest of your clap, especially in multi-plugin claps.
+add_library(${PROJECT_NAME}-impl STATIC distortion_clap.cpp)
+target_link_libraries(${PROJECT_NAME}-impl PUBLIC clap)
 
+# Then we use make_clapfirst_plugin, provided by the wrappers, to create the
+# project out of the impl and the cpp file which exports the entry
+make_clapfirst_plugins(
+        TARGET_NAME ${PROJECT_NAME}
+        IMPL_TARGET ${PROJECT_NAME}-impl
 
-# Now build and configure the CLAP.
-add_library(${PROJECT_NAME}_clap MODULE
-        distortion_clap_entry.cpp
+        OUTPUT_NAME "${PRODUCT_NAME}"
+
+        ENTRY_SOURCE "distortion_clap_entry.cpp"
+
+        BUNDLE_IDENTIFER "org.free-audio.clap-first-bad-distortion"
+        BUNDLE_VERSION ${PROJECT_VERSION}
+
+        COPY_AFTER_BUILD FALSE
+
+        PLUGIN_FORMATS CLAP VST3 AUV2
+
+        ASSET_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}_assets
+
+        # You can add a target-per-standalone you want. Syntax here is
+        #   target-postfix output-name clap-id
+        # This allows you to make multiple standalones from a multi-plugin clap
+        # In this case, the standalone has no UI and is an audio to audio effect
+        # so it isn't very useful
+        # STANDALONE_CONFIGURATIONS
+        # standalone "${PRODUCT_NAME}" "org.free-audio.clap-first-bad-distortion"
 )
-target_link_libraries(${PROJECT_NAME}_clap ${PROJECT_NAME}_base)
 
-if(APPLE)
-    set_target_properties(${PROJECT_NAME}_clap PROPERTIES
-            BUNDLE True
-            BUNDLE_EXTENSION clap
-            LIBRARY_OUTPUT_NAME ClapFirstDistortion
-            MACOSX_BUNDLE TRUE
-            MACOSX_BUNDLE_GUI_IDENTIFIER org.free-audio.clapfirst
-            MACOSX_BUNDLE_BUNDLE_NAME ClapFirstDistortion
-            MACOSX_BUNDLE_BUNDLE_VERSION "1"
-            MACOSX_BUNDLE_SHORT_VERSION_STRING "1"
-            XCODE_ATTRIBUTE_GENERATE_PKGINFO_FILE "YES"
-    )
-elseif(UNIX)
-    set_target_properties(${PROJECT_NAME}_clap PROPERTIES OUTPUT_NAME ClapFirstDistortion SUFFIX ".clap" PREFIX "")
-
-else()
-    set_target_properties(${PROJECT_NAME}_clap
-            PROPERTIES
-            OUTPUT_NAME ClapFirstDistortion
-            SUFFIX ".clap" PREFIX ""
-            LIBRARY_OUTPUT_DIRECTORY CLAP
-    )
-endif()
-
-# Building a VST3 is now easy. Make a MODULE library which compiles the entry code
-# and links the base library, then use the wraper cmake code to expose it as a VST3
-set(VST3_TARGET ${PROJECT_NAME}_vst3)
-add_library(${VST3_TARGET} MODULE)
-target_sources(${VST3_TARGET} PRIVATE distortion_clap_entry.cpp)
-target_add_vst3_wrapper(TARGET ${VST3_TARGET}
-        OUTPUT_NAME "ClapFirstDistortion"
-)
-target_link_libraries(${VST3_TARGET} PRIVATE ${PROJECT_NAME}_base)
-
-
-# And the same for the standalone
-set(SA_TARGET ${PROJECT_NAME}_standalone)
-add_executable(${SA_TARGET})
-target_sources(${SA_TARGET} PRIVATE distortion_clap_entry.cpp)
-target_link_libraries(${SA_TARGET} PRIVATE ${PROJECT_NAME}_base)
-target_add_standalone_wrapper(TARGET ${SA_TARGET}
-        OUTPUT_NAME "ClapFirstDistortion"
-        STATICALLY_LINKED_CLAP_ENTRY True
-        PLUGIN_ID "org.free-audio.clap-first-bad-distortion")
-
-if (APPLE)
-    # And the same for the AUV2
-    set(AUV2_TARGET ${PROJECT_NAME}_auv2)
-    add_library(${AUV2_TARGET} MODULE)
-    target_sources(${AUV2_TARGET} PRIVATE distortion_clap_entry.cpp)
-    target_link_libraries(${AUV2_TARGET} PRIVATE ${PROJECT_NAME}_base)
-    target_add_auv2_wrapper(
-            TARGET ${AUV2_TARGET}
-            OUTPUT_NAME "ClapFirstDistortion"
-            BUNDLE_IDENTIFIER "org.freeaudio.bad-clap-first"
-            BUNDLE_VERSION "1"
-
-            MANUFACTURER_NAME "FreeAudio Team"
-            MANUFACTURER_CODE "FrAU"
-            SUBTYPE_CODE "clDi"
-            INSTRUMENT_TYPE "aufx"
-
-            CLAP_TARGET_FOR_CONFIG ${PROJECT_NAME}_clap
-    )
-endif()
-
-
-# FInally collect those all in a utility target
-add_custom_target(${PROJECT_NAME}_all_plugins)
-add_dependencies(${PROJECT_NAME}_all_plugins ${PROJECT_NAME}_clap ${PROJECT_NAME}_vst3 ${PROJECT_NAME}_standalone)
-if (APPLE)
-    add_dependencies(${PROJECT_NAME}_all_plugins ${PROJECT_NAME}_auv2)
-endif()

--- a/tests/clap-first-example/distortion_clap.cpp
+++ b/tests/clap-first-example/distortion_clap.cpp
@@ -1,6 +1,6 @@
 /*
  * This implements a distortion CLAP and creates the appropriate factory
- * methods as a static library, which are then consumed by the various plugins
+ * methods and entry as a static library, which are then consumed by the various plugins
  * via distortion_clap_entry
  *
  * The DSP here is bad. Really. This is an example you don't want to use this for music.
@@ -13,8 +13,10 @@
 #include <clap/clap.h>
 #include <math.h>
 #include <assert.h>
+#include "distortion_clap_entry.h"
 
-static const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_STEREO, CLAP_PLUGIN_FEATURE_DISTORTION, nullptr};
+static const char *features[] = {CLAP_PLUGIN_FEATURE_AUDIO_EFFECT, CLAP_PLUGIN_FEATURE_STEREO,
+                                 CLAP_PLUGIN_FEATURE_DISTORTION, nullptr};
 
 static const clap_plugin_descriptor_t s_clap1stDist_desc = {
     CLAP_VERSION_INIT,
@@ -26,8 +28,7 @@ static const clap_plugin_descriptor_t s_clap1stDist_desc = {
     "",
     "1.0.0",
     "A few sloppy distortion algorithms using naive waveshapers",
-    &features[0]
-};
+    &features[0]};
 
 enum ClipType
 {
@@ -68,7 +69,7 @@ static uint32_t clap1stDist_audio_ports_count(const clap_plugin_t *plugin, bool 
 }
 
 static bool clap1stDist_audio_ports_get(const clap_plugin_t *plugin, uint32_t index, bool is_input,
-                                    clap_audio_port_info_t *info)
+                                        clap_audio_port_info_t *info)
 {
   if (index > 0) return false;
   info->id = 0;
@@ -97,7 +98,7 @@ uint32_t clap1stDist_param_count(const clap_plugin_t *plugin)
   return 3;
 }
 bool clap1stDist_param_get_info(const clap_plugin_t *plugin, uint32_t param_index,
-                            clap_param_info_t *param_info)
+                                clap_param_info_t *param_info)
 {
   switch (param_index)
   {
@@ -161,7 +162,7 @@ bool clap1stDist_param_get_value(const clap_plugin_t *plugin, clap_id param_id, 
   return false;
 }
 bool clap1stDist_param_value_to_text(const clap_plugin_t *plugin, clap_id param_id, double value,
-                                 char *display, uint32_t size)
+                                     char *display, uint32_t size)
 {
   auto *plug = (clap1st_distortion_plug *)plugin->plugin_data;
 
@@ -195,13 +196,13 @@ bool clap1stDist_param_value_to_text(const clap_plugin_t *plugin, clap_id param_
   return false;
 }
 bool clap1stDist_text_to_value(const clap_plugin_t *plugin, clap_id param_id, const char *display,
-                           double *value)
+                               double *value)
 {
   // I'm not going to bother to support this
   return false;
 }
 void clap1stDist_flush(const clap_plugin_t *plugin, const clap_input_events_t *in,
-                   const clap_output_events_t *out)
+                       const clap_output_events_t *out)
 {
   auto *plug = (clap1st_distortion_plug *)plugin->plugin_data;
 
@@ -215,12 +216,9 @@ void clap1stDist_flush(const clap_plugin_t *plugin, const clap_input_events_t *i
   }
 }
 
-static const clap_plugin_params_t s_clap1stDist_params = {clap1stDist_param_count,
-                                                      clap1stDist_param_get_info,
-                                                      clap1stDist_param_get_value,
-                                                      clap1stDist_param_value_to_text,
-                                                      clap1stDist_text_to_value,
-                                                      clap1stDist_flush};
+static const clap_plugin_params_t s_clap1stDist_params = {
+    clap1stDist_param_count,         clap1stDist_param_get_info, clap1stDist_param_get_value,
+    clap1stDist_param_value_to_text, clap1stDist_text_to_value,  clap1stDist_flush};
 
 bool clap1stDist_state_save(const clap_plugin_t *plugin, const clap_ostream_t *stream)
 {
@@ -278,8 +276,7 @@ bool clap1stDist_state_load(const clap_plugin_t *plugin, const clap_istream_t *s
 
   return true;
 }
-static const clap_plugin_state_t s_clap1stDist_state = {clap1stDist_state_save,
-                                                    clap1stDist_state_load};
+static const clap_plugin_state_t s_clap1stDist_state = {clap1stDist_state_save, clap1stDist_state_load};
 
 /////////////////
 // clap_plugin //
@@ -311,7 +308,7 @@ static void clap1stDist_destroy(const struct clap_plugin *plugin)
 }
 
 static bool clap1stDist_activate(const struct clap_plugin *plugin, double sample_rate,
-                             uint32_t min_frames_count, uint32_t max_frames_count)
+                                 uint32_t min_frames_count, uint32_t max_frames_count)
 {
   return true;
 }
@@ -362,7 +359,7 @@ static void clap1stDist_process_event(clap1st_distortion_plug *plug, const clap_
 }
 
 static clap_process_status clap1stDist_process(const struct clap_plugin *plugin,
-                                           const clap_process_t *process)
+                                               const clap_process_t *process)
 {
   auto *plug = (clap1st_distortion_plug *)plugin->plugin_data;
 
@@ -497,7 +494,7 @@ const clap_plugin_descriptor_t *plugin_factory_get_plugin_descriptor(
 }
 
 const clap_plugin_t *plugin_factory_create_plugin(const struct clap_plugin_factory *factory,
-                                                         const clap_host_t *host, const char *plugin_id)
+                                                  const clap_host_t *host, const char *plugin_id)
 {
   if (!clap_version_is_compatible(host->clap_version))
   {
@@ -506,5 +503,28 @@ const clap_plugin_t *plugin_factory_create_plugin(const struct clap_plugin_facto
 
   if (!strcmp(plugin_id, s_clap1stDist_desc.id)) return clap1stDist_create(host);
 
+  return nullptr;
+}
+
+static const clap_plugin_factory_t s_plugin_factory = {
+    plugin_factory_get_plugin_count,
+    plugin_factory_get_plugin_descriptor,
+    plugin_factory_create_plugin,
+};
+
+bool dist_entry_init(const char *plugin_path)
+{
+  // called only once, and very first
+  return true;
+}
+
+void dist_entry_deinit(void)
+{
+  // called before unloading the DSO
+}
+
+const void *dist_entry_get_factory(const char *factory_id)
+{
+  if (!strcmp(factory_id, CLAP_PLUGIN_FACTORY_ID)) return &s_plugin_factory;
   return nullptr;
 }

--- a/tests/clap-first-example/distortion_clap_entry.cpp
+++ b/tests/clap-first-example/distortion_clap_entry.cpp
@@ -1,46 +1,14 @@
 /*
  * distortion_clap_entry
  *
- * This uses extern versions of the factory methods from a static library to create
+ * This uses extern versions of the entry methods from a static library to create
  * a working exported C linkage clap entry point
  */
 
 #include <clap/clap.h>
 #include <cstring>
 
-extern uint32_t plugin_factory_get_plugin_count(const struct clap_plugin_factory *factory);
-extern const clap_plugin_descriptor_t *plugin_factory_get_plugin_descriptor(
-    const struct clap_plugin_factory *factory, uint32_t index);
-
-extern const clap_plugin_t *plugin_factory_create_plugin(const struct clap_plugin_factory *factory,
-                                                         const clap_host_t *host, const char *plugin_id);
-
-static const clap_plugin_factory_t s_plugin_factory = {
-    plugin_factory_get_plugin_count,
-    plugin_factory_get_plugin_descriptor,
-    plugin_factory_create_plugin,
-};
-
-////////////////
-// clap_entry //
-////////////////
-
-static bool entry_init(const char *plugin_path)
-{
-  // called only once, and very first
-  return true;
-}
-
-static void entry_deinit(void)
-{
-  // called before unloading the DSO
-}
-
-static const void *entry_get_factory(const char *factory_id)
-{
-  if (!strcmp(factory_id, CLAP_PLUGIN_FACTORY_ID)) return &s_plugin_factory;
-  return nullptr;
-}
+#include "distortion_clap_entry.h"
 
 extern "C"
 {
@@ -49,8 +17,8 @@ extern "C"
 #pragma GCC diagnostic ignored "-Wattributes"  // other peoples errors are outside my scope
 #endif
 
-  const CLAP_EXPORT struct clap_plugin_entry clap_entry = {CLAP_VERSION, entry_init, entry_deinit,
-                                                           entry_get_factory};
+  const CLAP_EXPORT struct clap_plugin_entry clap_entry = {CLAP_VERSION, dist_entry_init,
+                                                           dist_entry_deinit, dist_entry_get_factory};
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/tests/clap-first-example/distortion_clap_entry.h
+++ b/tests/clap-first-example/distortion_clap_entry.h
@@ -1,0 +1,9 @@
+//
+// Created by Paul Walker on 2/21/25.
+//
+
+#pragma once
+
+extern bool dist_entry_init(const char *plugin_path);
+extern void dist_entry_deinit(void);
+extern const void *dist_entry_get_factory(const char *factory_id);


### PR DESCRIPTION
1. Move the test to new cmake api
2. DOcument the test, document the clap first cmake, and include a link to six sines for a more expansive implementation