### PR TITLE
Windows filesystem related fixes and minor refactor

### DIFF
--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -5,14 +5,7 @@
 #include <sstream>
 
 #include "detail/clap/fsutil.h"
-
-#if MACOS_USE_STD_FILESYSTEM
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include "ghc/filesystem.hpp"
-namespace fs = ghc::filesystem;
-#endif
+#include "detail/os/fs.h"
 
 struct auInfo
 {

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -305,7 +305,7 @@ Library::Library()
           GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
           (LPCWSTR)ffeomwe, &selfmodule))
   {
-    if (this->getEntryFunction(selfmodule, getModulePath(selfmodule).u8string().c_str()))
+    if (this->getEntryFunction(selfmodule, os::getModulePath(selfmodule).u8string().c_str()))
     {
       _selfcontained = true;
     }

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -305,11 +305,19 @@ Library::Library()
           GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
           (LPCWSTR)ffeomwe, &selfmodule))
   {
-    std::wstring p;
-    auto size = GetModuleFileNameW(selfmodule, nullptr, 0);
-    p.resize(size);
-    size = GetModuleFileNameW(selfmodule, &p[0], size);
-    modulename = std::move(p);
+    DWORD bufferSize = MAX_PATH;
+    std::wstring buffer(bufferSize, L'\0');
+
+    DWORD length = GetModuleFileNameW(selfmodule, buffer.data(), bufferSize);
+
+    while (length == bufferSize && GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+    {
+      bufferSize *= 2;
+      buffer.resize(bufferSize);
+      length = GetModuleFileNameW(selfmodule, buffer.data(), bufferSize);
+    }
+    buffer.resize(length);
+    modulename = std::move(buffer);
   }
   if (selfmodule)
   {

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -293,7 +293,7 @@ Library::Library()
 #if STATICALLY_LINKED_CLAP_ENTRY
   _pluginEntry = &clap_entry;
   _selfcontained = true;
-  fs::path path = os::getModulePath();
+  fs::path path = os::getPluginPath();
   setupPluginsFromPluginEntry(path.u8string().c_str());
   return;
 #endif

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -293,8 +293,8 @@ Library::Library()
 #if STATICALLY_LINKED_CLAP_ENTRY
   _pluginEntry = &clap_entry;
   _selfcontained = true;
-  std::string path = os::getModulePath();
-  setupPluginsFromPluginEntry(path.c_str());
+  fs::path path = os::getModulePath();
+  setupPluginsFromPluginEntry(path.u8string().c_str());
   return;
 #endif
 

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -301,7 +301,9 @@ Library::Library()
 #if WIN
   fs::path modulename;
   HMODULE selfmodule;
-  if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCWSTR)ffeomwe, &selfmodule))
+  if (GetModuleHandleExW(
+          GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+          (LPCWSTR)ffeomwe, &selfmodule))
   {
     std::wstring p;
     auto size = GetModuleFileNameW(selfmodule, nullptr, 0);

--- a/src/detail/clap/fsutil.h
+++ b/src/detail/clap/fsutil.h
@@ -10,19 +10,6 @@
 
 */
 
-#if MAC
-#if MACOS_USE_STD_FILESYSTEM
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include "ghc/filesystem.hpp"
-namespace fs = ghc::filesystem;
-#endif
-#else
-#include <filesystem>
-namespace fs = std::filesystem;
-#endif
-
 #include <vector>
 #include <functional>
 #include <clap/clap.h>
@@ -33,6 +20,7 @@ namespace fs = std::filesystem;
 #include "clapwrapper/vst3.h"
 #include "clapwrapper/auv2.h"
 #include "../ara/ara.h"
+#include "detail/os/fs.h"
 
 #if MAC
 #include <CoreFoundation/CoreFoundation.h>

--- a/src/detail/clap/mac_helpers.mm
+++ b/src/detail/clap/mac_helpers.mm
@@ -11,16 +11,9 @@
 #include <vector>
 #include <dlfcn.h>
 
-// No need to ifdef this - it is mac only
-#if MACOS_USE_STD_FILESYSTEM
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include "ghc/filesystem.hpp"
-namespace fs = ghc::filesystem;
-#endif
-
 #include <Foundation/Foundation.h>
+
+#include "detail/os/fs.h"
 
 namespace Clap
 {

--- a/src/detail/os/fs.h
+++ b/src/detail/os/fs.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if MAC && !MACOS_USE_STD_FILESYSTEM
+#include "ghc/filesystem.hpp"
+namespace fs = ghc::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif

--- a/src/detail/os/linux.cpp
+++ b/src/detail/os/linux.cpp
@@ -85,7 +85,7 @@ fs::path getPluginPath()
 
 std::string getParentFolderName()
 {
-  std::filesystem::path n = getPluginPath();
+  fs::path n = getPluginPath();
   if (n.has_parent_path())
   {
     auto p = n.parent_path();
@@ -95,17 +95,17 @@ std::string getParentFolderName()
     }
   }
 
-  return std::string();
+  return {};
 }
 
 std::string getBinaryName()
 {
-  std::filesystem::path n = getPluginPath();
+  fs::path n = getPluginPath();
   if (n.has_filename())
   {
     return n.stem().u8string();
   }
-  return std::string();
+  return {};
 }
 
 #if 0

--- a/src/detail/os/linux.cpp
+++ b/src/detail/os/linux.cpp
@@ -73,10 +73,10 @@ static Steinberg::ModuleTerminator dropMessageWindow([] { gLinuxHelper.terminate
 	}
 #endif
 
-fs::path getModulePath()
+fs::path getPluginPath()
 {
   Dl_info info;
-  if (dladdr((void*)getModulePath, &info))
+  if (dladdr((void*)getPluginPath, &info))
   {
     return info.dli_fname;
   }
@@ -85,7 +85,7 @@ fs::path getModulePath()
 
 std::string getParentFolderName()
 {
-  std::filesystem::path n = getModulePath();
+  std::filesystem::path n = getPluginPath();
   if (n.has_parent_path())
   {
     auto p = n.parent_path();
@@ -100,7 +100,7 @@ std::string getParentFolderName()
 
 std::string getBinaryName()
 {
-  std::filesystem::path n = getModulePath();
+  std::filesystem::path n = getPluginPath();
   if (n.has_filename())
   {
     return n.stem().u8string();

--- a/src/detail/os/linux.cpp
+++ b/src/detail/os/linux.cpp
@@ -73,14 +73,14 @@ static Steinberg::ModuleTerminator dropMessageWindow([] { gLinuxHelper.terminate
 	}
 #endif
 
-std::string getModulePath()
+fs::path getModulePath()
 {
   Dl_info info;
   if (dladdr((void*)getModulePath, &info))
   {
     return info.dli_fname;
   }
-  return std::string();
+  return {};
 }
 
 std::string getParentFolderName()

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -120,7 +120,7 @@ uint64_t getTickInMS()
   return (::clock() * 1000) / CLOCKS_PER_SEC;
 }
 
-fs::path getModulePath()
+fs::path getPluginPath()
 {
   Dl_info info;
   if (dladdr((void*)getBundlePath, &info))
@@ -134,12 +134,12 @@ fs::path getModulePath()
 
 std::string getParentFolderName()
 {
-  return getModulePath().parent_path().stem();
+  return getPluginPath().parent_path().stem();
 }
 
 std::string getBinaryName()
 {
-  return getModulePath().stem();
+  return getPluginPath().stem();
 }
 
 }  // namespace os

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -123,7 +123,7 @@ uint64_t getTickInMS()
 fs::path getPluginPath()
 {
   Dl_info info;
-  if (dladdr((void*)getBundlePath, &info))
+  if (dladdr((void*)getPluginPath, &info))
   {
     fs::path binaryPath = info.dli_fname;
     return binaryPath.parent_path().parent_path().parent_path();

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -16,15 +16,10 @@
 #endif
 #include "osutil.h"
 #include <vector>
-#if MACOS_USE_STD_FILESYSTEM
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include "ghc/filesystem.hpp"
-namespace fs = ghc::filesystem;
-#endif
 #include <iostream>
 #include <dlfcn.h>
+
+#include "detail/os/fs.h"
 
 namespace os
 {

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -120,7 +120,7 @@ uint64_t getTickInMS()
   return (::clock() * 1000) / CLOCKS_PER_SEC;
 }
 
-fs::path getBundlePath()
+fs::path getModulePath()
 {
   Dl_info info;
   if (dladdr((void*)getBundlePath, &info))
@@ -132,19 +132,14 @@ fs::path getBundlePath()
   return {};
 }
 
-std::string getModulePath()
-{
-  return getBundlePath().string();
-}
-
 std::string getParentFolderName()
 {
-  return getBundlePath().parent_path().stem();
+  return getModulePath().parent_path().stem();
 }
 
 std::string getBinaryName()
 {
-  return getBundlePath().stem();
+  return getModulePath().stem();
 }
 
 }  // namespace os

--- a/src/detail/os/osutil.h
+++ b/src/detail/os/osutil.h
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "log.h"
+#include "fs.h"
 
 namespace os
 {
@@ -63,7 +64,9 @@ class IPlugObject
 void attach(IPlugObject* plugobject);
 void detach(IPlugObject* plugobject);
 uint64_t getTickInMS();
-std::string getModulePath();
+
+// Used for clap_plugin_entry.init(). Path to DSO (Linux, Windows), or the bundle (macOS).
+fs::path getModulePath();
 std::string getParentFolderName();
 std::string getBinaryName();
 }  // namespace os

--- a/src/detail/os/osutil.h
+++ b/src/detail/os/osutil.h
@@ -66,7 +66,7 @@ void detach(IPlugObject* plugobject);
 uint64_t getTickInMS();
 
 // Used for clap_plugin_entry.init(). Path to DSO (Linux, Windows), or the bundle (macOS).
-fs::path getModulePath();
+fs::path getPluginPath();
 std::string getParentFolderName();
 std::string getBinaryName();
 }  // namespace os

--- a/src/detail/os/osutil_windows.h
+++ b/src/detail/os/osutil_windows.h
@@ -5,5 +5,27 @@
 
 namespace os
 {
-fs::path getModulePath(HMODULE module);
+
+static fs::path getModulePath(HMODULE mod)
+{
+  fs::path modulePath{};
+  DWORD bufferSize = 150;  // Start off with a reasonably large size
+  std::wstring buffer(bufferSize, L'\0');
+
+  DWORD length = GetModuleFileNameW(mod, buffer.data(), bufferSize);
+
+  constexpr size_t maxExtendedPath = 0x7FFF - 24;  // From Windows Implementation Library
+
+  while (length == bufferSize && GetLastError() == ERROR_INSUFFICIENT_BUFFER &&
+         bufferSize < maxExtendedPath)
+  {
+    bufferSize *= 2;
+    buffer.resize(bufferSize);
+    length = GetModuleFileNameW(mod, buffer.data(), bufferSize);
+  }
+  buffer.resize(length);
+  modulePath = std::move(buffer);
+  return modulePath;
 }
+
+}  // namespace os

--- a/src/detail/os/osutil_windows.h
+++ b/src/detail/os/osutil_windows.h
@@ -3,4 +3,7 @@
 #include "fs.h"
 #include <windows.h>
 
+namespace os
+{
 fs::path getModulePath(HMODULE module);
+}

--- a/src/detail/os/osutil_windows.h
+++ b/src/detail/os/osutil_windows.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "fs.h"
+#include <windows.h>
+
+fs::path getModulePath(HMODULE module);

--- a/src/detail/os/windows.cpp
+++ b/src/detail/os/windows.cpp
@@ -103,7 +103,7 @@ LRESULT WindowsHelper::Wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
       return 1;
       break;
     default:
-      return ::DefWindowProc(hwnd, msg, wParam, lParam);
+      return DefWindowProc(hwnd, msg, wParam, lParam);
   }
 }
 
@@ -119,16 +119,16 @@ void WindowsHelper::init()
   /* auto a = */
   RegisterClassExW(&wc);
 
-  _msgWin = ::CreateWindowExW(0, modulename.c_str(), NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, 0);
-  ::SetWindowLongW(_msgWin, GWLP_WNDPROC, (LONG_PTR)&Wndproc);
-  _timer = ::SetTimer(_msgWin, 0, 20, NULL);
+  _msgWin = CreateWindowExW(0, modulename.c_str(), NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, 0, 0);
+  SetWindowLongW(_msgWin, GWLP_WNDPROC, (LONG_PTR)&Wndproc);
+  _timer = SetTimer(_msgWin, 0, 20, NULL);
 }
 
 void WindowsHelper::terminate()
 {
-  ::KillTimer(_msgWin, _timer);
-  ::DestroyWindow(_msgWin);
-  ::UnregisterClassW(getPluginPath().c_str(), ghInst);
+  KillTimer(_msgWin, _timer);
+  DestroyWindow(_msgWin);
+  UnregisterClassW(getPluginPath().c_str(), ghInst);
 }
 
 void WindowsHelper::executeDefered()

--- a/src/detail/os/windows.cpp
+++ b/src/detail/os/windows.cpp
@@ -44,7 +44,9 @@ static TCHAR* getModuleName()
 {
   static TCHAR modulename[2048];
   HMODULE selfmodule;
-  if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)getModuleName, &selfmodule))
+  if (GetModuleHandleEx(
+          GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+          (LPCTSTR)getModuleName, &selfmodule))
   {
     /* auto size = */
     GetModuleFileName(selfmodule, modulename, 2048);

--- a/src/detail/os/windows.cpp
+++ b/src/detail/os/windows.cpp
@@ -13,7 +13,6 @@
 #include <tchar.h>
 #include "public.sdk/source/main/moduleinit.h"
 #include "osutil.h"
-#include <filesystem>
 
 // from dllmain.cpp of the VST3 SDK
 extern HINSTANCE ghInst;
@@ -69,7 +68,7 @@ fs::path getPluginPath()
 
 std::string getParentFolderName()
 {
-  std::filesystem::path n = getPluginPath();
+  fs::path n = getPluginPath();
   if (n.has_parent_path())
   {
     auto p = n.parent_path();
@@ -84,7 +83,7 @@ std::string getParentFolderName()
 
 std::string getBinaryName()
 {
-  std::filesystem::path n = getPluginPath();
+  fs::path n = getPluginPath();
   if (n.has_filename())
   {
     return n.stem().u8string();

--- a/src/detail/os/windows.cpp
+++ b/src/detail/os/windows.cpp
@@ -40,13 +40,13 @@ class WindowsHelper
 static Steinberg::ModuleInitializer createMessageWindow([] { gWindowsHelper.init(); });
 static Steinberg::ModuleTerminator dropMessageWindow([] { gWindowsHelper.terminate(); });
 
-fs::path getModulePath()
+fs::path getPluginPath()
 {
   fs::path modulePath{};
   HMODULE selfmodule;
   if (GetModuleHandleExW(
           GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-          (LPCWSTR)getModulePath, &selfmodule))
+          (LPCWSTR)getPluginPath, &selfmodule))
   {
     std::wstring p;
     auto size = GetModuleFileNameW(selfmodule, nullptr, 0);
@@ -69,7 +69,7 @@ fs::path getModulePath()
 
 std::string getParentFolderName()
 {
-  std::filesystem::path n = getModulePath();
+  std::filesystem::path n = getPluginPath();
   if (n.has_parent_path())
   {
     auto p = n.parent_path();
@@ -84,7 +84,7 @@ std::string getParentFolderName()
 
 std::string getBinaryName()
 {
-  std::filesystem::path n = getModulePath();
+  std::filesystem::path n = getPluginPath();
   if (n.has_filename())
   {
     return n.stem().u8string();
@@ -110,7 +110,7 @@ LRESULT WindowsHelper::Wndproc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
 
 void WindowsHelper::init()
 {
-  auto modulename = getModulePath();
+  auto modulename = getPluginPath();
   WNDCLASSEXW wc;
   memset(&wc, 0, sizeof(wc));
   wc.cbSize = sizeof(wc);
@@ -129,7 +129,7 @@ void WindowsHelper::terminate()
 {
   ::KillTimer(_msgWin, _timer);
   ::DestroyWindow(_msgWin);
-  ::UnregisterClassW(getModulePath().c_str(), ghInst);
+  ::UnregisterClassW(getPluginPath().c_str(), ghInst);
 }
 
 void WindowsHelper::executeDefered()

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -1275,7 +1275,7 @@ bool Plugin::saveSettings()
 
   if (settingsPath.has_value())
   {
-    fs::path::create_directories(settingsPath.value() / plugin.plugin->desc->id);
+    fs::create_directories(settingsPath.value() / plugin.plugin->desc->id);
 
     settings.set<std::string>("audioApiName", sah->audioApiName);
     settings.set<double>("audioInputDeviceID", sah->audioInputDeviceID);

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -748,7 +748,7 @@ Plugin::Plugin(const clap_plugin_entry* entry, int argc, char** argv)
                      wil::unique_cotaskmem_string result;
                      shellItem->GetDisplayName(SIGDN_FILESYSPATH, &result);
 
-                     auto saveFile{std::filesystem::path(result.get())};
+                     auto saveFile{fs::path(result.get())};
 
                      try
                      {
@@ -778,7 +778,7 @@ Plugin::Plugin(const clap_plugin_entry* entry, int argc, char** argv)
                      wil::unique_cotaskmem_string result;
                      shellItem->GetDisplayName(SIGDN_FILESYSPATH, &result);
 
-                     auto saveFile{std::filesystem::path(result.get())};
+                     auto saveFile{fs::path(result.get())};
 
                      try
                      {
@@ -1275,7 +1275,7 @@ bool Plugin::saveSettings()
 
   if (settingsPath.has_value())
   {
-    std::filesystem::create_directories(settingsPath.value() / plugin.plugin->desc->id);
+    fs::path::create_directories(settingsPath.value() / plugin.plugin->desc->id);
 
     settings.set<std::string>("audioApiName", sah->audioApiName);
     settings.set<double>("audioInputDeviceID", sah->audioInputDeviceID);


### PR DESCRIPTION
Sorry this just one big set, I'm a bit stretched for time at the moment for teasing this into separate PRs.

I've been using these changes in Floe's alpha for a while.

There's a few things here (the commit comments are pretty descriptive too).

## Fix GetModuleFileNameW 
The way we were getting the filepath of a DLL was just straight up not working (a change I made in a previous PR). We were doing this:
```
    std::wstring p;
    auto size = GetModuleFileNameW(selfmodule, nullptr, 0);
    p.resize(size);
    size = GetModuleFileNameW(selfmodule, &p[0], size);
```

But GetModuleFileNameW doesn't ever return the needed size. So we need a new way of doing things.

## Fix edge cases and minor refactor
There's also a couple of edge cases that are now properly handled and I made usage of fs::path more universal.

Let me know of any changes.



