### PR TITLE
Force an activation in mac standalone

### DIFF
--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -39,6 +39,8 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
+  [NSApp activateIgnoringOtherApps:YES];
+
   // Insert code here to initialize your application
   const char *argv[2] = {OUTPUT_NAME, 0};
 


### PR DESCRIPTION
Right now we do a lot of work in applicationDidFinishLaunching and that delay sometimes stalls the app from activating. By forcing an activation up top, clion yields control properly and so on. Not a change on a standalone you double click.