### PR TITLE
`RESOURCE_DIRECTORY` for copying verbatim into clap-first bundle

### DIFF
--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -42,6 +42,7 @@ function(make_clapfirst_plugins)
             WINDOWS_FOLDER_VST3 # True for a filder, false for single file (default)
 
             ASSET_OUTPUT_DIRECTORY
+            RESOURCE_DIRECTORY # Entire directory to be copied into a bundle/folder's resources
 
             AUV2_MANUFACTURER_NAME # The AUV2 info. If absent we will probe the CLAP for the
             AUV2_MANUFACTURER_CODE # auv2 extension
@@ -64,6 +65,10 @@ function(make_clapfirst_plugins)
 
     if (NOT DEFINED C1ST_WINDOWS_FOLDER_VST3)
         set(C1ST_WINDOWS_FOLDER_VST3 FALSE)
+    endif()
+
+    if (NOT DEFINED C1ST_RESOURCE_DIRECTORY)
+        set(C1ST_RESOURCE_DIRECTORY "")
     endif()
 
     if (NOT DEFINED C1ST_PLUGIN_FORMATS)
@@ -122,6 +127,7 @@ function(make_clapfirst_plugins)
                 OUTPUT_NAME ${C1ST_OUTPUT_NAME}
                 BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFIER}.clap"
                 BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
+                RESOURCE_DIRECTORY "${C1ST_RESOURCE_DIRECTORY}"
         )
         if (DEFINED C1ST_ASSET_OUTPUT_DIRECTORY)
             if (NOT WIN32)
@@ -158,6 +164,7 @@ function(make_clapfirst_plugins)
                 BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
                 ASSET_OUTPUT_DIRECTORY "${vod}"
                 WINDOWS_FOLDER_VST3 ${C1ST_WINDOWS_FOLDER_VST3}
+                RESOURCE_DIRECTORY "${C1ST_RESOURCE_DIRECTORY}"
         )
 
         add_dependencies(${ALL_TARGET} ${VST3_TARGET})
@@ -175,6 +182,7 @@ function(make_clapfirst_plugins)
                     OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
                     BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.auv2"
                     BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
+                    RESOURCE_DIRECTORY "${C1ST_RESOURCE_DIRECTORY}"
 
                     MANUFACTURER_NAME "${C1ST_AUV2_MANUFACTURER_NAME}"
                     MANUFACTURER_CODE "${C1ST_AUV2_MANUFACTURER_CODE}"
@@ -187,6 +195,7 @@ function(make_clapfirst_plugins)
                     OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
                     BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.auv2"
                     BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
+                    RESOURCE_DIRECTORY "${C1ST_RESOURCE_DIRECTORY}"
 
                     CLAP_TARGET_FOR_CONFIG "${CLAP_TARGET}"
             )
@@ -207,9 +216,10 @@ function(make_clapfirst_plugins)
         target_link_libraries(${WCLAP_TARGET} PRIVATE ${C1ST_IMPL_TARGET})
         target_add_wclap_configuration(TARGET ${WCLAP_TARGET}
                 OUTPUT_NAME ${C1ST_OUTPUT_NAME}
+                RESOURCE_DIRECTORY "${C1ST_RESOURCE_DIRECTORY}"
         )
         if (DEFINED C1ST_ASSET_OUTPUT_DIRECTORY)
-	    # set the RUNTIME path because module.wasm are built as binaries (dynamic libraries for WASM aren't well-defined)
+            # set the RUNTIME path because module.wasm are built as binaries (dynamic libraries for WASM aren't well-defined)
             if (NOT WIN32)
                 set_target_properties(${WCLAP_TARGET} PROPERTIES
                         RUNTIME_OUTPUT_DIRECTORY ${C1ST_ASSET_OUTPUT_DIRECTORY}/${C1ST_OUTPUT_NAME}.wclap)
@@ -219,10 +229,10 @@ function(make_clapfirst_plugins)
             endif()
         endif()
 
-	# Emscripten flags
+        # Emscripten flags
         set_target_properties(${WCLAP_TARGET} PROPERTIES
-		COMPILE_FLAGS "-msimd128" # TODO: add this to the static library as well?
-        	LINK_FLAGS    "-msimd128 -sSTANDALONE_WASM --no-entry -s EXPORTED_FUNCTIONS=_clap_entry,_malloc -s INITIAL_MEMORY=512kb -s ALLOW_MEMORY_GROWTH=1 -s ALLOW_TABLE_GROWTH=1 -s PURE_WASI --export-table"
+                COMPILE_FLAGS "-msimd128" # TODO: add this to the static library as well?
+                LINK_FLAGS    "-msimd128 -sSTANDALONE_WASM --no-entry -s EXPORTED_FUNCTIONS=_clap_entry,_malloc -s INITIAL_MEMORY=512kb -s ALLOW_MEMORY_GROWTH=1 -s ALLOW_TABLE_GROWTH=1 -s PURE_WASI --export-table"
         )
 
         add_dependencies(${ALL_TARGET} ${WCLAP_TARGET})
@@ -255,6 +265,7 @@ function(make_clapfirst_plugins)
                         PLUGIN_ID "${clapid}"
                         MACOS_ICON "${C1ST_STANDALONE_MACOS_ICON}"
                         WINDOWS_ICON "${C1ST_STANDALONE_WINDOWS_ICON}"
+                        RESOURCE_DIRECTORY "${C1ST_RESOURCE_DIRECTORY}"
                 )
                 if (DEFINED C1ST_ASSET_OUTPUT_DIRECTORY)
                     if (NOT WIN32)

--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -229,11 +229,10 @@ function(make_clapfirst_plugins)
             endif()
         endif()
 
-        # Emscripten flags
-        set_target_properties(${WCLAP_TARGET} PROPERTIES
-                COMPILE_FLAGS "-msimd128" # TODO: add this to the static library as well?
-                LINK_FLAGS    "-msimd128 -sSTANDALONE_WASM --no-entry -s EXPORTED_FUNCTIONS=_clap_entry,_malloc -s INITIAL_MEMORY=512kb -s ALLOW_MEMORY_GROWTH=1 -s ALLOW_TABLE_GROWTH=1 -s PURE_WASI --export-table"
-        )
+	# Emscripten flags
+	target_compile_options(${C1ST_IMPL_TARGET} PUBLIC -msimd128 --no-entry)
+	target_compile_options(${WCLAP_TARGET} PUBLIC -msimd128 --no-entry)
+	target_link_options(${WCLAP_TARGET} PUBLIC -msimd128 -sSTANDALONE_WASM --no-entry -sEXPORTED_FUNCTIONS=_clap_entry,_malloc -sINITIAL_MEMORY=512kb -sALLOW_MEMORY_GROWTH=1 -sALLOW_TABLE_GROWTH=1 -sPURE_WASI --export-table)
 
         add_dependencies(${ALL_TARGET} ${WCLAP_TARGET})
     endif()

--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -229,10 +229,11 @@ function(make_clapfirst_plugins)
             endif()
         endif()
 
-	# Emscripten flags
-	target_compile_options(${C1ST_IMPL_TARGET} PUBLIC -msimd128 --no-entry)
-	target_compile_options(${WCLAP_TARGET} PUBLIC -msimd128 --no-entry)
-	target_link_options(${WCLAP_TARGET} PUBLIC -msimd128 -sSTANDALONE_WASM --no-entry -sEXPORTED_FUNCTIONS=_clap_entry,_malloc -sINITIAL_MEMORY=512kb -sALLOW_MEMORY_GROWTH=1 -sALLOW_TABLE_GROWTH=1 -sPURE_WASI --export-table)
+        # Emscripten flags
+        set_target_properties(${WCLAP_TARGET} PROPERTIES
+                COMPILE_FLAGS "-msimd128" # TODO: add this to the static library as well?
+                LINK_FLAGS    "-msimd128 -sSTANDALONE_WASM --no-entry -s EXPORTED_FUNCTIONS=_clap_entry,_malloc -s INITIAL_MEMORY=512kb -s ALLOW_MEMORY_GROWTH=1 -s ALLOW_TABLE_GROWTH=1 -s PURE_WASI --export-table"
+        )
 
         add_dependencies(${ALL_TARGET} ${WCLAP_TARGET})
     endif()

--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -5,6 +5,7 @@ function(target_add_auv2_wrapper)
             OUTPUT_NAME
             BUNDLE_IDENTIFIER
             BUNDLE_VERSION
+            RESOURCE_DIRECTORY
 
             MANUFACTURER_NAME
             MANUFACTURER_CODE
@@ -61,6 +62,10 @@ function(target_add_auv2_wrapper)
         message(WARNING "clap-wrapper: bundle version not defined. Chosing ${PROJECT_VERSION}")
         set(AUV2_BUNDLE_VERSION ${PROJECT_VERSION})
     endif ()
+
+    if (NOT DEFINED AUV2_RESOURCE_DIRECTORY)
+        set(AUV2_RESOURCE_DIRECTORY "")
+    endif()
 
     # We need a build helper which ejects our config code for info-plist and entry points
     set(bhtg ${AUV2_TARGET}-build-helper)
@@ -248,6 +253,11 @@ function(target_add_auv2_wrapper)
     macos_include_clap_in_bundle(TARGET ${AUV2_TARGET}
             MACOS_EMBEDDED_CLAP_LOCATION ${AUV2_MACOSX_EMBEDDED_CLAP_LOCATION})
     macos_bundle_flag(TARGET ${AUV2_TARGET})
+
+    # Copy resource directory, if defined
+    if(NOT AUV2_RESOURCE_DIRECTORY STREQUAL "")
+        message(WARNING "RESOURCE_DIRECTORY defined, but not (yet) supported for AUV2")
+    endif()
 
     if (${CLAP_WRAPPER_COPY_AFTER_BUILD})
         target_copy_after_build(TARGET ${AUV2_TARGET} FLAVOR auv2)

--- a/cmake/wrap_clap.cmake
+++ b/cmake/wrap_clap.cmake
@@ -13,6 +13,7 @@ function(target_add_clap_configuration)
             OUTPUT_NAME
             BUNDLE_IDENTIFIER
             BUNDLE_VERSION
+            RESOURCE_DIRECTORY
     )
     cmake_parse_arguments(TCLP "" "${oneValueArgs}" "" ${ARGN} )
 
@@ -35,6 +36,10 @@ function(target_add_clap_configuration)
         set(TCLP_BUNDLE_VERSION "0.1")
     endif()
 
+    if (NOT DEFINED TCLP_RESOURCE_DIRECTORY)
+        set(TCLP_RESOURCE_DIRECTORY "")
+    endif()
+
     if(APPLE)
         set_target_properties(${TCLP_TARGET} PROPERTIES
                 BUNDLE True
@@ -46,6 +51,13 @@ function(target_add_clap_configuration)
                 MACOSX_BUNDLE_BUNDLE_VERSION "${TCLP_BUNDLE_VERSION}"
                 MACOSX_BUNDLE_SHORT_VERSION_STRING "${TCLP_BUNDLE_VERSION}"
         )
+
+        # Copy resource directory, if defined
+        if(NOT TCLP_RESOURCE_DIRECTORY STREQUAL "")
+            add_custom_command(TARGET ${TCLP_TARGET} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_directory "${TCLP_RESOURCE_DIRECTORY}" "$<TARGET_FILE_DIR:${TCLP_TARGET}>/../Resources"
+            )
+        endif()
 
         macos_bundle_flag(TARGET ${TCLP_TARGET})
 

--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -5,6 +5,7 @@ function(target_add_standalone_wrapper)
             OUTPUT_NAME
             BUNDLE_IDENTIFIER
             BUNDLE_VERSION
+            RESOURCE_DIRECTORY
 
             PLUGIN_INDEX
             PLUGIN_ID
@@ -44,6 +45,10 @@ function(target_add_standalone_wrapper)
 
     if (NOT DEFINED SA_MACOS_ICON)
         set(SA_MACOS_ICON "")
+    endif()
+
+    if (NOT DEFINED SA_RESOURCE_DIRECTORY)
+        set(SA_RESOURCE_DIRECTORY "")
     endif()
 
     guarantee_rtaudio()
@@ -182,6 +187,11 @@ function(target_add_standalone_wrapper)
     else()
         target_sources(${SA_TARGET} PRIVATE
                 ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/wrapasstandalone.cpp)
+    endif()
+
+    # Copy resource directory, if defined
+    if(NOT SA_RESOURCE_DIRECTORY STREQUAL "")
+        message(WARNING "RESOURCE_DIRECTORY defined, but not (yet) supported for standalone")
     endif()
 
     if (DEFINED SA_HOSTED_CLAP_NAME)

--- a/cmake/wrap_wclap_emscripten.cmake
+++ b/cmake/wrap_wclap_emscripten.cmake
@@ -4,6 +4,7 @@ function(target_add_wclap_configuration)
     set(oneValueArgs
             TARGET
             OUTPUT_NAME
+            RESOURCE_DIRECTORY
     )
     cmake_parse_arguments(TCLP "" "${oneValueArgs}" "" ${ARGN} )
 
@@ -30,6 +31,13 @@ function(target_add_wclap_configuration)
     add_custom_command(TARGET ${TCLP_TARGET} PRE_BUILD
             COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:${TCLP_TARGET}>"
     )
+
+    # Copy resource directory, if defined
+    if(NOT TCLP_RESOURCE_DIRECTORY STREQUAL "")
+        add_custom_command(TARGET ${TCLP_TARGET} PRE_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_directory "${TCLP_RESOURCE_DIRECTORY}" "$<TARGET_FILE_DIR:${TCLP_TARGET}>"
+        )
+    endif()
 
     if (${CLAP_WRAPPER_COPY_AFTER_BUILD})
         target_copy_after_build(TARGET ${TCLP_TARGET} FLAVOR wclap)


### PR DESCRIPTION
This works for MacOS CLAP/VST3.

It *should* print out a warning for all other platforms, saying this option is not supported.