### PR TITLE
Use CMAKE_SYSTEM_PROCESSOR when building the VST3 directories

### DIFF
--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -142,6 +142,8 @@ function(target_add_vst3_wrapper)
         endif()
 
     elseif(UNIX)
+        message(STATUS "clap-wrapper: Building the VST3 Bundle Folder using the CMAKE_SYSTEM_PROCESSOR variable: (${CMAKE_SYSTEM_PROCESSOR})")
+
         target_link_libraries(${V3_TARGET} PUBLIC "-ldl")
         target_link_libraries(${V3_TARGET} PRIVATE "-Wl,--no-undefined")
 

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -159,13 +159,13 @@ function(target_add_vst3_wrapper)
 
         add_custom_command(TARGET ${V3_TARGET} PRE_BUILD
                 WORKING_DIRECTORY ${v3root}
-                COMMAND ${CMAKE_COMMAND} -E make_directory "${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/x86_64-linux"
+                COMMAND ${CMAKE_COMMAND} -E make_directory "${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-linux"
                 )
         set_target_properties(${V3_TARGET} PROPERTIES
                 LIBRARY_OUTPUT_NAME ${V3_OUTPUT_NAME}
-                LIBRARY_OUTPUT_DIRECTORY "${v3root}/${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/x86_64-linux"
-                LIBRARY_OUTPUT_DIRECTORY_DEBUG "${v3root}/${v3root_d}/${V3_OUTPUT_NAME}.vst3/Contents/x86_64-linux"
-                LIBRARY_OUTPUT_DIRECTORY_RELEASE "${v3root}/${v3root_r}/${V3_OUTPUT_NAME}.vst3/Contents/x86_64-linux"
+                LIBRARY_OUTPUT_DIRECTORY "${v3root}/${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-linux"
+                LIBRARY_OUTPUT_DIRECTORY_DEBUG "${v3root}/${v3root_d}/${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-linux"
+                LIBRARY_OUTPUT_DIRECTORY_RELEASE "${v3root}/${v3root_r}/${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-linux"
                 SUFFIX ".so" PREFIX "")
     else()
         if (NOT ${V3_WINDOWS_FOLDER_VST3})
@@ -195,13 +195,13 @@ function(target_add_vst3_wrapper)
 
             add_custom_command(TARGET ${V3_TARGET} PRE_BUILD
                     WORKING_DIRECTORY ${v3root}
-                    COMMAND ${CMAKE_COMMAND} -E make_directory "${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/x86_64-win"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-win"
                     )
             set_target_properties(${V3_TARGET} PROPERTIES
                     LIBRARY_OUTPUT_NAME ${V3_OUTPUT_NAME}
-                    LIBRARY_OUTPUT_DIRECTORY "${v3root}/${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/x86_64-win"
-                    LIBRARY_OUTPUT_DIRECTORY_DEBUG "${v3root}/${v3root_d}/${V3_OUTPUT_NAME}.vst3/Contents/x86_64-win"
-                    LIBRARY_OUTPUT_DIRECTORY_RELEASE "${v3root}/${v3root_r}/${V3_OUTPUT_NAME}.vst3/Contents/x86_64-win"
+                    LIBRARY_OUTPUT_DIRECTORY "${v3root}/${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-win"
+                    LIBRARY_OUTPUT_DIRECTORY_DEBUG "${v3root}/${v3root_d}/${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-win"
+                    LIBRARY_OUTPUT_DIRECTORY_RELEASE "${v3root}/${v3root_r}/${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-win"
                     SUFFIX ".vst3")
         endif()
     endif()

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -179,7 +179,17 @@ function(target_add_vst3_wrapper)
                         LIBRARY_OUTPUT_DIRECTORY "${V3_ASSET_OUTPUT_DIRECTORY}")
             endif()
         else()
-            message(STATUS "clap-wrapper: Building VST3 Bundle Folder")
+            message(STATUS "clap-wrapper: Building the VST3 Bundle Folder using the CMAKE_SYSTEM_PROCESSOR variable: (${CMAKE_SYSTEM_PROCESSOR})")
+
+            # Check against the list of supported targets found here:
+            # https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Locations+Format/Plugin+Format.html#for-the-windows-platform
+            if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "x86"
+                    AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"
+                    AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64ec"
+                    AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64"
+                    AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64x")
+                message(WARNING "clap-wrapper: The architecture (${CMAKE_SYSTEM_PROCESSOR}) is not officially suported by VST3. This may cause issues when loading the resulting plug-in")
+            endif()
 
             if ("${V3_ASSET_OUTPUT_DIRECTORY}" STREQUAL "")
                 set(v3root "${CMAKE_BINARY_DIR}")


### PR DESCRIPTION
This patch simply removes hard-coded "x86_64" when creating the .vst3 directory structure on Windows and Linux and replaces it with the `CMAKE_SYSTEM_PROCESSOR` variable.