### PR TITLE
Silence warnings when parent project has fmt-header-only target

### DIFF
--- a/src/detail/os/log.h
+++ b/src/detail/os/log.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 

--- a/src/detail/standalone/windows/windows_standalone.h
+++ b/src/detail/standalone/windows/windows_standalone.h
@@ -21,7 +21,7 @@
 #include <winrt/windows.foundation.h>
 #include <winrt/windows.data.json.h>
 
-#define FMT_HEADER_ONLY
+#define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 #include <fmt/xchar.h>
 


### PR DESCRIPTION
The `fmt-header-only` target in fmt defines `FMT_HEADER_ONLY` as `1` as seen [here](https://github.com/fmtlib/fmt/blob/b8192d233a4015144ba42be201ba15d9af8dfbdb/CMakeLists.txt#L379). However, throughout its use in clap-wrapper it is defined without the "1" leading to some warnings (or in my case errors). 

```
/Users/joe/Documents/GitHub/MiniMeters/external/clap-wrapper/src/detail/clap/../os/log.h:3:9: error: 'FMT_HEADER_ONLY' macro redefined [-Werror,-Wmacro-redefined]
    3 | #define FMT_HEADER_ONLY
      |         ^
<command line>:1:9: note: previous definition is here
    1 | #define FMT_HEADER_ONLY 1
      |         ^
1 error generated.
```

The simple fix is just to change the definitions in log.h and windows_standalone.h which is what this patch does.