### PR TITLE
Quote protect CMAKE_OSX_DEPLOYMENT_TARGET in IF

### DIFF
--- a/cmake/shared_prologue.cmake
+++ b/cmake/shared_prologue.cmake
@@ -25,7 +25,7 @@ endif()
 # deployment targets below 10.15 do not support std::filesystem
 if (APPLE)
     add_library(macos_filesystem_support INTERFACE)
-    if (${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_GREATER_EQUAL "10.15")
+    if ("${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_GREATER_EQUAL "10.15")
         message(STATUS "cmake-wrapper: using std::filesystem as macOS deployment it ${CMAKE_OSX_DEPLOYMENT_TARGET}; using std::filesystem")
         target_compile_definitions(macos_filesystem_support INTERFACE -DMACOS_USE_STD_FILESYSTEM)
     else()


### PR DESCRIPTION
this means if the deployment target is not set in cmake the comparison still proceeds without error