### PR TITLE
Fix thread-safety issues related to request_callback

### DIFF
--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -449,9 +449,12 @@ void Plugin::log(clap_log_severity severity, const char* msg)
 #endif
 }
 
+static thread_local uint32_t g_main_thread_override = 0;
+static thread_local uint32_t g_audio_thread_override = 0;
+
 bool Plugin::is_main_thread() const
 {
-  if (this->_main_thread_override > 0)
+  if (g_main_thread_override > 0)
   {
     return true;
   }
@@ -460,7 +463,7 @@ bool Plugin::is_main_thread() const
 
 bool Plugin::is_audio_thread() const
 {
-  if (this->_audio_thread_override > 0)
+  if (g_audio_thread_override > 0)
   {
     return true;
   }
@@ -469,12 +472,12 @@ bool Plugin::is_audio_thread() const
 
 CLAP_NODISCARD Raise Plugin::AlwaysAudioThread()
 {
-  return Raise(this->_audio_thread_override);
+  return Raise(g_audio_thread_override);
 }
 
 CLAP_NODISCARD Raise Plugin::AlwaysMainThread()
 {
-  return Raise(this->_main_thread_override);
+  return Raise(g_main_thread_override);
 }
 
 void Plugin::param_rescan(clap_param_rescan_flags flags)

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -121,7 +121,7 @@ struct ClapPluginExtensions
 class Raise
 {
  public:
-  Raise(std::atomic<uint32_t>& counter) : ctx(counter)
+  Raise(uint32_t& counter) : ctx(counter)
   {
     ++ctx;
   }
@@ -131,7 +131,7 @@ class Raise
   }
 
  private:
-  std::atomic<uint32_t>& ctx;
+  uint32_t& ctx;
 };
 
 /// <summary>
@@ -257,8 +257,6 @@ class Plugin
   clap_host_t _host;  // the host_t structure for the proxy
   IHost* _parentHost = nullptr;
   const std::thread::id _main_thread_id = std::this_thread::get_id();
-  std::atomic<uint32_t> _audio_thread_override = 0;
-  std::atomic<uint32_t> _main_thread_override = 0;
 
   AudioSetup _audioSetup;
 };

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -47,7 +47,6 @@ class queueEvent
     editstart,
     editvalue,
     editend,
-    triggerUICall,
   } type_t;
   type_t _type;
   union
@@ -55,15 +54,6 @@ class queueEvent
     clap_id _id;
     clap_event_param_value_t _value;
   } _data;
-};
-
-class TriggerUICallback : public queueEvent
-{
- public:
-  TriggerUICallback() : queueEvent()
-  {
-    this->_type = type::triggerUICall;
-  }
 };
 
 class BeginEvent : public queueEvent
@@ -372,7 +362,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
   }
   void request_callback() override
   {
-    _queueToUI.push(TriggerUICallback());
+    _requestUICallback = true;
   }
 
   void setupWrapperSpecifics(const clap_plugin_t* plugin)
@@ -559,6 +549,8 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   // ------------- for the MIDI output
   AUMIDIOutputCallbackStruct _midioutput_hostcallback = {nullptr, nullptr};
+
+  std::atomic_bool _requestUICallback = false;
 
   // the queue from audiothread to UI thread
   ClapWrapper::detail::shared::fixedqueue<queueEvent, 8192> _queueToUI;

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1105,19 +1105,16 @@ void WrapAsAUV2::onIdle()
         AUEventListenerNotify(NULL, NULL, &myEvent);
       }
       break;
-      case queueEvent::type::triggerUICall:
-      {
-        // if there is still a plugin
-        if (_plugin)
-        {
-          // also make sure the plugin knows this is the main thread
-          auto guarantee_mainthread = _plugin->AlwaysMainThread();
+    }
+  }
 
-          // and give the plugin some UI time...
-          _plugin->_plugin->on_main_thread(_plugin->_plugin);
-        }
-      }
-      break;
+  if (_requestUICallback)
+  {
+    _requestUICallback = false;
+    if (_plugin)
+    {
+      auto guarantee_mainthread = _plugin->AlwaysMainThread();
+      _plugin->_plugin->on_main_thread(_plugin->_plugin);
     }
   }
 }


### PR DESCRIPTION
Following on from #387, here are 2 changes:
- Fix is_main_thread/is_audio_thread by switching to use thread_local. Prior to this they could return true even when not the requested thread.
- Fix race condition in AU wrapper when using request_callback from threads other than the main thread/audio thread at the same time as other thread. We talked about adding a separate queue in the issue. But I found we can just copy what we already do in the VST3 wrapper and it's super simple.