### PR TITLE
Add VST3 Gain Reduction (Presonus Extension)

### DIFF
--- a/cmake/base_sdks.cmake
+++ b/cmake/base_sdks.cmake
@@ -72,7 +72,7 @@ function(guarantee_clap)
         CPMAddPackage(
                 NAME "clap"
                 GITHUB_REPOSITORY "free-audio/clap"
-                GIT_TAG "1.2.0"
+                GIT_TAG "1.2.6"
                 EXCLUDE_FROM_ALL TRUE
                 DOWNLOAD_ONLY TRUE
                 SOURCE_DIR cpm/clap

--- a/cmake/shared_prologue.cmake
+++ b/cmake/shared_prologue.cmake
@@ -25,7 +25,7 @@ endif()
 # deployment targets below 10.15 do not support std::filesystem
 if (APPLE)
     add_library(macos_filesystem_support INTERFACE)
-    if (${CMAKE_OSX_DEPLOYMENT_TARGET} VERSION_GREATER_EQUAL "10.15")
+    if ("${CMAKE_OSX_DEPLOYMENT_TARGET}" VERSION_GREATER_EQUAL "10.15")
         message(STATUS "cmake-wrapper: using std::filesystem as macOS deployment it ${CMAKE_OSX_DEPLOYMENT_TARGET}; using std::filesystem")
         target_compile_definitions(macos_filesystem_support INTERFACE -DMACOS_USE_STD_FILESYSTEM)
     else()

--- a/cmake/shared_prologue.cmake
+++ b/cmake/shared_prologue.cmake
@@ -179,6 +179,7 @@ function(guarantee_clap_wrapper_shared)
         message(STATUS "clap-wrapper: using included fmt library since no fmt-header-only available")
         target_include_directories(clap-wrapper-shared-detail PUBLIC libs/fmt)
     endif()
+
     target_include_directories(clap-wrapper-shared-detail PUBLIC src)
 
     if (APPLE)

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -31,6 +31,10 @@ function(private_add_vst3_wrapper_sources)
             )
 
     target_include_directories(${V3_TARGET}-clap-wrapper-vst3-lib PRIVATE "${sd}/include")
+
+    # psl
+    target_include_directories(${V3_TARGET}-clap-wrapper-vst3-lib PUBLIC libs/psl)
+
 endfunction(private_add_vst3_wrapper_sources)
 
 # define libraries

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -33,7 +33,7 @@ function(private_add_vst3_wrapper_sources)
     target_include_directories(${V3_TARGET}-clap-wrapper-vst3-lib PRIVATE "${sd}/include")
 
     # psl
-    target_include_directories(${V3_TARGET}-clap-wrapper-vst3-lib PUBLIC libs/psl)
+    target_include_directories(${V3_TARGET}-clap-wrapper-vst3-lib PUBLIC "${sd}/libs/psl")
 
 endfunction(private_add_vst3_wrapper_sources)
 

--- a/libs/psl/README.md
+++ b/libs/psl/README.md
@@ -1,0 +1,11 @@
+# Gain Reduction Extension
+
+Original source: 
+
+	https://github.com/fenderdigital/presonus-plugin-extension
+
+Licensed
+
+	Written and placed in the PUBLIC DOMAIN by PreSonus Software Ltd.
+
+This file is taken from the github repo above since it is the only extension the clap-wrapper currently supports.

--- a/libs/psl/presonus-plugin-extensions/ipslgainreduction.h
+++ b/libs/psl/presonus-plugin-extensions/ipslgainreduction.h
@@ -1,0 +1,54 @@
+//************************************************************************************************
+//
+// PreSonus Plug-In Extensions
+// Written and placed in the PUBLIC DOMAIN by PreSonus Software Ltd.
+//
+// Filename    : ipslgainreduction.h
+// Created by  : PreSonus Software Ltd., 03/2015
+// Description : Plug-in Gain Reduction Interface
+//
+//************************************************************************************************
+/*
+	DISCLAIMER:
+	PreSonus Plug-In Extensions are host-specific extensions of existing proprietary technologies,
+	provided to the community on an AS IS basis. They are not part of any official 3rd party SDK and
+	PreSonus is not affiliated with the owner of the underlying technology in any way.
+*/
+//************************************************************************************************
+
+#ifndef _ipslgainreduction_h
+#define _ipslgainreduction_h
+
+#include "pluginterfaces/base/funknown.h"
+#include "pluginterfaces/base/falignpush.h"
+
+namespace Presonus {
+
+//************************************************************************************************
+// IGainReductionInfo
+/**	Interface to report gain reduction imposed to the audio signal by the plug-in to the
+	host for display in the UI. Implemented by the VST3 edit controller class. 
+
+	@ingroup editController */
+//************************************************************************************************
+
+struct IGainReductionInfo: Steinberg::FUnknown
+{
+	/** Get current gain reduction for display. The returned value in dB is either 0.0 (no reduction)
+		or negative. The host calls this function periodically while the plug-in is active.
+		The value is used AS IS for UI display purposes, without imposing additional ballistics or
+		presentation latency compensation. Be sure to return zero if processing is bypassed internally.
+		For multiple reduction stages, please report the sum in dB here.
+	*/
+	virtual double PLUGIN_API getGainReductionValueInDb () = 0;
+
+    static const Steinberg::FUID iid;
+};
+
+DECLARE_CLASS_IID (IGainReductionInfo, 0x8e3c292c, 0x95924f9d, 0xb2590b1e, 0x100e4198)
+
+} // namespace Presonus
+
+#include "pluginterfaces/base/falignpop.h"
+
+#endif // _ipslgainreduction_h

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -220,6 +220,8 @@ void Plugin::connectClap(const clap_plugin_t* clap)
     getExtension(_plugin, _ext._contextmenu, CLAP_EXT_CONTEXT_MENU_COMPAT);
   }
 
+  getExtension(_plugin, _ext._gainreduc, CLAP_EXT_GAIN_ADJUSTMENT_METERING);
+
 #if LIN
   getExtension(_plugin, _ext._posixfd, CLAP_EXT_POSIX_FD_SUPPORT);
 #endif

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -25,6 +25,8 @@
 #endif
 
 #include "detail/clap/fsutil.h"
+#include <clap/ext/draft/gain-adjustment-metering.h>
+
 
 namespace Clap
 {
@@ -113,6 +115,7 @@ struct ClapPluginExtensions
   const clap_plugin_timer_support_t* _timer = nullptr;
   const clap_plugin_context_menu_t* _contextmenu = nullptr;
   const clap_ara_plugin_extension_t* _ara = nullptr;
+  const clap_plugin_gain_adjustment_metering_t* _gainreduc = nullptr; 
 #if LIN
   const clap_plugin_posix_fd_support* _posixfd = nullptr;
 #endif

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -27,7 +27,6 @@
 #include "detail/clap/fsutil.h"
 #include <clap/ext/draft/gain-adjustment-metering.h>
 
-
 namespace Clap
 {
 class Plugin;
@@ -115,7 +114,7 @@ struct ClapPluginExtensions
   const clap_plugin_timer_support_t* _timer = nullptr;
   const clap_plugin_context_menu_t* _contextmenu = nullptr;
   const clap_ara_plugin_extension_t* _ara = nullptr;
-  const clap_plugin_gain_adjustment_metering_t* _gainreduc = nullptr; 
+  const clap_plugin_gain_adjustment_metering_t* _gainreduc = nullptr;
 #if LIN
   const clap_plugin_posix_fd_support* _posixfd = nullptr;
 #endif

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -25,6 +25,7 @@
 
 DEF_CLASS_IID(ARA::IPlugInEntryPoint)
 DEF_CLASS_IID(ARA::IPlugInEntryPoint2)
+DEF_CLASS_IID(Presonus::IGainReductionInfo)
 
 #if 0
 --- 8< ---
@@ -1665,4 +1666,14 @@ tresult ClapAsVst3::getBusInfo(Vst::MediaType type, Vst::BusDirection dir, int32
     }
   }
   return SingleComponentEffect::getBusInfo(type, dir, index, bus);
+}
+
+double PLUGIN_API ClapAsVst3::getGainReductionValueInDb()
+{
+  auto* gr = _plugin->_ext._gainreduc;
+  if (gr)
+  {
+    return gr->get(_plugin->_plugin);
+  }
+  return 0.0;
 }

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -26,6 +26,8 @@
 #include <public.sdk/source/vst/vstnoteexpressiontypes.h>
 #include <pluginterfaces/vst/ivstcontextmenu.h>
 
+#include <presonus-plugin-extensions/ipslgainreduction.h>
+
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
@@ -115,6 +117,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
                    public Steinberg::Vst::IContextMenuTarget,
                    public ARA::IPlugInEntryPoint,
                    public ARA::IPlugInEntryPoint2,
+                   public Presonus::IGainReductionInfo,
                    public Clap::IHost,
                    public Clap::IAutomation,
                    public os::IPlugObject
@@ -130,6 +133,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
     , Steinberg::Vst::INoteExpressionController()
     , ARA::IPlugInEntryPoint()
     , ARA::IPlugInEntryPoint2()
+    , Presonus::IGainReductionInfo()
     , _library(lib)
     , _libraryIndex(number)
     , _creationcontext(context)
@@ -225,6 +229,9 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
       ARADocumentControllerRef documentControllerRef, ARAPlugInInstanceRoleFlags knownRoles,
       ARAPlugInInstanceRoleFlags assignedRoles) override;
 
+  //----from Presonus::GainReduction---------------------------
+  double PLUGIN_API getGainReductionValueInDb() override;
+
   //---Interface--------------------------------------------------------------------------
   OBJ_METHODS(ClapAsVst3, SingleComponentEffect)
   DEFINE_INTERFACES
@@ -256,6 +263,13 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
     if (_plugin->_ext._ara)
     {
       DEF_INTERFACE(IPlugInEntryPoint2)
+    }
+  }
+  if (::Steinberg::FUnknownPrivate::iidEqual(iid, Presonus::IGainReductionInfo::iid))
+  {
+    if (_plugin->_ext._gainreduc)
+    {
+      DEF_INTERFACE(Presonus::IGainReductionInfo);
     }
   }
 


### PR DESCRIPTION
This adds the ability for the VST3 wrapper to readout the extension `CLAP_EXT_GAIN_ADJUSTMENT_METERING` and pass it to VST3 hosts that support the `Presonus::IGainReductionInfo` interface, if the extension is present in the plugin.