### PR TITLE
add  CLAP_TRANSPORT_HAS_SECONDS_TIMELINE and  CLAP_TRANSPORT_HAS_BEAT…

### DIFF
--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -110,8 +110,9 @@ void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t fra
   }
 
   auto f = (float *)pOutput;
+
   clap_process process;
-  process.transport = nullptr;
+  process.transport = nullptr;            // this is a freefloating host
   process.in_events = &inputEvents;
   process.out_events = &outputEvents;
   process.frames_count = frameCount;
@@ -206,6 +207,7 @@ void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t fra
     memcpy(midi.data, ck.dat, sizeof(ck.dat));
     pushInputEvent(&(midi.header));
   }
+  
 
   clapPlugin->_plugin->process(clapPlugin->_plugin, &process);
 

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -206,7 +206,7 @@ void ProcessAdapter::process(Steinberg::Vst::ProcessData& data)
         ((_vstdata->processContext->state & Vst::ProcessContext::kTimeSigValid)
              ? CLAP_TRANSPORT_HAS_TIME_SIGNATURE
              : 0)
-
+      
         // the rest of the flags has no meaning to CLAP
         // kSystemTimeValid = 1 << 8,		///< systemTime contains valid information
         // kContTimeValid = 1 << 17,	///< continousTimeSamples contains valid information
@@ -225,11 +225,13 @@ void ProcessAdapter::process(Steinberg::Vst::ProcessData& data)
     _transport.song_pos_beats = 0;
 
     // samplerate and projectTimeSamples are always valid
+    _transport.flags |= CLAP_TRANSPORT_HAS_SECONDS_TIMELINE;
     _transport.song_pos_seconds = doubleToSecTime(_vstdata->processContext->projectTimeSamples /
                                                   _vstdata->processContext->sampleRate);
 
     if ((_vstdata->processContext->state & Vst::ProcessContext::kProjectTimeMusicValid))
     {
+      _transport.flags |= CLAP_TRANSPORT_HAS_BEATS_TIMELINE;
       _transport.song_pos_beats = doubleToBeatTime(_vstdata->processContext->projectTimeMusic);
     }
 


### PR DESCRIPTION
When filling the members `song_pos_seconds`and `song_pos_beats` the flags `CLAP_TRANSPORT_HAS_SECONDS_TIMELINE` and  `CLAP_TRANSPORT_HAS_BEATS_TIMELINE` need to be added to the process flags, too.

