### PR TITLE
fix #392 for VST3

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -129,7 +129,7 @@ tresult PLUGIN_API ClapAsVst3::initialize(FUnknown* context)
     {
       _plugin = Clap::Plugin::createInstance(*_library, _libraryIndex, this);
     }
-    result = (_plugin->initialize()) ? kResultOk : kResultFalse;
+    result = (_plugin && _plugin->initialize()) ? kResultOk : kResultFalse;
   }
 
   return result;


### PR DESCRIPTION
Fix null dereference when createInstance has an error and returns nullptr.