### PR TITLE
AU: consider inDesiredNameLength and protect against null input

### DIFF
--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -545,12 +545,14 @@ OSStatus WrapAsAUV2::SetParameter(AudioUnitParameterID inID, AudioUnitScope inSc
 OSStatus WrapAsAUV2::CopyClumpName(AudioUnitScope inScope, UInt32 inClumpID, UInt32 inDesiredNameLength,
                                    CFStringRef* outClumpName)
 {
+  if (outClumpName == nullptr) return kAudioUnitErr_InvalidParameter;
   if (inScope == kAudioUnitScope_Global)
   {
     auto p = _clumps.getClump(inClumpID);
     if (p)
     {
-      *outClumpName = CFStringCreateWithCString(NULL, p, kCFStringEncodingUTF8);
+      auto const len = std::min(strlen(p), (size_t)inDesiredNameLength);
+      *outClumpName = CFStringCreateWithBytes(NULL, (const UInt8*)p, len, kCFStringEncodingUTF8, false);
       return noErr;
     }
   }


### PR DESCRIPTION
We were not considering inDesiredNameLength, which I think is a problem if you have long module names in your CLAP.

Does this change look reasonable?

I will say that 2 months ago I got a report that I user had a crash in this function. I implemented this change and I have seen no further reports of this issue.

```
   ausdk::AUMethodGetProperty (/Users/runner/.cache/zig/p/N-V-__8AABXaAwCPe89grjjAXjcvmKwtSHo-0bx570E4IGYf/src/AudioUnitSDK/AUPlugInDispatch.cpp:157)
   ausdk::AUBase::DispatchGetProperty (/Users/runner/.cache/zig/p/N-V-__8AABXaAwCPe89grjjAXjcvmKwtSHo-0bx570E4IGYf/src/AudioUnitSDK/AUBase.cpp:627)
   free_audio::auv2_wrapper::WrapAsAUV2::CopyClumpName (/Users/runner/.cache/zig/p/N-V-__8AAI0aEAAgIOKJQmqSWnD9V2gBob6pqElBItNJFfsE/src/wrapasauv2.cpp:534)
   free_audio::auv2_wrapper::Clumps::getClump (/Users/runner/.cache/zig/p/N-V-__8AAI0aEAAgIOKJQmqSWnD9V2gBob6pqElBItNJFfsE/src/detail/auv2/auv2_base_classes.h:109)
   null (external-file)
   null (external-file)
   null (external-file)
   null (external-file)
   __ubsan_handle_type_mismatch_v1 (src/utils/debug/debug.cpp:235)
   HandleUbsanError (src/utils/debug/debug.cpp:81)
```