### PR TITLE
Fix thread-safety when calling request_resize()

### DIFF
--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -262,18 +262,15 @@ tresult PLUGIN_API WrappedView::checkSizeConstraint(ViewRect* rect)
 
 bool WrappedView::request_resize(uint32_t width, uint32_t height)
 {
+  if (_main_thread_id != std::this_thread::get_id())
+  {
+    resize_request = {width, height};
+    return true;
+  }
+
   auto oldrect = _rect;
   _rect.right = _rect.left + (int32)width;
   _rect.bottom = _rect.top + (int32)height;
-
-  if (_main_thread_id != std::this_thread::get_id())
-  {
-    requested_width = width;
-    requested_height = height;
-    // call request_resize again from ClapAsVst3::onIdle()
-    needs_resize_from_main_thread = true;
-    return true;
-  }
 
   if (_plugFrame && !_plugFrame->resizeView(this, &_rect))
   {

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -14,6 +14,7 @@
 #include <clap/clap.h>
 #include <functional>
 #include <thread>
+#include <atomic>
 
 using namespace Steinberg;
 

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -99,7 +99,14 @@ class WrappedView : public Steinberg::IPlugView,
   // processed in ClapAsVst3::onIdle()
   struct GuiResizeRequest
   {
-    bool operator==(GuiResizeRequest const& other) const = default;
+    bool operator==(GuiResizeRequest const& other) const
+    {
+      return w == other.w && h == other.h;
+    }
+    bool operator!=(GuiResizeRequest const& other) const
+    {
+      return w != other.w || h != other.h;
+    }
     uint32_t w, h;
   };
   constexpr static GuiResizeRequest invalid_size = {(uint32_t)-1, (uint32_t)-1};

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -97,9 +97,13 @@ class WrappedView : public Steinberg::IPlugView,
   bool request_resize(uint32_t width, uint32_t height);
 
   // processed in ClapAsVst3::onIdle()
-  std::atomic_bool needs_resize_from_main_thread = {false};
-  uint32_t requested_width = 0;
-  uint32_t requested_height = 0;
+  struct GuiResizeRequest
+  {
+    bool operator==(GuiResizeRequest const& other) const = default;
+    uint32_t w, h;
+  };
+  constexpr static GuiResizeRequest invalid_size = {(uint32_t)-1, (uint32_t)-1};
+  std::atomic<GuiResizeRequest> resize_request{invalid_size};
 
  private:
   void ensure_ui();

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -13,6 +13,7 @@
 #include <pluginterfaces/gui/iplugviewcontentscalesupport.h>
 #include <clap/clap.h>
 #include <functional>
+#include <thread>
 
 using namespace Steinberg;
 
@@ -94,6 +95,11 @@ class WrappedView : public Steinberg::IPlugView,
   // wrapper needed interfaces
   bool request_resize(uint32_t width, uint32_t height);
 
+  // processed in ClapAsVst3::onIdle()
+  std::atomic_bool needs_resize_from_main_thread = {false};
+  uint32_t requested_width = 0;
+  uint32_t requested_height = 0;
+
  private:
   void ensure_ui();
   void drop_ui();
@@ -107,6 +113,7 @@ class WrappedView : public Steinberg::IPlugView,
   ViewRect _rect = {0, 0, 0, 0};
   bool _created = false;
   bool _attached = false;
+  std::thread::id _main_thread_id{};
 
 #if LIN
  public:

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -1293,10 +1293,13 @@ void ClapAsVst3::onIdle()
     _plugin->_plugin->on_main_thread(_plugin->_plugin);
   }
 
-  if (_wrappedview->needs_resize_from_main_thread)
+  if (_wrappedview)
   {
-    _wrappedview->request_resize(_wrappedview->requested_width, _wrappedview->requested_height);
-    _wrappedview->needs_resize_from_main_thread = false;
+    if (auto const size = _wrappedview->resize_request.exchange(WrappedView::invalid_size);
+        size != WrappedView::invalid_size)
+    {
+      _wrappedview->request_resize(size.w, size.h);
+    }
   }
 
 #if LIN

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -9,6 +9,7 @@
 #include "detail/vst3/process.h"
 #include "detail/vst3/parameter.h"
 #include "detail/clap/fsutil.h"
+#include <atomic>
 #include <locale>
 #include <sstream>
 
@@ -1290,6 +1291,12 @@ void ClapAsVst3::onIdle()
   {
     _requestUICallback = false;
     _plugin->_plugin->on_main_thread(_plugin->_plugin);
+  }
+
+  if (_wrappedview->needs_resize_from_main_thread)
+  {
+    _wrappedview->request_resize(_wrappedview->requested_width, _wrappedview->requested_height);
+    _wrappedview->needs_resize_from_main_thread = false;
   }
 
 #if LIN


### PR DESCRIPTION
This patch checks if calls to request_resize() happen on the main UI thread, and if not, sets a flag and stores the requested size so ClapAsVst3::onIdle() can handle the request.