### PR TITLE
checking the instance pointer after creating a plugin instance

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -129,7 +129,7 @@ tresult PLUGIN_API ClapAsVst3::initialize(FUnknown* context)
     {
       _plugin = Clap::Plugin::createInstance(*_library, _libraryIndex, this);
     }
-    result = (_plugin->initialize()) ? kResultOk : kResultFalse;
+    result = (_plugin && _plugin->initialize()) ? kResultOk : kResultFalse;
   }
 
   return result;


### PR DESCRIPTION
Additional checking if the plugin pointer is not `nullptr` in case something in the plugin has been going wrong.

If this function returns an `nullptr`, it is a serious bug in the CLAP itself - yet, we want to check.