### PR TITLE
Fix thread-safety when calling request_resize()

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -1111,7 +1111,7 @@ bool ClapAsVst3::gui_can_resize()
 bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height)
 {
   // UIs with 65kx65k resolution are not supported
-  if ((width > 0xffff) && (height > 0xffff)) return false;
+  if ((width > 0xffff) || (height > 0xffff)) return false;
 
   if (_main_thread_id != std::this_thread::get_id())
   {

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -12,6 +12,10 @@
 #include <locale>
 #include <sstream>
 
+// we need this lock free since we can request a gui resize from any thread in CLAP
+static_assert(std::atomic<uint32_t>::is_always_lock_free,
+              "compiler must ensure that std::atomic<uint32_t> is lock free");
+
 #if WIN
 #include <tchar.h>
 #define S16(x) reinterpret_cast<const Steinberg::Vst::TChar*>(_T(x))
@@ -1106,6 +1110,16 @@ bool ClapAsVst3::gui_can_resize()
 
 bool ClapAsVst3::gui_request_resize(uint32_t width, uint32_t height)
 {
+  // UIs with 65kx65k resolution are not supported
+  if ((width > 0xffff) && (height > 0xffff)) return false;
+
+  if (_main_thread_id != std::this_thread::get_id())
+  {
+    uint32_t newSize = ((width & 0xffff) << 16) | (height & 0xffff);
+    _gui_resize_request.store(newSize);
+    return true;
+  }
+
   if (_wrappedview)
     return _wrappedview->request_resize(width, height);
   else
@@ -1290,6 +1304,16 @@ void ClapAsVst3::onIdle()
   {
     _requestUICallback = false;
     _plugin->_plugin->on_main_thread(_plugin->_plugin);
+  }
+
+  if (_wrappedview)
+  {
+    if (auto const size = _gui_resize_request.exchange(_gui_invalid_size); size != _gui_invalid_size)
+    {
+      auto w = (size >> 16) & 0xffff;
+      auto h = (size & 0xffff);
+      _wrappedview->request_resize(w, h);
+    }
   }
 
 #if LIN

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -40,6 +40,8 @@
 #include "detail/vst3/aravst3.h"
 #include "detail/shared/spinlock.h"
 #include <mutex>
+#include <thread>
+#include <atomic>
 
 using namespace Steinberg;
 
@@ -385,6 +387,11 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   std::atomic_bool _requestUICallback = false;
   bool _missedLatencyRequest = false;
+  
+  std::thread::id _main_thread_id{};
+  static const uint32_t _gui_invalid_size = 0xffffffff;
+  std::atomic<uint32_t> _gui_resize_request = _gui_invalid_size;
+
 
   // the queue from audiothread to UI thread
   ClapWrapper::detail::shared::fixedqueue<queueEvent, 8192> _queueToUI;

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -387,11 +387,10 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   std::atomic_bool _requestUICallback = false;
   bool _missedLatencyRequest = false;
-  
+
   std::thread::id _main_thread_id{};
   static const uint32_t _gui_invalid_size = 0xffffffff;
   std::atomic<uint32_t> _gui_resize_request = _gui_invalid_size;
-
 
   // the queue from audiothread to UI thread
   ClapWrapper::detail::shared::fixedqueue<queueEvent, 8192> _queueToUI;


### PR DESCRIPTION
This patch checks if calls to request_resize() happen on the main UI thread, and if not, sets a flag and stores the requested size so ClapAsVst3::onIdle() can handle the request.