### PR TITLE
AUv2: make GetParameterInfo() thread safe

### DIFF
--- a/src/detail/auv2/parameter.cpp
+++ b/src/detail/auv2/parameter.cpp
@@ -4,17 +4,66 @@
 namespace Clap::AUv2
 {
 
-Parameter::Parameter(clap_param_info_t &clap_param)
+Parameter::Parameter(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext, const clap_param_info_t &clap_param)
 {
-  _info = clap_param;
-  _cfstring = CFStringCreateWithCString(NULL, _info.name, kCFStringEncodingUTF8);
+  updateInfo(plugin, clap_param_ext, clap_param);
 }
 
-void Parameter::resetInfo(const clap_param_info_t &i)
+void Parameter::updateInfo(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext, const clap_param_info_t& i)
 {
+  if ( _cfstring )
+  {
+    CFRelease(_cfstring);
+  }
   _info = i;
-  CFRelease(_cfstring);
   _cfstring = CFStringCreateWithCString(NULL, _info.name, kCFStringEncodingUTF8);
+  
+  const auto& info = _info;
+  AudioUnitParameterOptions flags = 0;
+
+  flags |= kAudioUnitParameterFlag_Global;
+
+  if (!(info.flags & CLAP_PARAM_IS_AUTOMATABLE)) flags |= kAudioUnitParameterFlag_NonRealTime;
+  if (!(info.flags & CLAP_PARAM_IS_HIDDEN))
+  {
+    if (info.flags & CLAP_PARAM_IS_READONLY)
+      flags |= kAudioUnitParameterFlag_IsReadable;
+    else
+      flags |= kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_IsWritable;
+  }
+  if (info.flags & CLAP_PARAM_IS_STEPPED)
+  {
+    if (info.max_value - info.min_value == 1)
+    {
+      flags |= kAudioUnitParameterUnit_Boolean;
+    }
+    // flags |= kAudioUnitParameterUnit_Indexed;  // probably need to add the lists then
+  }
+  if (info.max_value - info.min_value > 100)
+  {
+    flags |= kAudioUnitParameterFlag_IsHighResolution;
+  }
+
+  // checking if the parameter supports the conversion of its value to text
+
+  // we can't get the value since we are not in the audio thread
+  // auto guarantee_mainthread = _plugin->AlwaysMainThread();
+  
+  {
+    char buf[200];
+    if (clap_param_ext->value_to_text(plugin, info.id, info.default_value, buf, sizeof(buf)))
+    {
+      flags |= kAudioUnitParameterFlag_HasName;
+    }
+  }
+
+  /*
+   * The CFString() used from the param can reset which releases it. So add a ref count
+   * and ask the param to release it too
+   */
+  flags |= kAudioUnitParameterFlag_HasCFNameString | kAudioUnitParameterFlag_CFNameRelease;
+  
+  _flags = flags;
 }
 Parameter::~Parameter()
 {

--- a/src/detail/auv2/parameter.cpp
+++ b/src/detail/auv2/parameter.cpp
@@ -4,20 +4,22 @@
 namespace Clap::AUv2
 {
 
-Parameter::Parameter(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext, const clap_param_info_t &clap_param)
+Parameter::Parameter(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext,
+                     const clap_param_info_t& clap_param)
 {
   updateInfo(plugin, clap_param_ext, clap_param);
 }
 
-void Parameter::updateInfo(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext, const clap_param_info_t& i)
+void Parameter::updateInfo(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext,
+                           const clap_param_info_t& i)
 {
-  if ( _cfstring )
+  if (_cfstring)
   {
     CFRelease(_cfstring);
   }
   _info = i;
   _cfstring = CFStringCreateWithCString(NULL, _info.name, kCFStringEncodingUTF8);
-  
+
   const auto& info = _info;
   AudioUnitParameterOptions flags = 0;
 
@@ -48,7 +50,7 @@ void Parameter::updateInfo(const clap_plugin_t* plugin, const clap_plugin_params
 
   // we can't get the value since we are not in the audio thread
   // auto guarantee_mainthread = _plugin->AlwaysMainThread();
-  
+
   {
     char buf[200];
     if (clap_param_ext->value_to_text(plugin, info.id, info.default_value, buf, sizeof(buf)))
@@ -62,7 +64,7 @@ void Parameter::updateInfo(const clap_plugin_t* plugin, const clap_plugin_params
    * and ask the param to release it too
    */
   flags |= kAudioUnitParameterFlag_HasCFNameString | kAudioUnitParameterFlag_CFNameRelease;
-  
+
   _flags = flags;
 }
 Parameter::~Parameter()

--- a/src/detail/auv2/parameter.h
+++ b/src/detail/auv2/parameter.h
@@ -28,14 +28,14 @@
 #include <AudioUnit/AudioUnitParameters.h>
 #include <AudioUnit/AUComponent.h>
 
-
 namespace Clap::AUv2
 {
 
 class Parameter
 {
  public:
-  Parameter(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext, const clap_param_info_t& clap_param);
+  Parameter(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext,
+            const clap_param_info_t& clap_param);
   ~Parameter();
   const clap_param_info_t& info() const
   {
@@ -50,7 +50,8 @@ class Parameter
     return _flags;
   }
 
-  void updateInfo(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext, const clap_param_info_t& i);
+  void updateInfo(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext,
+                  const clap_param_info_t& i);
 
  private:
   clap_param_info_t _info;

--- a/src/detail/auv2/parameter.h
+++ b/src/detail/auv2/parameter.h
@@ -28,13 +28,14 @@
 #include <AudioUnit/AudioUnitParameters.h>
 #include <AudioUnit/AUComponent.h>
 
+
 namespace Clap::AUv2
 {
 
 class Parameter
 {
  public:
-  Parameter(clap_param_info_t& clap_param);
+  Parameter(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext, const clap_param_info_t& clap_param);
   ~Parameter();
   const clap_param_info_t& info() const
   {
@@ -44,12 +45,17 @@ class Parameter
   {
     return _cfstring;
   }
+  AudioUnitParameterOptions AudioUnitFlags() const
+  {
+    return _flags;
+  }
 
-  void resetInfo(const clap_param_info_t& i);
+  void updateInfo(const clap_plugin_t* plugin, const clap_plugin_params_t* clap_param_ext, const clap_param_info_t& i);
 
  private:
   clap_param_info_t _info;
-  CFStringRef _cfstring;
+  CFStringRef _cfstring = nullptr;
+  AudioUnitParameterOptions _flags;
 };
 
 }  // namespace Clap::AUv2

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -90,7 +90,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
   ui = *cont;
   canary = 0xbeebbeeb;
-  
+
   if (ui._registerWindow)
   {
     ui._registerWindow((clap_window_t *)self, &canary);
@@ -148,9 +148,9 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 {
   // auto gui = ui._plugin->_ext._gui;
 }
-- (void) viewDidMoveToWindow
+- (void)viewDidMoveToWindow
 {
-  if ( [self window] == nil )
+  if ([self window] == nil)
   {
     LOGINFO("[clap-wrapper] - view removed from a window");
     if (idleTimer)
@@ -158,10 +158,10 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
       CFRunLoopTimerInvalidate(idleTimer);
       idleTimer = 0;
     }
-    if ( canary )
+    if (canary)
     {
       ui._destroyWindow();
-      
+
       assert(canary == 0);
     }
   }
@@ -175,7 +175,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   {
     CFRunLoopTimerInvalidate(idleTimer);
   }
-  if ( canary )
+  if (canary)
   {
     LOGINFO("[clap-wrapper] the host did not call viewDidMoveWindow with a nil window");
     ui._destroyWindow();
@@ -185,7 +185,7 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 - (void)setFrame:(NSRect)newSize
 {
   [super setFrame:newSize];
-  if ( canary )
+  if (canary)
   {
     auto gui = ui._plugin->_ext._gui;
     gui->set_scale(ui._plugin->_plugin, 1.0);

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -365,7 +365,8 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
           {
             // creating the mapping object and insert it into the tree
             // this will also create Clumps if necessary
-            _parametertree[paraminfo.id] = std::make_unique<Clap::AUv2::Parameter>(_plugin->_plugin, p, paraminfo);
+            _parametertree[paraminfo.id] =
+                std::make_unique<Clap::AUv2::Parameter>(_plugin->_plugin, p, paraminfo);
           }
           else
           {
@@ -443,7 +444,6 @@ OSStatus WrapAsAUV2::GetParameterInfo(AudioUnitScope inScope, AudioUnitParameter
   // const uint64_t stdflag = kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_IsWritable;
   if (inScope == kAudioUnitScope_Global)
   {
-    
     auto pi = _parametertree.find(inParameterID);
     if (pi != _parametertree.end())
     {

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -365,11 +365,11 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t* plugin, const clap_plugin_
           {
             // creating the mapping object and insert it into the tree
             // this will also create Clumps if necessary
-            _parametertree[paraminfo.id] = std::make_unique<Clap::AUv2::Parameter>(paraminfo);
+            _parametertree[paraminfo.id] = std::make_unique<Clap::AUv2::Parameter>(_plugin->_plugin, p, paraminfo);
           }
           else
           {
-            piter->second->resetInfo(paraminfo);
+            piter->second->updateInfo(_plugin->_plugin, p, paraminfo);
           }
           Globals()->SetParameter(paraminfo.id, result);
         }
@@ -443,57 +443,14 @@ OSStatus WrapAsAUV2::GetParameterInfo(AudioUnitScope inScope, AudioUnitParameter
   // const uint64_t stdflag = kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_IsWritable;
   if (inScope == kAudioUnitScope_Global)
   {
-    AudioUnitParameterOptions flags = 0;
+    
     auto pi = _parametertree.find(inParameterID);
     if (pi != _parametertree.end())
     {
       auto f = pi->second.get();
-      const auto info = f->info();
+      const auto& info = f->info();
 
-      flags |= kAudioUnitParameterFlag_Global;
-
-      if (!(info.flags & CLAP_PARAM_IS_AUTOMATABLE)) flags |= kAudioUnitParameterFlag_NonRealTime;
-      if (!(info.flags & CLAP_PARAM_IS_HIDDEN))
-      {
-        if (info.flags & CLAP_PARAM_IS_READONLY)
-          flags |= kAudioUnitParameterFlag_IsReadable;
-        else
-          flags |= kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_IsWritable;
-      }
-      if (info.flags & CLAP_PARAM_IS_STEPPED)
-      {
-        if (info.max_value - info.min_value == 1)
-        {
-          flags |= kAudioUnitParameterUnit_Boolean;
-        }
-        // flags |= kAudioUnitParameterUnit_Indexed;  // probably need to add the lists then
-      }
-      if (info.max_value - info.min_value > 100)
-      {
-        flags |= kAudioUnitParameterFlag_IsHighResolution;
-      }
-
-      // checking if the parameter supports the conversion of its value to text
-
-      // we can't get the value since we are not in the audio thread
-      auto guarantee_mainthread = _plugin->AlwaysMainThread();
-      double value;
-      if (_plugin->_ext._params->get_value(_plugin->_plugin, info.id, &value))
-      {
-        char buf[200];
-        if (_plugin->_ext._params->value_to_text(_plugin->_plugin, info.id, value, buf, sizeof(buf)))
-        {
-          flags |= kAudioUnitParameterFlag_HasName;
-        }
-      }
-
-      /*
-       * The CFString() used from the param can reset which releases it. So add a ref count
-       * and ask the param to release it too
-       */
-      flags |= kAudioUnitParameterFlag_HasCFNameString | kAudioUnitParameterFlag_CFNameRelease;
-
-      outParameterInfo.flags = flags;
+      outParameterInfo.flags = f->AudioUnitFlags();
 
       // according to the documentation, the name field should be zeroed. In fact, AULab does display anything then.
       // strcpy(outParameterInfo.name, info.name);


### PR DESCRIPTION
should fix an AUv2 issue when GetParameterInfo() is being called
See #395 