### PR TITLE
Feature/auv2 musiceffect support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ ignore/
 build/
 out/
 .DS_Store
+
+#vscode
+.vscode/*

--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -88,7 +88,6 @@ function(target_add_auv2_wrapper)
         get_property(ton TARGET ${clpt} PROPERTY LIBRARY_OUTPUT_NAME)
         set(AUV2_OUTPUT_NAME "${ton}")
         set(AUV2_SUBTYPE_CODE "Fooo")
-        set(AUV2_INSTRUMENT_TYPE "aumu")
 
         add_dependencies(${AUV2_TARGET} ${clpt})
         add_dependencies(${bhtg} ${clpt})
@@ -107,7 +106,6 @@ function(target_add_auv2_wrapper)
     elseif (DEFINED AUV2_MACOSX_EMBEDDED_CLAP_LOCATION)
         message(STATUS "clap-wrapper: building auv2 based on clap ${AUV2_MACOSX_EMBEDDED_CLAP_LOCATION}")
         set(AUV2_SUBTYPE_CODE "----")
-        set(AUV2_INSTRUMENT_TYPE "aumu")
 
         add_custom_command(
                 TARGET ${bhtg}
@@ -118,7 +116,7 @@ function(target_add_auv2_wrapper)
                 COMMAND $<TARGET_FILE:${bhtg}> --fromclap
                 "${AUV2_OUTPUT_NAME}"
                 "${AUV2_MACOSX_EMBEDDED_CLAP_LOCATION}" "${AUV2_BUNDLE_VERSION}"
-                "${AUV2_MANUFACTURER_CODE}" "${AUV2_MANUFACTURER_NAME}"
+                "${AUV2_MANUFACTURER_CODE}" "${AUV2_MANUFACTURER_NAME}" "${AUV2_INSTRUMENT_TYPE}"
         )
     else ()
         if (NOT DEFINED AUV2_OUTPUT_NAME)

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -94,7 +94,7 @@ struct auInfo
 };
 
 bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname, std::string &manu,
-                        std::string &manuName, std::vector<auInfo> &units)
+                        std::string &manuName, std::vector<auInfo> &units, std::string &type)
 {
   Clap::Library loader;
   if (!loader.load(clapfile))
@@ -145,23 +145,27 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
     u.manu = manu;
     u.manunm = manuName;
 
-    auto f = clapPlug->features[0];
-    if (f == nullptr || strcmp(f, CLAP_PLUGIN_FEATURE_INSTRUMENT) == 0)
-    {
-      u.type = "aumu";
-    }
-    else if (strcmp(f, CLAP_PLUGIN_FEATURE_AUDIO_EFFECT) == 0)
-    {
-      u.type = "aufx";
-    }
-    else if (strcmp(f, CLAP_PLUGIN_FEATURE_NOTE_EFFECT) == 0)
-    {
-      u.type = "aumi";
-    }
-    else
-    {
-      std::cout << "[WARNING] can't determine instrument type. Using aumu" << std::endl;
-      u.type = "aumu";
+    if (type.empty()) {
+      auto f = clapPlug->features[0];
+      if (f == nullptr || strcmp(f, CLAP_PLUGIN_FEATURE_INSTRUMENT) == 0)
+      {
+        u.type = "aumu";
+      }
+      else if (strcmp(f, CLAP_PLUGIN_FEATURE_AUDIO_EFFECT) == 0)
+      {
+        u.type = "aufx";
+      }
+      else if (strcmp(f, CLAP_PLUGIN_FEATURE_NOTE_EFFECT) == 0)
+      {
+        u.type = "aumi";
+      }
+      else
+      {
+        std::cout << "[WARNING] can't determine instrument type. Using aumu" << std::endl;
+        u.type = "aumu";
+      }
+    } else {
+      u.type = type;
     }
 
     auto fp = clapPlug->features;
@@ -249,6 +253,7 @@ int main(int argc, char **argv)
     auto bundlev = std::string(argv[idx++]);
     auto mcode = (idx < argc) ? std::string(argv[idx++]) : std::string();
     auto mname = (idx < argc) ? std::string(argv[idx++]) : std::string();
+    auto type = (idx < argc) ? std::string(argv[idx++]) : std::string();
 
     try
     {
@@ -274,7 +279,7 @@ int main(int argc, char **argv)
     std::cout << "  - building information from CLAP directly\n"
               << "  - source clap: '" << clapfile << "'" << std::endl;
 
-    if (!buildUnitsFromClap(clapfile, clapname, mcode, mname, units))
+    if (!buildUnitsFromClap(clapfile, clapname, mcode, mname, units, type))
     {
       std::cout << "[ERROR] Can't build units from CLAP" << std::endl;
       return 4;

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -93,6 +93,16 @@ struct auInfo
   }
 };
 
+bool contains(const char* const* array, const char* target) {
+  if (!array || !target) return false;
+  for (auto p = array; *p != nullptr; ++p) {
+    if (strcmp(*p, target) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname, std::string &manu,
                         std::string &manuName, std::vector<auInfo> &units, std::string &type)
 {
@@ -146,16 +156,24 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
     u.manunm = manuName;
 
     if (type.empty()) {
-      auto f = clapPlug->features[0];
-      if (f == nullptr || strcmp(f, CLAP_PLUGIN_FEATURE_INSTRUMENT) == 0)
+      auto f = clapPlug->features;
+      if (!f || f[0] == nullptr)
       {
         u.type = "aumu";
       }
-      else if (strcmp(f, CLAP_PLUGIN_FEATURE_AUDIO_EFFECT) == 0)
+      else if (contains(f, CLAP_PLUGIN_FEATURE_INSTRUMENT) && contains(f, CLAP_PLUGIN_FEATURE_AUDIO_EFFECT))
+      {
+        u.type = "aumf";
+      }
+      else if (contains(f, CLAP_PLUGIN_FEATURE_INSTRUMENT))
+      {
+        u.type = "aumu";
+      }
+      else if (contains(f, CLAP_PLUGIN_FEATURE_AUDIO_EFFECT))
       {
         u.type = "aufx";
       }
-      else if (strcmp(f, CLAP_PLUGIN_FEATURE_NOTE_EFFECT) == 0)
+      else if (contains(f, CLAP_PLUGIN_FEATURE_NOTE_EFFECT))
       {
         u.type = "aumi";
       }


### PR DESCRIPTION
I want to create an AUv2 plugin of type "aumf" (music effect) when the MACOSX_EMBEDDED_CLAP_LOCATION is set. 

In the first commit I made INSTRUMENT_TYPE take precedence over setting the plugin type based on the present CLAP features. This way you could also create all the other possible AUv2 plugin types.

In the second commit I changed the automatic AUv2 plugin type assignment a bit. When the CLAP plugin has both the AudioEffect and the Instrument feature the "aumf" plugin type is assigned. Also, this checks the whole set of features, instead of only the first.

I wouldn't be surprised if this not mergeable yet. Maybe I'm missing some caveats. But I'd be happy to contribute. I could also turn this into an issue if this is way off.