### PR TITLE
Implement host request_restart on standalone

### DIFF
--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -35,6 +35,17 @@
     auto *plugin = freeaudio::clap_wrapper::standalone::getMainPlugin()->_plugin;
     plugin->on_main_thread(plugin);
   }
+
+  if (standaloneHost->restartRequested.exchange(false))
+  {
+    // manually set running to false to make clapProcess a no-op
+    // while the plugin is being reactivated. otherwise,
+    // stopping and starting the entire audio engine is probably
+    // overkill.
+    standaloneHost->running = false;
+    standaloneHost->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
+    standaloneHost->running = true;
+  }
 }
 
 - (void)doSetup

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -46,7 +46,6 @@
       ClapWrapper::detail::shared::SpinLockGuard g(standaloneHost->processLock);
       standaloneHost->running = false;
     }
-    standaloneHost->running = false;
     standaloneHost->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
     standaloneHost->running = true;
   }

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -42,6 +42,10 @@
     // while the plugin is being reactivated. otherwise,
     // stopping and starting the entire audio engine is probably
     // overkill.
+    {
+      ClapWrapper::detail::shared::SpinLockGuard g(standaloneHost->processLock);
+      standaloneHost->running = false;
+    }
     standaloneHost->running = false;
     standaloneHost->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
     standaloneHost->running = true;

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -46,7 +46,8 @@
       ClapWrapper::detail::shared::SpinLockGuard g(standaloneHost->processLock);
       standaloneHost->running = false;
     }
-    standaloneHost->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
+    standaloneHost->activatePlugin(standaloneHost->currentSampleRate, 1,
+                                   standaloneHost->currentBufferSize * 2);
     standaloneHost->running = true;
   }
 }

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -103,13 +103,15 @@ void StandaloneHost::setupMIDIBusses(const clap_plugin_t *plugin,
 
 void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t frameCount)
 {
+  ClapWrapper::detail::shared::SpinLockGuard processLockGuard(processLock);
+  auto f = (float *)pOutput;
+  
   if (!running)
   {
+    memset(f, 0, frameCount * 2 * sizeof(float));
     finishedRunning = true;
     return;
   }
-
-  auto f = (float *)pOutput;
 
   clap_process process;
   process.transport = nullptr;  // this is a freefloating host

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -105,7 +105,7 @@ void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t fra
 {
   ClapWrapper::detail::shared::SpinLockGuard processLockGuard(processLock);
   auto f = (float *)pOutput;
-  
+
   if (!running)
   {
     memset(f, 0, frameCount * currentOutputChannels * sizeof(float));

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -108,7 +108,7 @@ void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t fra
   
   if (!running)
   {
-    memset(f, 0, frameCount * 2 * sizeof(float));
+    memset(f, 0, frameCount * currentOutputChannels * sizeof(float));
     finishedRunning = true;
     return;
   }

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -111,9 +111,10 @@ struct StandaloneHost : Clap::IHost
   {
     TRACE;
   }
+  std::atomic<bool> restartRequested{false};
   void restartPlugin() override
   {
-    TRACE;
+    restartRequested = true;
   }
   std::atomic<bool> callbackRequested{false};
   void request_callback() override

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -26,6 +26,7 @@
 
 #include "clap_proxy.h"
 #include "detail/shared/fixedqueue.h"
+#include "detail/shared/spinlock.h"
 
 namespace freeaudio::clap_wrapper::standalone
 {
@@ -287,6 +288,7 @@ struct StandaloneHost : Clap::IHost
   clap_input_events inputEvents{};
   clap_output_events outputEvents{};
 
+  ClapWrapper::detail::shared::SpinLock processLock;
   std::atomic<bool> running{true}, finishedRunning{false};
 
   // We need to have play buffers for the clap. For now lets assume

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -958,6 +958,17 @@ Plugin::Plugin(const clap_plugin_entry* entry, int argc, char** argv)
                  {
                    plugin.plugin->on_main_thread(plugin.plugin);
                  }
+
+                 if (sah->restartRequested.exchange(false))
+                 {
+                   // manually set running to false to make clapProcess a no-op
+                   // while the plugin is being reactivated. otherwise,
+                   // stopping and starting the entire audio engine is probably
+                   // overkill.
+                   sah->running = false;
+                   sah->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
+                   sah->running = true;
+                 }
                }
 
                return 0;

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -965,7 +965,10 @@ Plugin::Plugin(const clap_plugin_entry* entry, int argc, char** argv)
                    // while the plugin is being reactivated. otherwise,
                    // stopping and starting the entire audio engine is probably
                    // overkill.
-                   sah->running = false;
+                   {
+                    ClapWrapper::detail::shared::SpinLockGuard g(sah->processLock);
+                    sah->running = false;
+                   }
                    sah->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
                    sah->running = true;
                  }

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -966,8 +966,8 @@ Plugin::Plugin(const clap_plugin_entry* entry, int argc, char** argv)
                    // stopping and starting the entire audio engine is probably
                    // overkill.
                    {
-                    ClapWrapper::detail::shared::SpinLockGuard g(sah->processLock);
-                    sah->running = false;
+                     ClapWrapper::detail::shared::SpinLockGuard g(sah->processLock);
+                     sah->running = false;
                    }
                    sah->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
                    sah->running = true;


### PR DESCRIPTION
This PR fully implements the clap_host_t request_restart method for Windows and macOS standalone, although the macOS implementation is currently untested.