### PR TITLE
VST3: Make host->request_restart thread-safe

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -1161,9 +1161,7 @@ void ClapAsVst3::request_callback()
 
 void ClapAsVst3::restartPlugin()
 {
-  if (componentHandler)
-    componentHandler->restartComponent(Vst::RestartFlags::kIoChanged |
-                                       Vst::RestartFlags::kLatencyChanged);
+  _requestRestart = true;
 }
 
 void ClapAsVst3::onBeginEdit(clap_id id)
@@ -1304,6 +1302,14 @@ void ClapAsVst3::onIdle()
   {
     _requestUICallback = false;
     _plugin->_plugin->on_main_thread(_plugin->_plugin);
+  }
+
+  if (_requestRestart)
+  {
+    _requestRestart = false;
+    if (componentHandler)
+      componentHandler->restartComponent(Vst::RestartFlags::kIoChanged |
+                                         Vst::RestartFlags::kLatencyChanged);
   }
 
   if (_wrappedview)

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -386,6 +386,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   ClapWrapper::detail::shared::SpinLock _processOrFlushLock;
 
   std::atomic_bool _requestUICallback = false;
+  std::atomic_bool _requestRestart = false;
   bool _missedLatencyRequest = false;
 
   std::thread::id _main_thread_id{};


### PR DESCRIPTION
This uses the same method as request_callback to make request_restart thread-safe. The restart will chronologically occur after the UI callback request is handled.