### PR TITLE
Change WCLAP max-memory 4GB -> 2GB

### DIFF
--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -236,7 +236,7 @@ function(make_clapfirst_plugins)
         else()
             target_compile_options(${C1ST_IMPL_TARGET} PUBLIC -msimd128 -fno-exceptions)
             target_compile_options(${WCLAP_TARGET} PUBLIC -msimd128 -fno-exceptions)
-            target_link_options(${WCLAP_TARGET} PUBLIC -mexec-model=reactor -Wl,--max-memory=4294967296,--export-table,--growable-table,--export=malloc,--export=clap_entry)
+            target_link_options(${WCLAP_TARGET} PUBLIC -mexec-model=reactor -Wl,--max-memory=2147483648,--export-table,--growable-table,--export=malloc,--export=clap_entry)
         endif()
 
         add_dependencies(${ALL_TARGET} ${WCLAP_TARGET})


### PR DESCRIPTION
2GB is the default Emscripten uses, for reasons explained [here](https://emscripten.org/docs/tools_reference/settings_reference.html#maximum-memory):

> Note that the default value here is 2GB, which means that by default if you enable memory growth then we can grow up to 2GB but no higher. 2GB is a natural limit for several reasons:
> * If the maximum heap size is over 2GB, then pointers must be unsigned in JavaScript, which increases code size. We don’t want memory growth builds to be larger unless someone explicitly opts in to >2GB+ heaps.
> * Historically no VM has supported more >2GB+, and only recently (Mar 2020) has support started to appear. As support is limited, it’s safer for people to opt into >2GB+ heaps rather than get a build that may not work on all VMs.

This change matches that when compiling with WASI SDK, providing more consistent WCLAP results.