### PR TITLE
Add VST3 Validator + auval steps to the pull request validation workflow

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -191,24 +191,33 @@ jobs:
             cmakeargs: -A x64
             install_ninja: false
             run_aptget: false
+            vst3_validator: ./vst3sdk/cmake-build/bin/Debug/validator
+            vst3_path: ./build/clap-first-distortion_assets/VST3/ClapFirst Bad Distortion.vst3
             name: ClapFirst Windows 64bit MSVC
 
           - os: ubuntu-latest
             cmakeargs: -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12
             install_ninja: false
             run_aptget: true
+            vst3_validator: ./vst3sdk/cmake-build/bin/validator
+            vst3_path: ./build/clap-first-distortion_assets/ClapFirst Bad Distortion.vst3
             name: ClapFirst Linux gcc12
 
           - os: ubuntu-24.04
             cmakeargs: -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14
             install_ninja: false
             run_aptget: true
+            vst3_validator: ./vst3sdk/cmake-build/bin/validator
+            vst3_path: ./build/clap-first-distortion_assets/ClapFirst Bad Distortion.vst3
             name: ClapFirst Linux ub24 gcc14
 
           - os: macos-latest
             cmakeargs: -G"Xcode"
             install_ninja: false
             run_aptget: false
+            vst3_validator: ./vst3sdk/cmake-build/bin/validator
+            vst3_path: ./build/clap-first-distortion_assets/Debug/ClapFirst Bad Distortion.vst3
+            auv2_path: ./build/clap-first-distortion_assets/Debug/ClapFirst Bad Distortion.component
             name: ClapFirst MacOS Xcode
 
 
@@ -239,5 +248,35 @@ jobs:
         shell: bash
         run: |
           find build -name "ClapFirst*" -print
+
+      - name: Build VST3 validator
+        shell: bash
+        run: |
+          # checkout VST3 SDK (shallow clone), can we reuse one from the build step?
+          git clone --depth=1 https://github.com/steinbergmedia/vst3sdk
+          cd vst3sdk
+          git submodule update --init base
+          git submodule update --init cmake
+          git submodule update --init public.sdk
+          git submodule update --init pluginterfaces
+
+          # build the validator
+          cmake -DSMTG_ENABLE_VSTGUI_SUPPORT=OFF -DSMTG_ENABLE_VST3_PLUGIN_EXAMPLES=OFF -DSMTG_ENABLE_VST3_HOSTING_EXAMPLES=OFF -B cmake-build
+          cmake --build cmake-build --target validator
+          cd ..
+
+      - name: Run VST3 validator
+        shell: bash
+        run: |
+          "${{ matrix.vst3_validator }}" "${{ matrix.vst3_path }}"
+
+      - name: Run auval
+        shell: bash
+        if: ${{ matrix.auv2_path }}
+        run: |
+          mkdir -p ~/Library/Audio/Plug-Ins/Components/
+          cp -R "${{ matrix.auv2_path }}" ~/Library/Audio/Plug-Ins/Components/
+          killall -9 AudioComponentRegistrar || true
+          auval -strict -v aufx BdDt FrAD
           
 

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -216,12 +216,17 @@ function(target_add_vst3_wrapper)
 
             # Check against the list of supported targets found here:
             # https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Locations+Format/Plugin+Format.html#for-the-windows-platform
-            if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "x86"
-                    AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"
-                    AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64ec"
-                    AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64"
-                    AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64x")
+            if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
+                set(v3arch "x86_64")  
+            elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "IA64")
+                set(v3arch "x86_64")
+            elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86")
+                set(v3arch "x86")
+            elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
+                set(v3arch "arm64")
+            else()
                 message(WARNING "clap-wrapper: The architecture (${CMAKE_SYSTEM_PROCESSOR}) is not officially suported by VST3. This may cause issues when loading the resulting plug-in")
+                set(v3arch "${CMAKE_SYSTEM_PROCESSOR}")
             endif()
 
             if ("${V3_ASSET_OUTPUT_DIRECTORY}" STREQUAL "")
@@ -238,13 +243,13 @@ function(target_add_vst3_wrapper)
 
             add_custom_command(TARGET ${V3_TARGET} PRE_BUILD
                     WORKING_DIRECTORY ${v3root}
-                    COMMAND ${CMAKE_COMMAND} -E make_directory "${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-win"
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/${v3arch}-win"
                     )
             set_target_properties(${V3_TARGET} PROPERTIES
                     LIBRARY_OUTPUT_NAME ${V3_OUTPUT_NAME}
-                    LIBRARY_OUTPUT_DIRECTORY "${v3root}/${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-win"
-                    LIBRARY_OUTPUT_DIRECTORY_DEBUG "${v3root}/${v3root_d}/${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-win"
-                    LIBRARY_OUTPUT_DIRECTORY_RELEASE "${v3root}/${v3root_r}/${V3_OUTPUT_NAME}.vst3/Contents/${CMAKE_SYSTEM_PROCESSOR}-win"
+                    LIBRARY_OUTPUT_DIRECTORY "${v3root}/${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/${v3arch}-win"
+                    LIBRARY_OUTPUT_DIRECTORY_DEBUG "${v3root}/${v3root_d}/${V3_OUTPUT_NAME}.vst3/Contents/${v3arch}-win"
+                    LIBRARY_OUTPUT_DIRECTORY_RELEASE "${v3root}/${v3root_r}/${V3_OUTPUT_NAME}.vst3/Contents/${v3arch}-win"
                     SUFFIX ".vst3")
 
             # Copy resource directory, if defined

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -217,10 +217,8 @@ function(target_add_vst3_wrapper)
             # Check against the list of supported targets found here:
             # https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Locations+Format/Plugin+Format.html#for-the-windows-platform
             if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
-                set(v3arch "x86_64")  
-            elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "IA64")
                 set(v3arch "x86_64")
-            elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86")
+            elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "X86")
                 set(v3arch "x86")
             elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ARM64")
                 set(v3arch "arm64")

--- a/tests/clap-first-example/CMakeLists.txt
+++ b/tests/clap-first-example/CMakeLists.txt
@@ -31,6 +31,9 @@ make_clapfirst_plugins(
 
         COPY_AFTER_BUILD FALSE
 
+        # vst3 validator on windows needs this to be true to pass
+        WINDOWS_FOLDER_VST3 TRUE
+
         PLUGIN_FORMATS CLAP VST3 AUV2 WCLAP
 
         ASSET_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME}_assets


### PR DESCRIPTION
This PR adds a VST3 validator test step and an auval step on macOS when building the ClapFirst example plugin. Currently it builds and runs the official VST3 validator provided by Steinberg.

Also this PR fixes a small issue with VST3 bundle folder generation on Windows where clap-wrapper used a wrong architecture name, this is needed for the validator to pass.

Tested that it works on my fork [here](https://github.com/Quant1um/clap-wrapper/actions/runs/20881660854)