### PR TITLE
Fix VST3 memory leaks

### DIFF
--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -132,7 +132,7 @@ Vst3Parameter* Vst3Parameter::create(
     v.stepCount = 0;
 
   auto result = new Vst3Parameter(v, info);
-  result->addRef();  // ParameterContainer doesn't add the ref -> but we don't have copies
+  //result->addRef();  // ParameterContainer doesn't add the ref -> but we don't have copies
   return result;
 }
 
@@ -184,6 +184,6 @@ Vst3Parameter* Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, V
   }
 
   auto result = new Vst3Parameter(v, bus, channel, cc);
-  result->addRef();  // ParameterContainer doesn't add the ref -> but we don't have copies
+  //result->addRef();  // ParameterContainer doesn't add the ref -> but we don't have copies
   return result;
 }

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -34,23 +34,19 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t* plugin, const clap_plu
 
   if (numSamples > 0)
   {
-    delete[] _silent_input;
-    _silent_input = new float[numSamples];
-
-    delete[] _silent_output;
-    _silent_output = new float[numSamples];
+    // wait do we even use these?
+    _silent_input = std::make_unique<float[]>(numSamples);
+    _silent_output = std::make_unique<float[]>(numSamples);
   }
 
   auto numInputs = (uint32_t)_audioinputs->size();
   auto numOutputs = (uint32_t)_audiooutputs->size();
 
   _processData.audio_inputs_count = numInputs;
-  delete[] _input_ports;
-  _input_ports = nullptr;
 
   if (numInputs > 0)
   {
-    _input_ports = new clap_audio_buffer_t[numInputs];
+    _input_ports = std::make_unique<clap_audio_buffer_t[]>(numInputs);
     for (auto i = 0U; i < numInputs; ++i)
     {
       clap_audio_buffer_t& bus = _input_ports[i];
@@ -64,20 +60,19 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t* plugin, const clap_plu
         bus.data32 = nullptr;
       }
     }
-    _processData.audio_inputs = _input_ports;
+    _processData.audio_inputs = _input_ports.get();
   }
   else
   {
+    _input_ports = nullptr;
     _processData.audio_inputs = nullptr;
   }
 
   _processData.audio_outputs_count = numOutputs;
-  delete[] _output_ports;
-  _output_ports = nullptr;
 
   if (numOutputs > 0)
   {
-    _output_ports = new clap_audio_buffer_t[numOutputs];
+    _output_ports = std::make_unique<clap_audio_buffer_t[]>(numOutputs);
     for (auto i = 0U; i < numOutputs; ++i)
     {
       clap_audio_buffer_t& bus = _output_ports[i];
@@ -91,10 +86,11 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t* plugin, const clap_plu
         bus.data32 = nullptr;
       }
     }
-    _processData.audio_outputs = _output_ports;
+    _processData.audio_outputs = _output_ports.get();
   }
   else
   {
+    _output_ports = nullptr;
     _processData.audio_outputs = nullptr;
   }
 

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -116,14 +116,14 @@ class ProcessAdapter
   };
   std::vector<ActiveNote> _activeNotes;
 
-  clap_audio_buffer_t* _input_ports = nullptr;
-  clap_audio_buffer_t* _output_ports = nullptr;
+  std::unique_ptr<clap_audio_buffer_t[]> _input_ports;
+  std::unique_ptr<clap_audio_buffer_t[]> _output_ports;
   clap_event_transport_t _transport = {};
   clap_input_events_t _in_events = {};
   clap_output_events_t _out_events = {};
 
-  float* _silent_input = nullptr;
-  float* _silent_output = nullptr;
+  std::unique_ptr<float[]> _silent_input;
+  std::unique_ptr<float[]> _silent_output;
 
   clap_process_t _processData = {-1, 0, &_transport, nullptr, nullptr, 0, 0, &_in_events, &_out_events};
 

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -408,7 +408,7 @@ IPlugView* PLUGIN_API ClapAsVst3::createView(FIDString /*name*/)
     clearContextMenu();
     if (_wrappedview == nullptr)
     {
-      _wrappedview = new WrappedView(
+      _wrappedview = std::make_unique<WrappedView>(
           _plugin->_plugin, _plugin->_ext._gui, [this]() { clearContextMenu(); },
           [this](bool everCreated)
           {
@@ -436,7 +436,8 @@ IPlugView* PLUGIN_API ClapAsVst3::createView(FIDString /*name*/)
 #endif
           });
     }
-    return _wrappedview;
+
+    return _wrappedview.get();
   }
   return nullptr;
 }
@@ -1597,12 +1598,12 @@ bool ClapAsVst3::context_menu_populate(const clap_context_menu_target_t* target,
 
   if (target->kind == CLAP_CONTEXT_MENU_TARGET_KIND_GLOBAL)
   {
-    this->vst3ContextMenu = componentHandler3->createContextMenu(this->_wrappedview, nullptr);
+    this->vst3ContextMenu = componentHandler3->createContextMenu(_wrappedview.get(), nullptr);
   }
   if (target->kind == CLAP_CONTEXT_MENU_TARGET_KIND_PARAM)
   {
     vst3ContextMenuParamID = target->id;
-    vst3ContextMenu = componentHandler3->createContextMenu(_wrappedview, &vst3ContextMenuParamID);
+    vst3ContextMenu = componentHandler3->createContextMenu(_wrappedview.get(), &vst3ContextMenuParamID);
   }
   if (vst3ContextMenu)
   {

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -183,7 +183,7 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
     if (_active) return kResultFalse;
     if (!_plugin->activate()) return kResultFalse;
     _active = true;
-    _processAdapter = new Clap::ProcessAdapter();
+    _processAdapter = std::make_unique<Clap::ProcessAdapter>();
 
     auto supportsnoteexpression =
         (_expressionmap & clap_supported_note_expressions::AS_VST3_NOTE_EXPRESSION_PRESSURE);
@@ -213,7 +213,6 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
       _plugin->deactivate();
     }
     _active = false;
-    delete _processAdapter;
     _processAdapter = nullptr;
   }
   return super::setActive(state);

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -372,7 +372,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   std::shared_ptr<Clap::Plugin> _plugin;
   clap_plugin_as_vst3_t* _vst3specifics = nullptr;
   std::unique_ptr<Clap::ProcessAdapter> _processAdapter;
-  WrappedView* _wrappedview = nullptr;
+  std::unique_ptr<WrappedView> _wrappedview;
 
   void* _creationcontext;  // context from the CLAP library
 

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -34,11 +34,12 @@
 
 #include "detail/os/osutil.h"
 #include "detail/vst3/plugview.h"
+#include "detail/vst3/process.h"
+#include "detail/vst3/aravst3.h"
 #include "detail/clap/automation.h"
 #include "detail/shared/fixedqueue.h"
-#include "detail/ara/ara.h"
-#include "detail/vst3/aravst3.h"
 #include "detail/shared/spinlock.h"
+#include "detail/ara/ara.h"
 #include <mutex>
 #include <thread>
 #include <atomic>
@@ -370,7 +371,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   int _libraryIndex = 0;
   std::shared_ptr<Clap::Plugin> _plugin;
   clap_plugin_as_vst3_t* _vst3specifics = nullptr;
-  Clap::ProcessAdapter* _processAdapter = nullptr;
+  std::unique_ptr<Clap::ProcessAdapter> _processAdapter;
   WrappedView* _wrappedview = nullptr;
 
   void* _creationcontext;  // context from the CLAP library


### PR DESCRIPTION
I found that when validating the example plugin with ASAN on the wrapper leaks about 2mb of memory. This PR fixes it by:
- Using `std::unique_ptr` where applicable, and
- Removing `result->addRef();` in `Vst3Parameter::create`. Not sure if it is correct, or what the original purpose of this was, but it seems to work in validator under ASAN, Bitwig and Reaper. Review needed.

Side note: it would probably be a good idea to turn on address sanitizer while validating the plugin in CI