### PR TITLE
Provide an X11 standalone wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@
 # CLAP_WRAPPER_DOWNLOAD_DEPENDENCIES if set will download the needed SDKs using CPM from github
 # CLAP_WRAPPER_COPY_AFTER_BUILD if included mac and lin will copy to ~/... (lin t/k)
 
+
 cmake_minimum_required(VERSION 3.21)
 cmake_policy(SET CMP0091 NEW)
 cmake_policy(SET CMP0149 NEW)

--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -1,4 +1,5 @@
 
+option(CLAP_WRAPPER_LINUX_STANDALONE_USES_GTK "Linux uses GTC vs simple X11" FALSE)
 function(target_add_standalone_wrapper)
     set(oneValueArgs
             TARGET
@@ -155,9 +156,15 @@ function(target_add_standalone_wrapper)
         target_sources(${SA_TARGET} PRIVATE
                 ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/wrapasstandalone.cpp)
 
-        find_package(PkgConfig REQUIRED)
-        pkg_check_modules(GTK gtkmm-3.0)
-        if (${GTK_FOUND})
+        set(TRY_GTK False)
+        if (${CLAP_WRAPPER_LINUX_STANDALONE_USES_GTK})
+            message(STATUS "clap-wrapper: Attempting to find gtkmm-3")
+            find_package(PkgConfig REQUIRED)
+            pkg_check_modules(GTK gtkmm-3.0)
+            set(TRY_GTK ${GTK_FOUND})
+        endif()
+
+        if (${TRY_GTK})
             message(STATUS "clap-wrapper: using gtkmm-3.0 for standalone")
             target_compile_options(${salib} PUBLIC ${GTK_CFLAGS})
             target_include_directories(${salib} PUBLIC ${GTK_INCLUDE_DIRS})
@@ -165,7 +172,10 @@ function(target_add_standalone_wrapper)
             target_compile_definitions(${salib} PUBLIC CLAP_WRAPPER_HAS_GTK3)
             target_sources(${salib} PRIVATE ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/linux/gtkutils.cpp)
         else()
-            message(WARNING "clap-wrapper: can't find gtkmm-3.0; no ui in standalone")
+            message(STATUS "clap-wrapper: Using Standalone X11 gui for CLAP Wrapper")
+            target_link_libraries(${salib} PUBLIC X11)
+            target_compile_definitions(${salib} PUBLIC CLAP_WRAPPER_STANDALONE_X11)
+            target_sources(${salib} PRIVATE ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/linux/x11_gui.cpp)
         endif()
 
         set_target_properties(${SA_TARGET} PROPERTIES OUTPUT_NAME ${SA_OUTPUT_NAME})

--- a/src/detail/standalone/linux/x11_gui.cpp
+++ b/src/detail/standalone/linux/x11_gui.cpp
@@ -1,0 +1,273 @@
+
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+#include <poll.h>
+#include <string.h>
+#include <cstdint>
+
+#include "x11_gui.h"
+#include <sys/epoll.h>
+
+namespace freeaudio::clap_wrapper::standalone::linux_standalone
+{
+void X11Gui::initialize(freeaudio::clap_wrapper::standalone::StandaloneHost* sah)
+{
+  display = XOpenDisplay(nullptr);
+  sah->x11Gui = this;
+  sah->onRequestResize = [this](int w, int h) { return resetSizeTo(w, h); };
+  epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+  if (epoll_fd < 0)
+  {
+    LOGINFO("Unable to create epoll");
+  }
+}
+
+void X11Gui::runloop()
+{
+  if (!display || window == 0 || epoll_fd < 0)
+  {
+    // no gui. Only way to kill us is with a signal.
+    while (true)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+    return;
+  }
+  XEvent e;
+  struct epoll_event events[maxEpollEvents];
+  bool running{true};
+  while (running)
+  {
+    while (XPending(display))
+    {
+      XNextEvent(display, &e);
+      switch (e.type)
+      {
+        case MapNotify:
+        {
+          clap_window win;
+          win.api = CLAP_WINDOW_API_X11;
+          win.x11 = window;
+          auto ui = plugin->_ext._gui;
+          ui->set_parent(plugin->_plugin, &win);
+          ui->show(plugin->_plugin);
+        }
+        break;
+        case ClientMessage:
+        {
+          // 3. Check if the message is the delete request
+          if ((Atom)(e.xclient.data.l[0]) == wmDeleteMessage)
+          {
+            running = false;
+          }
+          break;
+        }
+      }
+    }
+    // Poll for both X11 events and timer events
+    int num{0};
+    if (running) num = epoll_wait(epoll_fd, events, maxEpollEvents, 50);
+
+    if (num > 0)
+    {
+      for (int i = 0; i < num; ++i)
+      {
+        auto fd = events[i].data.fd;
+        auto tfd = fdToTimerId.find(fd);
+        auto pfd = registeredFds.find(fd);
+
+        if (tfd != fdToTimerId.end())
+        {
+          if (plugin->_ext._timer)
+          {
+            plugin->_ext._timer->on_timer(plugin->_plugin, tfd->second);
+          }
+        }
+        if (pfd != registeredFds.end())
+        {
+          if (plugin->_ext._posixfd)
+          {
+            plugin->_ext._posixfd->on_fd(plugin->_plugin, fd, pfd->second);
+          }
+        }
+      }
+    }
+  }
+}
+
+void X11Gui::setPlugin(std::shared_ptr<Clap::Plugin> p)
+{
+  this->plugin = p;
+  if (display && plugin->_ext._gui)
+  {
+    auto ui = plugin->_ext._gui;
+    auto p = plugin->_plugin;
+    if (!ui->is_api_supported(p, CLAP_WINDOW_API_X11, false))
+    {
+      LOGINFO("[ERROR] CLAP does not support X11");
+      window = 0;
+      return;
+    }
+
+    ui->create(p, CLAP_WINDOW_API_X11, false);
+
+    uint32_t w, h;
+    ui->get_size(p, &w, &h);
+    ui->adjust_size(p, &w, &h);
+
+    int s = DefaultScreen(display);
+    window = XCreateSimpleWindow(display, RootWindow(display, s), 10, 10, w, h, 1,
+                                 BlackPixel(display, s), WhitePixel(display, s));
+    XStoreName(display, window, plugin->_plugin->desc->name);
+    XSelectInput(display, window, InputOutput | StructureNotifyMask);
+
+    // Get window clsoed notifications
+    wmDeleteMessage = XInternAtom(display, "WM_DELETE_WINDOW", False);
+    XSetWMProtocols(display, window, &wmDeleteMessage, 1);
+
+    resetSizeTo(w, h);
+
+    XMapWindow(display, window);
+
+    epoll_event event;
+    event.events = EPOLLIN;
+    event.data.fd = ConnectionNumber(display);
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, ConnectionNumber(display), &event) == -1)
+    {
+      LOGINFO("Unable to register display epoll");
+      close(epoll_fd);
+      epoll_fd = -1;
+      return;
+    }
+  }
+}
+void X11Gui::shutdown()
+{
+  if (epoll_fd >= 0)
+  {
+    close(epoll_fd);
+  }
+  if (display && window > 0)
+  {
+    XDestroyWindow(display, window);
+    XFlush(display);
+  }
+  if (display)
+  {
+    XCloseDisplay(display);
+  }
+}
+
+int X11Gui::nextTimerId{2112};
+
+bool X11Gui::register_timer(int period_ms, clap_id* tid)
+{
+  int tfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
+  struct itimerspec ts;
+  memset(&ts, 0, sizeof(ts));
+  ts.it_interval.tv_nsec = period_ms * 1e6;  // Repeat every 1s
+  ts.it_value.tv_nsec = period_ms * 1e6;     // First expiry in 1s
+  timerfd_settime(tfd, 0, &ts, NULL);
+
+  epoll_event event;
+  event.events = EPOLLIN;
+  event.data.fd = tfd;
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, tfd, &event) == -1)
+  {
+    LOGINFO("Unable to register timer epoll");
+    return false;
+  }
+
+  auto id = nextTimerId;
+  nextTimerId++;
+  *tid = id;
+
+  timerIdToFd[id] = tfd;
+  fdToTimerId[tfd] = id;
+
+  return true;
+}
+bool X11Gui::unregister_timer(clap_id tid)
+{
+  LOGINFO("Unregistering timer: {}", tid);
+  if (epoll_fd < 0)
+  {
+    return false;
+  }
+  auto idF = timerIdToFd.find(tid);
+  if (idF == timerIdToFd.end())
+  {
+    return false;
+  }
+  auto fd = idF->second;
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, fd, NULL) == -1)
+  {
+    LOGINFO("epoll_ctl EPOLL_CTL_DEL failed to unregister timer");
+    // Handle error
+    return false;
+  }
+  close(fd);  // thereby stopping the timer
+  timerIdToFd.erase(tid);
+  fdToTimerId.erase(fd);
+  return true;
+}
+
+bool X11Gui::register_fd(int fd, clap_posix_fd_flags_t iflags)
+{
+  int flags{0};
+  if (iflags & CLAP_POSIX_FD_READ) flags = flags | EPOLLIN;
+  if (iflags & CLAP_POSIX_FD_WRITE) flags = flags | EPOLLOUT;
+  if (iflags & CLAP_POSIX_FD_ERROR) flags = flags | EPOLLERR;
+
+  epoll_event event;
+  event.events = flags;
+  event.data.fd = fd;
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &event) == -1)
+  {
+    LOGINFO("Unable to register plugin provided fd");
+    return false;
+  }
+  registeredFds[fd] = iflags;
+  return true;
+}
+
+bool X11Gui::unregister_fd(int fd)
+{
+  LOGINFO("Unregistering FD: {}", fd);
+  if (epoll_fd < 0) return false;
+
+  if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, fd, NULL) == -1)
+  {
+    LOGINFO("epoll_ctl EPOLL_CTL_DEL failed");
+    // Handle error
+    return false;
+  }
+
+  registeredFds.erase(fd);
+  return true;
+}
+
+bool X11Gui::resetSizeTo(int w, int h)
+{
+  if (!display || window == 0) return false;
+  XResizeWindow(display, window, w, h);
+
+  XSizeHints* hints = XAllocSizeHints();
+  hints->flags = PMinSize | PMaxSize;
+  hints->min_width = w;
+  hints->max_width = w;
+  hints->min_height = h;
+  hints->max_height = h;
+
+  // Apply hints to the window
+  XSetWMNormalHints(display, window, hints);
+  XFree(hints);
+
+  return true;
+}
+};  // namespace freeaudio::clap_wrapper::standalone::linux_standalone

--- a/src/detail/standalone/linux/x11_gui.h
+++ b/src/detail/standalone/linux/x11_gui.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <clap_proxy.h>
+#include <unordered_set>
+#include "detail/standalone/standalone_host.h"
+#include <poll.h>
+#include <map>
+#include <set>
+
+#include <X11/Xlib.h>
+namespace freeaudio::clap_wrapper::standalone::linux_standalone
+{
+struct X11Gui
+{
+  void initialize(freeaudio::clap_wrapper::standalone::StandaloneHost*);
+  void setPlugin(std::shared_ptr<Clap::Plugin>);
+  void runloop();
+  void shutdown();
+
+  bool register_timer(int period_ms, clap_id* tid);
+  bool unregister_timer(clap_id tid);
+
+  bool register_fd(int fd, clap_posix_fd_flags_t flags);
+  bool unregister_fd(int fd);
+
+  Display* display{nullptr};
+  Window window{0};
+  Atom wmDeleteMessage{0};
+
+  int epoll_fd{-1};
+  static constexpr size_t maxEpollEvents{256};
+
+  std::shared_ptr<Clap::Plugin> plugin{nullptr};
+
+  bool resetSizeTo(int w, int h);
+
+  std::map<int, clap_id> fdToTimerId;
+  std::map<clap_id, int> timerIdToFd;
+
+  std::map<int, int> registeredFds;
+
+  static int nextTimerId;
+};
+}  // namespace freeaudio::clap_wrapper::standalone::linux_standalone

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -7,6 +7,9 @@
 #if CLAP_WRAPPER_HAS_GTK3
 #include "detail/standalone/linux/gtkutils.h"
 #endif
+#if CLAP_WRAPPER_STANDALONE_X11
+#include "detail/standalone/linux/x11_gui.h"
+#endif
 #endif
 
 #if WIN
@@ -23,7 +26,7 @@ namespace freeaudio::clap_wrapper::standalone
 #if WIN && CLAP_WRAPPER_HAS_WIN32
 std::optional<fs::path> getStandaloneSettingsPath()
 {
-  wchar_t *buffer{nullptr};
+  wchar_t* buffer{nullptr};
 
   if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &buffer)))
   {
@@ -49,8 +52,8 @@ StandaloneHost::~StandaloneHost()
 {
 }
 
-void StandaloneHost::setupAudioBusses(const clap_plugin_t *plugin,
-                                      const clap_plugin_audio_ports_t *audioports)
+void StandaloneHost::setupAudioBusses(const clap_plugin_t* plugin,
+                                      const clap_plugin_audio_ports_t* audioports)
 {
   if (!audioports) return;
   numAudioInputs = audioports->count(plugin, true);
@@ -76,8 +79,8 @@ void StandaloneHost::setupAudioBusses(const clap_plugin_t *plugin,
   assert(totalOutputChannels + totalInputChannels < utilityBufferMaxChannels);
 }
 
-void StandaloneHost::setupMIDIBusses(const clap_plugin_t *plugin,
-                                     const clap_plugin_note_ports_t *noteports)
+void StandaloneHost::setupMIDIBusses(const clap_plugin_t* plugin,
+                                     const clap_plugin_note_ports_t* noteports)
 {
   auto numMIDIInPorts = noteports->count(plugin, true);
   if (numMIDIInPorts > 0)
@@ -101,10 +104,10 @@ void StandaloneHost::setupMIDIBusses(const clap_plugin_t *plugin,
   }
 }
 
-void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t frameCount)
+void StandaloneHost::clapProcess(void* pOutput, const void* pInput, uint32_t frameCount)
 {
   ClapWrapper::detail::shared::SpinLockGuard processLockGuard(processLock);
-  auto f = (float *)pOutput;
+  auto f = (float*)pOutput;
 
   if (!running)
   {
@@ -130,7 +133,7 @@ void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t fra
 
   process.audio_outputs_count = 1;
 
-  float *bufferChanPtr[utilityBufferMaxChannels]{};
+  float* bufferChanPtr[utilityBufferMaxChannels]{};
   clap_audio_buffer buffers[utilityBufferMaxChannels]{};  // probably twice as large
   size_t ptrIdx{0};
   size_t bufIdx{0};
@@ -184,7 +187,7 @@ void StandaloneHost::clapProcess(void *pOutput, const void *pInput, uint32_t fra
 
   if (mainInIdx >= 0 && pInput)
   {
-    auto *g = (const float *)pInput;
+    auto* g = (const float*)pInput;
     auto stride = currentInputChannels;
     auto chan2Off = (currentInputChannels > 1) ? 1 : 0;
 
@@ -239,18 +242,21 @@ bool StandaloneHost::gui_request_resize(uint32_t width, uint32_t height)
   return false;
 }
 
-const char *StandaloneHost::host_get_name()
+const char* StandaloneHost::host_get_name()
 {
   return "CLAP-Wrapper-As-Standalone";
 }
 
 #if LIN
 
-bool StandaloneHost::register_timer(uint32_t period_ms, clap_id *timer_id)
+bool StandaloneHost::register_timer(uint32_t period_ms, clap_id* timer_id)
 {
 #if LIN && CLAP_WRAPPER_HAS_GTK3
   assert(gtkGui);
   return gtkGui->register_timer(period_ms, timer_id);
+#elif LIN && CLAP_WRAPPER_STANDALONE_X11
+  assert(x11Gui);
+  return x11Gui->register_timer(period_ms, timer_id);
 #else
   return false;
 #endif
@@ -259,6 +265,9 @@ bool StandaloneHost::unregister_timer(clap_id timer_id)
 {
 #if LIN && CLAP_WRAPPER_HAS_GTK3
   return gtkGui->unregister_timer(timer_id);
+#elif LIN && CLAP_WRAPPER_STANDALONE_X11
+  assert(x11Gui);
+  return x11Gui->unregister_timer(timer_id);
 #else
   return false;
 #endif
@@ -268,6 +277,8 @@ bool StandaloneHost::register_fd(int fd, clap_posix_fd_flags_t flags)
 {
 #if LIN && CLAP_WRAPPER_HAS_GTK3
   return gtkGui->register_fd(fd, flags);
+#elif LIN && CLAP_WRAPPER_STANDALONE_X11
+  return x11Gui->register_fd(fd, flags);
 #else
   return false;
 #endif
@@ -280,13 +291,15 @@ bool StandaloneHost::unregister_fd(int fd)
 {
 #if LIN && CLAP_WRAPPER_HAS_GTK3
   return gtkGui->unregister_fd(fd);
+#elif LIN && CLAP_WRAPPER_STANDALONE_X11
+  return x11Gui->unregister_fd(fd);
 #else
   return false;
 #endif
 }
 
 #else
-bool StandaloneHost::register_timer(uint32_t period_ms, clap_id *timer_id)
+bool StandaloneHost::register_timer(uint32_t period_ms, clap_id* timer_id)
 {
   return false;
 }
@@ -296,19 +309,19 @@ bool StandaloneHost::unregister_timer(clap_id timer_id)
 }
 #endif
 
-static int64_t clapwrite(const clap_ostream *s, const void *buffer, uint64_t size)
+static int64_t clapwrite(const clap_ostream* s, const void* buffer, uint64_t size)
 {
-  auto ofs = static_cast<std::ofstream *>(s->ctx);
-  ofs->write((const char *)buffer, size);
+  auto ofs = static_cast<std::ofstream*>(s->ctx);
+  ofs->write((const char*)buffer, size);
   return size;
 }
 
-static int64_t clapread(const struct clap_istream *s, void *buffer, uint64_t size)
+static int64_t clapread(const struct clap_istream* s, void* buffer, uint64_t size)
 {
-  auto ifs = static_cast<std::ifstream *>(s->ctx);
+  auto ifs = static_cast<std::ifstream*>(s->ctx);
 
   // Oh this API is so terrible. I think this is right?
-  ifs->read(static_cast<char *>(buffer), size);
+  ifs->read(static_cast<char*>(buffer), size);
   if (ifs->rdstate() == std::ios::goodbit || ifs->rdstate() == std::ios::eofbit) return ifs->gcount();
 
   if (ifs->rdstate() & std::ios::eofbit) return ifs->gcount();
@@ -316,7 +329,7 @@ static int64_t clapread(const struct clap_istream *s, void *buffer, uint64_t siz
   return -1;
 }
 
-bool StandaloneHost::saveStandaloneAndPluginSettings(const fs::path &intoDir, const fs::path &withName)
+bool StandaloneHost::saveStandaloneAndPluginSettings(const fs::path& intoDir, const fs::path& withName)
 {
   // This should obviously be a more robust file format. What we
   // want is an envelope containing the standalone settings and then
@@ -342,8 +355,8 @@ bool StandaloneHost::saveStandaloneAndPluginSettings(const fs::path &intoDir, co
   return true;
 }
 
-bool StandaloneHost::tryLoadStandaloneAndPluginSettings(const fs::path &fromDir,
-                                                        const fs::path &withName)
+bool StandaloneHost::tryLoadStandaloneAndPluginSettings(const fs::path& fromDir,
+                                                        const fs::path& withName)
 {
   // see comment above on this file format being not just the
   // raw stream in the future

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -37,6 +37,12 @@ namespace linux_standalone
 struct GtkGui;
 }
 #endif
+#if CLAP_WRAPPER_STANDALONE_X11
+namespace linux_standalone
+{
+struct X11Gui;
+}
+#endif
 #endif
 
 std::optional<fs::path> getStandaloneSettingsPath();
@@ -53,19 +59,19 @@ struct StandaloneHost : Clap::IHost
   }
   virtual ~StandaloneHost();
 
-  static bool oe_try_push(const struct clap_output_events *oe, const clap_event_header_t *evt)
+  static bool oe_try_push(const struct clap_output_events* oe, const clap_event_header_t* evt)
   {
     return true;
   }
 
-  static uint32_t ie_getsize(const struct clap_input_events *ie)
+  static uint32_t ie_getsize(const struct clap_input_events* ie)
   {
-    auto sh = (StandaloneHost *)ie->ctx;
+    auto sh = (StandaloneHost*)ie->ctx;
     return sh->inputEventSize();
   }
-  static const clap_event_header_t *ie_get(const struct clap_input_events *ie, uint32_t idx)
+  static const clap_event_header_t* ie_get(const struct clap_input_events* ie, uint32_t idx)
   {
-    auto sh = (StandaloneHost *)ie->ctx;
+    auto sh = (StandaloneHost*)ie->ctx;
     return sh->inputEvent(idx);
   }
 
@@ -79,7 +85,7 @@ struct StandaloneHost : Clap::IHost
   {
     currInput = 0;
   }
-  bool pushInputEvent(clap_event_header_t *event)
+  bool pushInputEvent(clap_event_header_t* event)
   {
     if (event->size > eventSize)
     {
@@ -89,7 +95,7 @@ struct StandaloneHost : Clap::IHost
     {
       return false;
     }
-    memcpy((void *)(eventQueue + currInput * eventSize), (const void *)event, event->size);
+    memcpy((void*)(eventQueue + currInput * eventSize), (const void*)event, event->size);
     currInput++;
     return true;
   }
@@ -97,9 +103,9 @@ struct StandaloneHost : Clap::IHost
   {
     return currInput;
   }
-  const clap_event_header_t *inputEvent(uint32_t idx)
+  const clap_event_header_t* inputEvent(uint32_t idx)
   {
-    return (const clap_event_header_t *)(eventQueue + idx * eventSize);
+    return (const clap_event_header_t*)(eventQueue + idx * eventSize);
   }
 
   std::shared_ptr<Clap::Plugin> clapPlugin;
@@ -122,26 +128,26 @@ struct StandaloneHost : Clap::IHost
   {
     callbackRequested = true;
   }
-  void setupWrapperSpecifics(const clap_plugin_t *plugin) override
+  void setupWrapperSpecifics(const clap_plugin_t* plugin) override
   {
     TRACE;
   }
 
-  bool saveStandaloneAndPluginSettings(const fs::path &intoDir, const fs::path &withName);
-  bool tryLoadStandaloneAndPluginSettings(const fs::path &fromDir, const fs::path &withName);
+  bool saveStandaloneAndPluginSettings(const fs::path& intoDir, const fs::path& withName);
+  bool tryLoadStandaloneAndPluginSettings(const fs::path& fromDir, const fs::path& withName);
 
   uint32_t numAudioInputs{0}, numAudioOutputs{0};
   std::vector<uint32_t> inputChannelByBus;
   std::vector<uint32_t> outputChannelByBus;
   uint32_t mainInput{0}, mainOutput{0};
   uint32_t totalInputChannels{0}, totalOutputChannels{0};
-  void setupAudioBusses(const clap_plugin_t *plugin,
-                        const clap_plugin_audio_ports_t *audioports) override;
+  void setupAudioBusses(const clap_plugin_t* plugin,
+                        const clap_plugin_audio_ports_t* audioports) override;
 
   bool hasMIDIInput{false}, hasClapNoteInput{false}, createsMidiOutput{false};
-  void setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_note_ports_t *noteports) override;
+  void setupMIDIBusses(const clap_plugin_t* plugin, const clap_plugin_note_ports_t* noteports) override;
 
-  void setupParameters(const clap_plugin_t *plugin, const clap_plugin_params_t *params) override
+  void setupParameters(const clap_plugin_t* plugin, const clap_plugin_params_t* params) override
   {
     TRACE;
   }
@@ -175,16 +181,20 @@ struct StandaloneHost : Clap::IHost
 
 #if LIN
 #if CLAP_WRAPPER_HAS_GTK3
-  freeaudio::clap_wrapper::standalone::linux_standalone::GtkGui *gtkGui{nullptr};
+  freeaudio::clap_wrapper::standalone::linux_standalone::GtkGui* gtkGui{nullptr};
 #endif
+#if CLAP_WRAPPER_STANDALONE_X11
+  freeaudio::clap_wrapper::standalone::linux_standalone::X11Gui* x11Gui{nullptr};
 #endif
 
-  bool register_timer(uint32_t period_ms, clap_id *timer_id) override;
+#endif
+
+  bool register_timer(uint32_t period_ms, clap_id* timer_id) override;
   bool unregister_timer(clap_id timer_id) override;
 
-  const char *host_get_name() override;
+  const char* host_get_name() override;
 
-  bool track_info_get(clap_track_info_t *info) override
+  bool track_info_get(clap_track_info_t* info) override
   {
     return false;
   }
@@ -194,12 +204,12 @@ struct StandaloneHost : Clap::IHost
   {
     return false;
   }
-  bool context_menu_populate(const clap_context_menu_target_t *target,
-                             const clap_context_menu_builder_t *builder) override
+  bool context_menu_populate(const clap_context_menu_target_t* target,
+                             const clap_context_menu_builder_t* builder) override
   {
     return false;
   }
-  bool context_menu_perform(const clap_context_menu_target_t *target, clap_id action_id) override
+  bool context_menu_perform(const clap_context_menu_target_t* target, clap_id action_id) override
   {
     return false;
   }
@@ -207,7 +217,7 @@ struct StandaloneHost : Clap::IHost
   {
     return false;
   }
-  bool context_menu_popup(const clap_context_menu_target_t *target, int32_t screen_index, int32_t x,
+  bool context_menu_popup(const clap_context_menu_target_t* target, int32_t screen_index, int32_t x,
                           int32_t y) override
   {
     return false;
@@ -244,15 +254,15 @@ struct StandaloneHost : Clap::IHost
   std::vector<uint32_t> currentMidiPorts;
   void startMIDIThread();
   void stopMIDIThread();
-  void processMIDIEvents(double deltatime, std::vector<unsigned char> *message);
-  static void midiCallback(double deltatime, std::vector<unsigned char> *message, void *userData);
+  void processMIDIEvents(double deltatime, std::vector<unsigned char>* message);
+  static void midiCallback(double deltatime, std::vector<unsigned char>* message, void* userData);
 
   // in standalone_host.cpp
-  void clapProcess(void *pOutput, const void *pInoput, uint32_t frameCount);
+  void clapProcess(void* pOutput, const void* pInoput, uint32_t frameCount);
 
   // Actual audio IO In standalone_host_audio.cpp
   std::unique_ptr<RtAudio> rtaDac;
-  std::function<void(const std::string &)> displayAudioError{nullptr};
+  std::function<void(const std::string&)> displayAudioError{nullptr};
   RtAudio::Api audioApi{RtAudio::Api::UNSPECIFIED};
   std::string audioApiName{RtAudio::getApiName(RtAudio::Api::UNSPECIFIED)};
   std::string audioApiDisplayName{RtAudio::getApiDisplayName(RtAudio::Api::UNSPECIFIED)};

--- a/src/wrapasstandalone.cpp
+++ b/src/wrapasstandalone.cpp
@@ -7,13 +7,16 @@
 #if CLAP_WRAPPER_HAS_GTK3
 #include "detail/standalone/linux/gtkutils.h"
 #endif
+#if CLAP_WRAPPER_STANDALONE_X11
+#include "detail/standalone/linux/x11_gui.h"
+#endif
 #endif
 
 // For now just a simple main. In the future this will branch out to
 // an [NSApplicationMain ] and so on depending on platform
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
-  const clap_plugin_entry *entry{nullptr};
+  const clap_plugin_entry* entry{nullptr};
 #ifdef STATICALLY_LINKED_CLAP_ENTRY
   extern const clap_plugin_entry clap_entry;
   entry = &clap_entry;
@@ -26,7 +29,7 @@ int main(int argc, char **argv)
 
   auto lib = Clap::Library();
 
-  for (const auto &searchPaths : pts)
+  for (const auto& searchPaths : pts)
   {
     auto clapPath = searchPaths / (clapName + ".clap");
 
@@ -49,6 +52,11 @@ int main(int argc, char **argv)
   }
   gtkGui.initialize(freeaudio::clap_wrapper::standalone::getStandaloneHost());
 #endif
+#if CLAP_WRAPPER_STANDALONE_X11
+  freeaudio::clap_wrapper::standalone::linux_standalone::X11Gui x11Gui{};
+
+  x11Gui.initialize(freeaudio::clap_wrapper::standalone::getStandaloneHost());
+#endif
 #endif
 
   if (!entry)
@@ -61,7 +69,7 @@ int main(int argc, char **argv)
   int pindex{PLUGIN_INDEX};
 
   auto plugin =
-      freeaudio::clap_wrapper::standalone::mainCreatePlugin(entry, pid, pindex, 1, (char **)argv);
+      freeaudio::clap_wrapper::standalone::mainCreatePlugin(entry, pid, pindex, 1, (char**)argv);
   freeaudio::clap_wrapper::standalone::mainStartAudio();
 
 #if LIN
@@ -70,6 +78,10 @@ int main(int argc, char **argv)
   gtkGui.runloop(argc, argv);
   gtkGui.shutdown();
   gtkGui.setPlugin(nullptr);
+#elif CLAP_WRAPPER_STANDALONE_X11
+  x11Gui.setPlugin(plugin);
+  x11Gui.runloop();
+  x11Gui.shutdown();
 #else
   freeaudio::clap_wrapper::standalone::mainWait();
 #endif


### PR DESCRIPTION
As big libs go to wayland only and stuff, write a small simple X11 poll based wrapper for the standalone. This actually makes it on by default and I think thats appropriate. Later we should remove that GTK based code