### PR TITLE
VST3 track info

### DIFF
--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -134,6 +134,13 @@ static void tail_changed(const clap_host_t* host)
 
 const clap_host_tail tail = {tail_changed};
 
+static bool track_info_get(const clap_host_t* host, clap_track_info_t* info)
+{
+  return self(host)->track_info_get(info);
+}
+
+const clap_host_track_info trackinfo = {track_info_get};
+
 }  // namespace HostExt
 
 std::shared_ptr<Plugin> Plugin::createInstance(const clap_plugin_factory* factory, const std::string& id,
@@ -224,6 +231,7 @@ void Plugin::connectClap(const clap_plugin_t* clap)
   getExtension(_plugin, _ext._tail, CLAP_EXT_TAIL);
   getExtension(_plugin, _ext._gui, CLAP_EXT_GUI);
   getExtension(_plugin, _ext._timer, CLAP_EXT_TIMER_SUPPORT);
+  getExtension(_plugin, _ext._trackinfo, CLAP_EXT_TRACK_INFO);
   getExtension(_plugin, _ext._ara, CLAP_EXT_ARA_PLUGINEXTENSION);
 
   getExtension(_plugin, _ext._contextmenu, CLAP_EXT_CONTEXT_MENU);
@@ -516,6 +524,7 @@ const void* Plugin::clapExtension(const clap_host* /*host*/, const char* extensi
 {
   if (!strcmp(extension, CLAP_EXT_LOG)) return &HostExt::log;
   if (!strcmp(extension, CLAP_EXT_PARAMS)) return &HostExt::params;
+  if (!strcmp(extension, CLAP_EXT_TRACK_INFO)) return &HostExt::trackinfo;
   if (!strcmp(extension, CLAP_EXT_THREAD_CHECK)) return &HostExt::threadcheck;
   if (!strcmp(extension, CLAP_EXT_GUI)) return &HostExt::hostgui;
   if (!strcmp(extension, CLAP_EXT_TIMER_SUPPORT)) return &HostExt::hosttimer;

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -70,6 +70,7 @@ class IHost
   virtual bool register_timer(uint32_t period_ms, clap_id* timer_id) = 0;
   virtual bool unregister_timer(clap_id timer_id) = 0;
 
+  virtual bool track_info_get(clap_track_info_t* info) = 0;
   virtual const char* host_get_name() = 0;
 
   // context menu
@@ -112,6 +113,7 @@ struct ClapPluginExtensions
   const clap_plugin_render_t* _render = nullptr;
   const clap_plugin_tail_t* _tail = nullptr;
   const clap_plugin_timer_support_t* _timer = nullptr;
+  const clap_plugin_track_info_t* _trackinfo = nullptr;
   const clap_plugin_context_menu_t* _contextmenu = nullptr;
   const clap_ara_plugin_extension_t* _ara = nullptr;
   const clap_plugin_gain_adjustment_metering_t* _gainreduc = nullptr;
@@ -232,6 +234,11 @@ class Plugin
   }
   void closed(bool was_destroyed)
   {
+  }
+
+  bool track_info_get(clap_track_info_t* info)
+  {
+    return _parentHost->track_info_get(info);
   }
 
   // clap_timer support

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -468,6 +468,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
     return _hostname.c_str();
   }
 
+  bool track_info_get(clap_track_info_t* info) override
+  {
+    return false;
+  }
+
   // --------------- IAutomation
   void onBeginEdit(clap_id id) override;
   void onPerformEdit(const clap_event_param_value_t* value) override;

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -184,6 +184,11 @@ struct StandaloneHost : Clap::IHost
 
   const char *host_get_name() override;
 
+  bool track_info_get(clap_track_info_t *info) override
+  {
+    return false;
+  }
+
   // context menu extension
   bool supportsContextMenu() const override
   {

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -3,6 +3,7 @@
 #include <pluginterfaces/base/ustring.h>
 #include <pluginterfaces/vst/ivstevents.h>
 #include <pluginterfaces/vst/ivstnoteexpression.h>
+#include <pluginterfaces/vst/ivstchannelcontextinfo.h>
 #include <public.sdk/source/vst/utility/stringconvert.h>
 
 // With 3.8.0 fstring is no longer up to snuff for wextra gcc so...
@@ -574,6 +575,33 @@ tresult PLUGIN_API ClapAsVst3::getMidiControllerAssignment(int32 busIndex, int16
     }
   }
   return kResultFalse;
+}
+
+//----from IInfoListener--------------------------------------
+tresult PLUGIN_API ClapAsVst3::setChannelContextInfos(Vst::IAttributeList* list /*in*/)
+{
+  if (!_plugin->_ext._trackinfo) return kResultFalse;
+  if (!_trackInfo) _trackInfo = std::make_unique<clap_track_info_t>();
+  _trackInfo->flags = 0;
+
+  int64_t color = 0;
+  if (list->getInt(Vst::ChannelContext::kChannelColorKey, color) == kResultOk)
+  {
+    _trackInfo->flags |= CLAP_TRACK_INFO_HAS_TRACK_COLOR;
+    _trackInfo->color = clap_color{
+        Vst::ChannelContext::GetAlpha((uint32_t)color), Vst::ChannelContext::GetRed((uint32_t)color),
+        Vst::ChannelContext::GetGreen((uint32_t)color), Vst::ChannelContext::GetBlue((uint32_t)color)};
+  }
+
+  Steinberg::Vst::TChar name[CLAP_NAME_SIZE];
+  if (list->getString(Vst::ChannelContext::kChannelNameKey, name, sizeof(name)) == kResultOk)
+  {
+    _trackInfo->flags |= CLAP_TRACK_INFO_HAS_TRACK_NAME;
+    Steinberg::String(name, CLAP_NAME_SIZE).copyTo8(_trackInfo->name, 0, CLAP_NAME_SIZE);
+  }
+
+  _plugin->_ext._trackinfo->changed(_plugin->_plugin);
+  return kResultOk;
 }
 
 #if 1
@@ -1195,6 +1223,18 @@ void ClapAsVst3::onPerformEdit(const clap_event_param_value_t* value)
 void ClapAsVst3::onEndEdit(clap_id id)
 {
   _queueToUI.push(endEvent(id));
+}
+
+// track-info
+bool ClapAsVst3::track_info_get(clap_track_info_t* info)
+{
+  if (_trackInfo)
+  {
+    *info = *_trackInfo;
+    return true;
+  }
+
+  return false;
 }
 
 // ext-timer

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -22,9 +22,11 @@
 
 #include <pluginterfaces/vst/ivstmidicontrollers.h>
 #include <pluginterfaces/vst/ivstnoteexpression.h>
+#include <pluginterfaces/vst/ivstchannelcontextinfo.h>
+#include <pluginterfaces/vst/ivstcontextmenu.h>
+#include <pluginterfaces/vst/ivstattributes.h>
 #include <public.sdk/source/vst/vstsinglecomponenteffect.h>
 #include <public.sdk/source/vst/vstnoteexpressiontypes.h>
-#include <pluginterfaces/vst/ivstcontextmenu.h>
 
 #include <presonus-plugin-extensions/ipslgainreduction.h>
 
@@ -117,6 +119,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
                    public Steinberg::Vst::IMidiMapping,
                    public Steinberg::Vst::INoteExpressionController,
                    public Steinberg::Vst::IContextMenuTarget,
+                   public Steinberg::Vst::ChannelContext::IInfoListener,
                    public ARA::IPlugInEntryPoint,
                    public ARA::IPlugInEntryPoint2,
                    public Presonus::IGainReductionInfo,
@@ -133,6 +136,7 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
     : super()
     , Steinberg::Vst::IMidiMapping()
     , Steinberg::Vst::INoteExpressionController()
+    , Steinberg::Vst::ChannelContext::IInfoListener()
     , ARA::IPlugInEntryPoint()
     , ARA::IPlugInEntryPoint2()
     , Presonus::IGainReductionInfo()
@@ -182,6 +186,9 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   tresult PLUGIN_API getMidiControllerAssignment(int32 busIndex, int16 channel,
                                                  Vst::CtrlNumber midiControllerNumber,
                                                  Vst::ParamID& id /*out*/) override;
+
+  //----from IInfoListener--------------------------------------
+  tresult PLUGIN_API setChannelContextInfos(Vst::IAttributeList* list /*in*/) override;
 
   //----from INoteExpressionController-------------------------
   /** Returns number of supported note change types for event bus index and channel. */
@@ -274,6 +281,13 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
       DEF_INTERFACE(Presonus::IGainReductionInfo);
     }
   }
+  if (::Steinberg::FUnknownPrivate::iidEqual(iid, Steinberg::Vst::ChannelContext::IInfoListener::iid))
+  {
+    if (_plugin->_ext._trackinfo)
+    {
+      DEF_INTERFACE(Steinberg::Vst::ChannelContext::IInfoListener);
+    }
+  }
 
   // add any other interfaces here:
   //if (::Steinberg::FUnknownPrivate::iidEqual(iid, IExampleSomething::iid))
@@ -322,6 +336,8 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   void restartPlugin() override;
 
   void request_callback() override;
+
+  bool track_info_get(clap_track_info_t* info) override;
 
   // clap_timer support
   bool register_timer(uint32_t period_ms, clap_id* timer_id) override;
@@ -374,6 +390,9 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   WrappedView* _wrappedview = nullptr;
 
   void* _creationcontext;  // context from the CLAP library
+
+  // track info
+  std::unique_ptr<clap_track_info_t> _trackInfo;
 
   // plugin state
   bool _active = false;

--- a/tests/clap-first-example/distortion_clap.cpp
+++ b/tests/clap-first-example/distortion_clap.cpp
@@ -58,6 +58,30 @@ typedef struct
 
 static void clap1stDist_process_event(clap1st_distortion_plug *plug, const clap_event_header_t *hdr);
 
+////////////////////////////
+// clap_plugin_track_info //
+////////////////////////////
+
+static void clap1stDist_track_info_changed(const clap_plugin_t* plugin)
+{
+  auto* plug = (clap1st_distortion_plug*)plugin->plugin_data;
+  const clap_host_track_info_t* trackInfo =
+      (const clap_host_track_info_t*)plug->host->get_extension(plug->host, CLAP_EXT_TRACK_INFO);
+
+  clap_track_info_t info;
+  if (trackInfo && trackInfo->get(plug->host, &info))
+  {
+    fprintf(stderr, "  Track name: %s\n", info.name);
+    fprintf(stderr, "  Track color (R): %d\n", info.color.red);
+    fprintf(stderr, "  Track color (G): %d\n", info.color.green);
+    fprintf(stderr, "  Track color (B): %d\n", info.color.blue);
+  }
+}
+
+static const clap_plugin_track_info_t s_clap1stDist_track_info = {
+    clap1stDist_track_info_changed,
+};
+
 /////////////////////////////
 // clap_plugin_audio_ports //
 /////////////////////////////
@@ -454,6 +478,7 @@ static clap_process_status clap1stDist_process(const struct clap_plugin *plugin,
 
 static const void *clap1stDist_get_extension(const struct clap_plugin *plugin, const char *id)
 {
+  if (!strcmp(id, CLAP_EXT_TRACK_INFO)) return &s_clap1stDist_track_info;
   if (!strcmp(id, CLAP_EXT_AUDIO_PORTS)) return &s_clap1stDist_audio_ports;
   if (!strcmp(id, CLAP_EXT_PARAMS)) return &s_clap1stDist_params;
   if (!strcmp(id, CLAP_EXT_STATE)) return &s_clap1stDist_state;


### PR DESCRIPTION
VST3 wrapper now exposes track info (name and color) provided by `IInfoListener` via the `CLAP_EXT_TRACK_INFO` extension.