### PR TITLE
AUv2: Fix reported parameter info

### DIFF
--- a/src/detail/auv2/parameter.cpp
+++ b/src/detail/auv2/parameter.cpp
@@ -35,16 +35,14 @@ void Parameter::updateInfo(const clap_plugin_t* plugin, const clap_plugin_params
   }
   if (info.flags & CLAP_PARAM_IS_STEPPED)
   {
-    if (info.max_value - info.min_value == 1)
-    {
+    if (info.max_value == 1 && info.min_value == 0)
       flags |= kAudioUnitParameterUnit_Boolean;
-    }
-    // flags |= kAudioUnitParameterUnit_Indexed;  // probably need to add the lists then
+    else
+      flags |= kAudioUnitParameterUnit_Indexed;
   }
-  if (info.max_value - info.min_value > 100)
-  {
-    flags |= kAudioUnitParameterFlag_IsHighResolution;
-  }
+
+  // we need this, otherwise hosts may quantize the parameter to 100 steps
+  flags |= kAudioUnitParameterFlag_IsHighResolution;
 
   // checking if the parameter supports the conversion of its value to text
 

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -460,11 +460,7 @@ OSStatus WrapAsAUV2::GetParameterInfo(AudioUnitScope inScope, AudioUnitParameter
       outParameterInfo.cfNameString = f->CFString();
       outParameterInfo.minValue = info.min_value;
       outParameterInfo.maxValue = info.max_value;
-      outParameterInfo.defaultValue = info.min_value;
-      if (info.min_value < 0.0)
-      {
-        outParameterInfo.defaultValue = 0.0;
-      }
+      outParameterInfo.defaultValue = info.default_value;
 
       // adding the clump information
       if (info.module[0] != 0)


### PR DESCRIPTION
- Use the default value that is reported by the params extension
- Always set `IsHighResolution` flag (see #441)
- Set `kAudioUnitParameterUnit_Boolean` only if the range is 0..1 ([apple docs](https://developer.apple.com/documentation/audiotoolbox/audiounitparameterunit/boolean?changes=_6&language=objc))
- Set `kAudioUnitParameterUnit_Indexed` for stepped parameters