### PR TITLE
Make it so reasonable defaults for AUV2 cmake win

### DIFF
--- a/cmake/wrap_auv2.cmake
+++ b/cmake/wrap_auv2.cmake
@@ -99,8 +99,21 @@ function(target_add_auv2_wrapper)
         message(STATUS "clap-wrapper: building auv2 based on target ${AUV2_CLAP_TARGET_FOR_CONFIG}")
         get_property(ton TARGET ${clpt} PROPERTY LIBRARY_OUTPUT_NAME)
         set(AUV2_OUTPUT_NAME "${ton}")
-        set(AUV2_SUBTYPE_CODE "Fooo")
-        set(AUV2_INSTRUMENT_TYPE "aumu")
+
+        if (NOT DEFINED AUV2_MANUFACTURER_CODE)
+            set(AUV2_MANUFACTURER_CODE "errr")
+        endif()
+        if (NOT DEFINED AUV2_MANUFACTURER_NAME)
+            set(AUV2_MANUFACTURER_CODE "errr")
+        endif()
+
+        if (NOT DEFINED AUV2_SUBTYPE_CODE)
+            # this value indicates not set to the helper
+            set(AUV2_SUBTYPE_CODE "errr")
+        endif()
+        if (NOT DEFINED AUV2_INSTRUMENT_TYPE)
+            set(AUV2_INSTRUMENT_TYPE "errr")
+        endif()
 
         add_dependencies(${AUV2_TARGET} ${clpt})
         add_dependencies(${bhtg} ${clpt})
@@ -115,11 +128,24 @@ function(target_add_auv2_wrapper)
                 "${AUV2_OUTPUT_NAME}"
                 "$<TARGET_FILE:${clpt}>" "${AUV2_BUNDLE_VERSION}"
                 "${AUV2_MANUFACTURER_CODE}" "${AUV2_MANUFACTURER_NAME}"
+                "${AUV2_INSTRUMENT_TYPE}" "${AUV2_SUBTYPE_CODE}"
         )
     elseif (NOT ${PREF} AND DEFINED AUV2_MACOSX_EMBEDDED_CLAP_LOCATION)
         message(STATUS "clap-wrapper: building auv2 based on clap ${AUV2_MACOSX_EMBEDDED_CLAP_LOCATION}")
-        set(AUV2_SUBTYPE_CODE "----")
-        set(AUV2_INSTRUMENT_TYPE "aumu")
+
+        if (NOT DEFINED AUV2_MANUFACTURER_CODE)
+            set(AUV2_MANUFACTURER_CODE "errr")
+        endif()
+        if (NOT DEFINED AUV2_MANUFACTURER_NAME)
+            set(AUV2_MANUFACTURER_CODE "errr")
+        endif()
+
+        if (NOT DEFINED AUV2_SUBTYPE_CODE)
+            set(AUV2_SUBTYPE_CODE "errr")
+        endif()
+        if (NOT DEFINED AUV2_INSTRUMENT_TYPE)
+            set(AUV2_INSTRUMENT_TYPE "errr")
+        endif()
 
         add_custom_command(
                 TARGET ${bhtg}
@@ -131,6 +157,7 @@ function(target_add_auv2_wrapper)
                 "${AUV2_OUTPUT_NAME}"
                 "${AUV2_MACOSX_EMBEDDED_CLAP_LOCATION}" "${AUV2_BUNDLE_VERSION}"
                 "${AUV2_MANUFACTURER_CODE}" "${AUV2_MANUFACTURER_NAME}"
+                "${AUV2_INSTRUMENT_TYPE}" "${AUV2_SUBTYPE_CODE}"
         )
     else ()
         message(STATUS "clap-wrapper: using cmake configuration for auv2")

--- a/src/detail/auv2/build-helper/build-helper.cpp
+++ b/src/detail/auv2/build-helper/build-helper.cpp
@@ -38,7 +38,7 @@ struct auInfo
     return sum();
   }
 
-  void writePListFragment(std::ostream &of, int idx) const
+  void writePListFragment(std::ostream& of, int idx) const
   {
     if (!clapid.empty())
     {
@@ -93,8 +93,9 @@ struct auInfo
   }
 };
 
-bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname, std::string &manu,
-                        std::string &manuName, std::vector<auInfo> &units)
+bool buildUnitsFromClap(const std::string& clapfile, const std::string& clapname, std::string manu,
+                        std::string manuName, std::string itype, std::string subt,
+                        std::vector<auInfo>& units)
 {
   Clap::Library loader;
   if (!loader.load(clapfile))
@@ -118,8 +119,13 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
     std::cout << "  - using factory manufacturer '" << manuName << "' (" << manu << ")" << std::endl;
   }
 
-  static const char *encoder = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
-  for (const auto *clapPlug : loader.plugins)
+  if (!itype.empty() && !subt.empty() && loader.plugins.size() > 1)
+  {
+    std::cout << "[ERROR] Multi-plugin claps must speciy itype and subtype via extension" << std::endl;
+  }
+
+  static const char* encoder = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+  for (const auto* clapPlug : loader.plugins)
   {
     auto u = auInfo();
     bool doExport = true;
@@ -141,12 +147,16 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
       idHash = idHash >> 9;  // mix it up a bit
     }
 
-    u.subt = stH;
+    u.subt = subt.empty() ? stH : subt;
     u.manu = manu;
     u.manunm = manuName;
 
     auto f = clapPlug->features[0];
-    if (f == nullptr || strcmp(f, CLAP_PLUGIN_FEATURE_INSTRUMENT) == 0)
+    if (!itype.empty())
+    {
+      u.type = itype;
+    }
+    else if (f == nullptr || strcmp(f, CLAP_PLUGIN_FEATURE_INSTRUMENT) == 0)
     {
       u.type = "aumu";
     }
@@ -203,7 +213,7 @@ bool buildUnitsFromClap(const std::string &clapfile, const std::string &clapname
   return true;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   if (argc < 2) return 1;
 
@@ -247,8 +257,21 @@ int main(int argc, char **argv)
     auto clapname = std::string(argv[idx++]);
     auto clapfile = std::string(argv[idx++]);
     auto bundlev = std::string(argv[idx++]);
-    auto mcode = (idx < argc) ? std::string(argv[idx++]) : std::string();
-    auto mname = (idx < argc) ? std::string(argv[idx++]) : std::string();
+
+    auto nerr = [](const auto& a)
+    {
+      if (a == "errr")
+        return std::string();
+      else
+        return a;
+    };
+
+    auto mcode = nerr((idx < argc) ? std::string(argv[idx++]) : std::string());
+    auto mname = nerr((idx < argc) ? std::string(argv[idx++]) : std::string());
+    ;
+
+    auto itype = nerr((idx < argc) ? std::string(argv[idx++]) : std::string());
+    auto isubt = nerr((idx < argc) ? std::string(argv[idx++]) : std::string());
 
     try
     {
@@ -265,7 +288,7 @@ int main(int argc, char **argv)
         clapfile = p.u8string();
       }
     }
-    catch (const fs::filesystem_error &e)
+    catch (const fs::filesystem_error& e)
     {
       std::cout << "[ERROR] cant get path " << e.what() << std::endl;
       return 3;
@@ -274,7 +297,7 @@ int main(int argc, char **argv)
     std::cout << "  - building information from CLAP directly\n"
               << "  - source clap: '" << clapfile << "'" << std::endl;
 
-    if (!buildUnitsFromClap(clapfile, clapname, mcode, mname, units))
+    if (!buildUnitsFromClap(clapfile, clapname, mcode, mname, itype, isubt, units))
     {
       std::cout << "[ERROR] Can't build units from CLAP" << std::endl;
       return 4;
@@ -286,7 +309,7 @@ int main(int argc, char **argv)
       return 5;
     }
 
-    for (auto &u : units)
+    for (auto& u : units)
     {
       u.bundlevers = bundlev;
     }
@@ -316,7 +339,7 @@ int main(int argc, char **argv)
 
   of << "    <key>AudioComponents</key>\n    <array>\n";
   int idx{0};
-  for (const auto &u : units)
+  for (const auto& u : units)
   {
     std::cout << "    + " << u.name << " (" << u.type << "/" << u.subt << ") by " << u.manunm << " ("
               << u.manu << ")" << std::endl;
@@ -340,7 +363,7 @@ int main(int argc, char **argv)
     cppf << "#include \"detail/auv2/auv2_base_classes.h\"\n\n";
 
     idx = 0;
-    for (const auto &u : units)
+    for (const auto& u : units)
     {
       auto on = u.factoryBase + std::to_string(idx);
 
@@ -430,7 +453,7 @@ int main(int argc, char **argv)
                "std::shared_ptr<Clap::Plugin> _plugin) {\n";
 
     idx = 0;
-    for (const auto &u : units)
+    for (const auto& u : units)
     {
       std::string strcid;
 
@@ -443,7 +466,7 @@ int main(int argc, char **argv)
         strcid = u.clapid;
       }
 
-      for (auto &c : strcid)
+      for (auto& c : strcid)
       {
         if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'A') || (c >= '0' && c <= '9'))
         {

--- a/tests/clap-macos-embedded/CMakeLists.txt
+++ b/tests/clap-macos-embedded/CMakeLists.txt
@@ -30,7 +30,7 @@ target_add_auv2_wrapper(
         BUNDLE_VERSION "1.0"
 
         # This allows CMake to override the auv2 extension configuration
-        PREFER_CMAKE_AUV2_CONFIGURATION TRUE
+        # PREFER_CMAKE_AUV2_CONFIGURATION TRUE
 
         MANUFACTURER_NAME "Free Audio"
         MANUFACTURER_CODE "FRaD"


### PR DESCRIPTION
- If you have an auv2 extension and an embedded clap that wins
- If you have cmake args, one plugin, and no auv2 that wins
- If you have cmake args, > 1 plugin, no extension: error
- If you have 1 plugin and auv2, add an option to prefer cmake