### PR TITLE
Fix VST3 memory leaks (2)

### DIFF
--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -131,9 +131,7 @@ Vst3Parameter *Vst3Parameter::create(
   else
     v.stepCount = 0;
 
-  auto result = new Vst3Parameter(v, info);
-  result->addRef();  // ParameterContainer doesn't add the ref -> but we don't have copies
-  return result;
+  return new Vst3Parameter(v, info);
 }
 
 Vst3Parameter *Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, Vst::ParamID id)
@@ -183,7 +181,5 @@ Vst3Parameter *Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, V
     v.stepCount = 16383;
   }
 
-  auto result = new Vst3Parameter(v, bus, channel, cc);
-  result->addRef();  // ParameterContainer doesn't add the ref -> but we don't have copies
-  return result;
+  return new Vst3Parameter(v, bus, channel, cc);
 }

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -34,23 +34,18 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plu
 
   if (numSamples > 0)
   {
-    delete[] _silent_input;
-    _silent_input = new float[numSamples];
-
-    delete[] _silent_output;
-    _silent_output = new float[numSamples];
+    _silent_input = std::make_unique<float[]>(numSamples);
+    _silent_output = std::make_unique<float[]>(numSamples);
   }
 
   auto numInputs = (uint32_t)_audioinputs->size();
   auto numOutputs = (uint32_t)_audiooutputs->size();
 
   _processData.audio_inputs_count = numInputs;
-  delete[] _input_ports;
-  _input_ports = nullptr;
 
   if (numInputs > 0)
   {
-    _input_ports = new clap_audio_buffer_t[numInputs];
+    _input_ports = std::make_unique<clap_audio_buffer_t[]>(numInputs);
     for (auto i = 0U; i < numInputs; ++i)
     {
       clap_audio_buffer_t &bus = _input_ports[i];
@@ -64,20 +59,19 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plu
         bus.data32 = nullptr;
       }
     }
-    _processData.audio_inputs = _input_ports;
+    _processData.audio_inputs = _input_ports.get();
   }
   else
   {
+    _input_ports = nullptr;
     _processData.audio_inputs = nullptr;
   }
 
   _processData.audio_outputs_count = numOutputs;
-  delete[] _output_ports;
-  _output_ports = nullptr;
 
   if (numOutputs > 0)
   {
-    _output_ports = new clap_audio_buffer_t[numOutputs];
+    _output_ports = std::make_unique<clap_audio_buffer_t[]>(numOutputs);
     for (auto i = 0U; i < numOutputs; ++i)
     {
       clap_audio_buffer_t &bus = _output_ports[i];
@@ -91,10 +85,11 @@ void ProcessAdapter::setupProcessing(const clap_plugin_t *plugin, const clap_plu
         bus.data32 = nullptr;
       }
     }
-    _processData.audio_outputs = _output_ports;
+    _processData.audio_outputs = _output_ports.get();
   }
   else
   {
+    _output_ports = nullptr;
     _processData.audio_outputs = nullptr;
   }
 

--- a/src/detail/vst3/process.h
+++ b/src/detail/vst3/process.h
@@ -116,14 +116,14 @@ class ProcessAdapter
   };
   std::vector<ActiveNote> _activeNotes;
 
-  clap_audio_buffer_t* _input_ports = nullptr;
-  clap_audio_buffer_t* _output_ports = nullptr;
+  std::unique_ptr<clap_audio_buffer_t[]> _input_ports;
+  std::unique_ptr<clap_audio_buffer_t[]> _output_ports;
   clap_event_transport_t _transport = {};
   clap_input_events_t _in_events = {};
   clap_output_events_t _out_events = {};
 
-  float* _silent_input = nullptr;
-  float* _silent_output = nullptr;
+  std::unique_ptr<float[]> _silent_input;
+  std::unique_ptr<float[]> _silent_output;
 
   clap_process_t _processData = {-1, 0, &_transport, nullptr, nullptr, 0, 0, &_in_events, &_out_events};
 

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -385,9 +385,9 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   Clap::Library *_library = nullptr;
   int _libraryIndex = 0;
   std::shared_ptr<Clap::Plugin> _plugin;
-  clap_plugin_as_vst3_t* _vst3specifics = nullptr;
-  Clap::ProcessAdapter* _processAdapter = nullptr;
-  WrappedView* _wrappedview = nullptr;
+  clap_plugin_as_vst3_t *_vst3specifics = nullptr;
+  Clap::ProcessAdapter *_processAdapter = nullptr;
+  WrappedView *_wrappedview = nullptr;
 
   void *_creationcontext;  // context from the CLAP library
 


### PR DESCRIPTION
Same as #431 but without touching the `_wrappedview` or any other FObject variables:
- remove `addRef()` for `Vst3Parameter`
- use `unique_ptr` for audio buffers in the `ProcessAdapter`

Tested with ASAN/vst3-validator and Bitwig with clapfirst example; if anyone can test this on a plugin with a gui (just in case) that'd be awesome