### PR TITLE
Implement an extension for auv2 parameter ordering

### DIFF
--- a/include/clapwrapper/auv2.h
+++ b/include/clapwrapper/auv2.h
@@ -35,11 +35,19 @@ extern "C"
   // clap_plugin_auv2_param_ordering extension allows you to provide an ordering for your params
   // by mapping the get_param_info index (0..num-params) to a different ordering.
   //
-  // The default behavior absent this extension is to sort by parameter id, which is clap param id.
+  // The result of this will be used such that `auv2_index = ordering[clap_index]`. So in a five
+  // parameter case, if you want clap index 0 to appear at auv2 position 3, and clap index 3 to appear
+  // at auv2 position 0, you would return `3 1 2 0 4`
+  //
+  // The default behavior absent this extension is to sort by auv2 parameter id, which is clap param id.
   // So if you use a strategy where you go from not adopting this to adopting this when you add params,
   // make sure your old version param subset retains the param id ordering.
   //
-  // For instance, a good impementation if your parameters have a 'version' increasint parameter could be
+  // The clap wrapper will check if your ordering is complete and valid, and if not, generate errors
+  // to stdout and, in a debug build, fail an assertion. Running in auval while developing this
+  // method with a debug build enabled is helpful.
+  //
+  // A reasonable implementation if your parameters have a 'version' increasing parameter could be
   //
   // static bool CLAP_ABI auv2_get_param_order(const clap_plugin_t *plugin, size_t *order,
   //   size_t param_count) noexcept
@@ -67,8 +75,8 @@ extern "C"
   typedef struct clap_plugin_auv2_param_ordering
   {
     // given an empty input array order of size param_count, populate it with the index ordering.
-    // return true if succesful. if succesful, the order array will contain each inded 0...param_count-1
-    // once and only once
+    // return true if successful. if successful, the order array will contain each index 0...param_count-1
+    // once and only once and the param at auv2_index will be the clap param at ordering[clap_index].
     bool(CLAP_ABI *get_param_order)(const clap_plugin_t *plugin, size_t *order, size_t param_count);
   } clap_plugin_auv2_param_ordering_t;
 

--- a/include/clapwrapper/auv2.h
+++ b/include/clapwrapper/auv2.h
@@ -30,6 +30,48 @@ extern "C"
                                   clap_plugin_info_as_auv2_t *info);
   } clap_plugin_factory_as_auv2_t;
 
+  // Parameter order matters in auv2 critically still in logic and garage band, and if you add
+  // parameters after a release, you need to order them (alas) even if the ids aren't changed.
+  // clap_plugin_auv2_param_ordering extension allows you to provide an ordering for your params
+  // by mapping the get_param_info index (0..num-params) to a different ordering.
+  //
+  // The default behavior absent this extension is to sort by parameter id, which is clap param id.
+  // So if you use a strategy where you go from not adopting this to adopting this when you add params,
+  // make sure your old version param subset retains the param id ordering.
+  //
+  // For instance, a good impementation if your parameters have a 'version' increasint parameter could be
+  //
+  // static bool CLAP_ABI auv2_get_param_order(const clap_plugin_t *plugin, size_t *order,
+  //   size_t param_count) noexcept
+  // {
+  //   auto *self = static_cast<SixSinesClap *>(plugin->plugin_data);
+  //   auto &params = self->engine->patch.params; // your internal model!
+  //   if (param_count != params.size())
+  //     return false;
+  //
+  //   std::iota(order, order + param_count, (size_t)0);
+  //   std::sort(order, order + param_count, [&params](size_t a, size_t b) {
+  //       bool aVer = params[a]->meta.version;
+  //       bool bVer = params[b]->meta.version;
+  //       if (aVer != bVer)
+  //       {
+  //           return aVer < bVer;
+  //       }
+  //       return params[a]->meta.id < params[b]->meta.id;
+  //   });
+  //   return true;
+  // }
+  static const CLAP_CONSTEXPR char CLAP_PLUGIN_AUV2_PARAM_ORDERING[] =
+      "clap.plugin-auv2-param-ordering/0";
+
+  typedef struct clap_plugin_auv2_param_ordering
+  {
+    // given an empty input array order of size param_count, populate it with the index ordering.
+    // return true if succesful. if succesful, the order array will contain each inded 0...param_count-1
+    // once and only once
+    bool(CLAP_ABI *get_param_order)(const clap_plugin_t *plugin, size_t *order, size_t param_count);
+  } clap_plugin_auv2_param_ordering_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -241,6 +241,7 @@ void Plugin::connectClap(const clap_plugin_t *clap)
   }
 
   getExtension(_plugin, _ext._gainreduc, CLAP_EXT_GAIN_ADJUSTMENT_METERING);
+  getExtension(_plugin, _ext._auv2_param_ordering, CLAP_PLUGIN_AUV2_PARAM_ORDERING);
 
 #if LIN
   getExtension(_plugin, _ext._posixfd, CLAP_EXT_POSIX_FD_SUPPORT);

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -117,6 +117,7 @@ struct ClapPluginExtensions
   const clap_plugin_context_menu_t *_contextmenu = nullptr;
   const clap_ara_plugin_extension_t *_ara = nullptr;
   const clap_plugin_gain_adjustment_metering_t *_gainreduc = nullptr;
+  const clap_plugin_auv2_param_ordering_t *_auv2_param_ordering = nullptr;
 #if LIN
   const clap_plugin_posix_fd_support *_posixfd = nullptr;
 #endif

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -550,6 +550,8 @@ class WrapAsAUV2 : public ausdk::AUBase,
   bool _midi_dualscheduling_mode = false;
 #endif
   std::map<uint32_t, std::unique_ptr<Clap::AUv2::Parameter>> _parametertree;
+  std::vector<AudioUnitParameterID> _orderedParameterList;
+  bool _paramOrderingProvided{false};
   Clumps _clumps;
 
   CFStringRef _current_program_name = 0;

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -347,14 +347,33 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
   // creating parameters.
 
   _clumps.reset();
+  _orderedParameterList.clear();
+  _paramOrderingProvided = false;
   auto *p = _plugin->_ext._params;
   if (p)
   {
     uint32_t numparams = p->count(_plugin->_plugin);
+
+    // If the plugin provides a custom AUv2 param ordering, build an indirection array.
+    // order[i] is the CLAP param index to use for AUv2 position i.
+    std::vector<size_t> orderingStorage;
+    const size_t *ordering = nullptr;
+    auto *paramOrdering = _plugin->_ext._auv2_param_ordering;
+    if (paramOrdering)
+    {
+      orderingStorage.resize(numparams);
+      if (paramOrdering->get_param_order(_plugin->_plugin, orderingStorage.data(), numparams))
+      {
+        ordering = orderingStorage.data();
+        _paramOrderingProvided = true;
+      }
+    }
+
     clap_param_info_t paraminfo;
     for (uint32_t i = 0; i < numparams; ++i)
     {
-      if (p->get_info(_plugin->_plugin, i, &paraminfo))
+      uint32_t clapIndex = ordering ? static_cast<uint32_t>(ordering[i]) : i;
+      if (p->get_info(_plugin->_plugin, clapIndex, &paraminfo))
       {
         double result;
         if (p->get_value(_plugin->_plugin, paraminfo.id, &result))
@@ -373,6 +392,7 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
             piter->second->updateInfo(_plugin->_plugin, p, paraminfo);
           }
           Globals()->SetParameter(paraminfo.id, result);
+          _orderedParameterList.push_back(static_cast<AudioUnitParameterID>(paraminfo.id));
         }
       }
     }
@@ -382,7 +402,17 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
 OSStatus WrapAsAUV2::GetParameterList(AudioUnitScope inScope, AudioUnitParameterID *outParameterList,
                                       UInt32 &outNumParameters)
 {
-  return AUBase::GetParameterList(inScope, outParameterList, outNumParameters);
+  if (inScope != kAudioUnitScope_Global || !_paramOrderingProvided)
+  {
+    return AUBase::GetParameterList(inScope, outParameterList, outNumParameters);
+  }
+
+  outNumParameters = static_cast<UInt32>(_orderedParameterList.size());
+  if (outParameterList)
+  {
+    for (UInt32 i = 0; i < outNumParameters; ++i) outParameterList[i] = _orderedParameterList[i];
+  }
+  return noErr;
 }
 
 void WrapAsAUV2::param_rescan(clap_param_rescan_flags flags)

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1,6 +1,8 @@
 #include "generated_entrypoints.hxx"
 #include "detail/auv2/process.h"
 #include <set>
+#include <limits>
+#include <cassert>
 
 extern bool fillAudioUnitCocoaView(AudioUnitCocoaViewInfo *viewInfo, std::shared_ptr<Clap::Plugin>);
 
@@ -361,11 +363,45 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
     auto *paramOrdering = _plugin->_ext._auv2_param_ordering;
     if (paramOrdering)
     {
-      orderingStorage.resize(numparams);
+      // Pre-fill with an out-of-range sentinel so we can detect untouched slots.
+      orderingStorage.assign(numparams, std::numeric_limits<size_t>::max());
       if (paramOrdering->get_param_order(_plugin->_plugin, orderingStorage.data(), numparams))
       {
-        ordering = orderingStorage.data();
-        _paramOrderingProvided = true;
+        // Sanity-check: every index 0..numparams-1 must appear exactly once.
+        std::set<size_t> seen;
+        bool orderingValid = true;
+        for (size_t i = 0; i < numparams; ++i)
+        {
+          size_t idx = orderingStorage[i];
+          if (idx >= numparams)
+          {
+            std::cout << "CLAP_PLUGIN_AUV2_PARAM_ORDERING: index " << idx << " at position " << i
+                      << " is out of range [0, " << numparams << ")" << std::endl;
+            orderingValid = false;
+          }
+          else if (!seen.insert(idx).second)
+          {
+            std::cout << "CLAP_PLUGIN_AUV2_PARAM_ORDERING: index " << idx << " appears more than once"
+                      << std::endl;
+            orderingValid = false;
+          }
+        }
+        // Check for any indices that were never used (implies a duplicate stole their slot).
+        for (size_t i = 0; i < numparams; ++i)
+        {
+          if (seen.find(i) == seen.end())
+          {
+            std::cout << "CLAP_PLUGIN_AUV2_PARAM_ORDERING: index " << i << " was never provided"
+                      << std::endl;
+            orderingValid = false;
+          }
+        }
+        assert(orderingValid);
+        if (orderingValid)
+        {
+          ordering = orderingStorage.data();
+          _paramOrderingProvided = true;
+        }
       }
     }
 


### PR DESCRIPTION
In logic and garage band, auv2 parameter ordering in the parameter index list matters for automation, so adding parameters needs a way to set the explicit ordering (as opposed to the default param-id ordering that the AUBase class will use as cast before this commit).

Addresses #427