### PR TITLE
Statically link libc and libc++ to vst3 when using mingw to build

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -230,11 +230,11 @@ jobs:
 
 
           - os: windows-latest
-            cmakeargs: -GNinja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DEXAMPLE_USE_WINDOWS_FOLDER=TRUE
+            cmakeargs: -GNinja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DEXAMPLE_USE_WINDOWS_FOLDER=TRUE -DMSVC_VST3_VALIDATOR=TRUE
             install_ninja: true
             run_aptget: false
             run_validator: true
-            vst3_validator: build/validator-build/bin/validator
+            vst3_validator: build/validator-build/bin/Debug/validator
             vst3_path: ./build/clap-first-distortion_assets/VST3/ClapFirst Bad Distortion.vst3
             name: ClapFirst Windows 64bit Folder gcc/minGW
 

--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -219,6 +219,25 @@ jobs:
             vst3_path: ./build/clap-first-distortion_assets/VST3/ClapFirst Bad Distortion.vst3
             name: ClapFirst Windows 64bit Folder MSVC
 
+          - os: windows-latest
+            cmakeargs: -GNinja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
+            install_ninja: true
+            run_aptget: false
+            run_validator: false
+            vst3_validator: build/validator-build/bin/validator
+            vst3_path: ./build/clap-first-distortion_assets/VST3/ClapFirst Bad Distortion.vst3
+            name: ClapFirst Windows 64bit Single File gcc/minGW
+
+
+          - os: windows-latest
+            cmakeargs: -GNinja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DEXAMPLE_USE_WINDOWS_FOLDER=TRUE
+            install_ninja: true
+            run_aptget: false
+            run_validator: true
+            vst3_validator: build/validator-build/bin/validator
+            vst3_path: ./build/clap-first-distortion_assets/VST3/ClapFirst Bad Distortion.vst3
+            name: ClapFirst Windows 64bit Folder gcc/minGW
+
           - os: ubuntu-latest
             cmakeargs: -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12
             install_ninja: false
@@ -296,5 +315,4 @@ jobs:
           cp -R "${{ matrix.auv2_path }}" ~/Library/Audio/Plug-Ins/Components/
           killall -9 AudioComponentRegistrar || true
           auval -strict -v aufx BdDt FrAD
-          
 

--- a/cmake/base_sdks.cmake
+++ b/cmake/base_sdks.cmake
@@ -189,6 +189,10 @@ function(guarantee_vst3sdk)
 
 
     if (NOT TARGET vst3_validator)
+        if(MSVC_VST3_VALIDATOR)
+            set(MSVC_VALIDATOR_FLAG -DCMAKE_CXX_COMPILER="MSVC" -DCMAKE_C_COMPILER="MSVC" -G "Visual Studio 17 2022" -A x64)
+        endif()
+
         add_custom_target(vst3_validator)
         add_custom_command(TARGET vst3_validator
                 POST_BUILD
@@ -206,6 +210,8 @@ function(guarantee_vst3sdk)
                         -DSMTG_ENABLE_VSTGUI_SUPPORT=OFF
                         -DSMTG_ENABLE_VST3_PLUGIN_EXAMPLES=OFF
                         -DSMTG_ENABLE_VST3_HOSTING_EXAMPLES=OFF
+
+                        ${MSVC_VALIDATOR_FLAG}
 
                         -B ${CMAKE_BINARY_DIR}/validator-build
 

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -248,7 +248,8 @@ function(target_add_vst3_wrapper)
                     LIBRARY_OUTPUT_DIRECTORY "${v3root}/${v3root_dor}${V3_OUTPUT_NAME}.vst3/Contents/${v3arch}-win"
                     LIBRARY_OUTPUT_DIRECTORY_DEBUG "${v3root}/${v3root_d}/${V3_OUTPUT_NAME}.vst3/Contents/${v3arch}-win"
                     LIBRARY_OUTPUT_DIRECTORY_RELEASE "${v3root}/${v3root_r}/${V3_OUTPUT_NAME}.vst3/Contents/${v3arch}-win"
-                    SUFFIX ".vst3")
+                    SUFFIX ".vst3"
+                    PREFIX "")
 
             # Copy resource directory, if defined
             if(NOT TCLP_RESOURCE_DIRECTORY STREQUAL "")

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -250,6 +250,10 @@ function(target_add_vst3_wrapper)
                     LIBRARY_OUTPUT_DIRECTORY_RELEASE "${v3root}/${v3root_r}/${V3_OUTPUT_NAME}.vst3/Contents/${v3arch}-win"
                     SUFFIX ".vst3")
 
+            if(MINGW)
+                target_link_options(${V3_TARGET} PRIVATE -static-libgcc -static-libstdc++)
+            endif(MINGW)
+
             # Copy resource directory, if defined
             if(NOT TCLP_RESOURCE_DIRECTORY STREQUAL "")
                 message(WARNING "RESOURCE_DIRECTORY defined, but not (yet) supported for Windows VST3s")

--- a/cmake/wrap_vst3.cmake
+++ b/cmake/wrap_vst3.cmake
@@ -250,16 +250,16 @@ function(target_add_vst3_wrapper)
                     LIBRARY_OUTPUT_DIRECTORY_RELEASE "${v3root}/${v3root_r}/${V3_OUTPUT_NAME}.vst3/Contents/${v3arch}-win"
                     SUFFIX ".vst3")
 
-            if(MINGW)
-                target_link_options(${V3_TARGET} PRIVATE -static-libgcc -static-libstdc++)
-            endif(MINGW)
-
             # Copy resource directory, if defined
             if(NOT TCLP_RESOURCE_DIRECTORY STREQUAL "")
                 message(WARNING "RESOURCE_DIRECTORY defined, but not (yet) supported for Windows VST3s")
             endif()
 
         endif()
+
+        if(MINGW)
+            target_link_options(${V3_TARGET} PRIVATE -static-libgcc -static-libstdc++)
+        endif(MINGW)
     endif()
 
     if (${CLAP_WRAPPER_COPY_AFTER_BUILD})

--- a/tests/clap-first-example/distortion_clap_entry.cpp
+++ b/tests/clap-first-example/distortion_clap_entry.cpp
@@ -17,7 +17,7 @@ extern "C"
 #pragma GCC diagnostic ignored "-Wattributes"  // other peoples errors are outside my scope
 #endif
 
-  const CLAP_EXPORT struct clap_plugin_entry clap_entry = {CLAP_VERSION, dist_entry_init,
+  CLAP_EXPORT extern const struct clap_plugin_entry clap_entry = {CLAP_VERSION, dist_entry_init,
                                                            dist_entry_deinit, dist_entry_get_factory};
 
 #ifdef __GNUC__


### PR DESCRIPTION
When building a VST3 for Windows on Linux using MinGW the resultant plugin would not work due to the missing libraries as they were dynamically linked.

Not sure if this is the best place or way of fixing this, so welcome to suggestions or updates to the PR.