### PR TITLE
fix(cmake): correct C1ST_BUNDLE_IDENTIFER typo in VST3 path

### DIFF
--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -154,7 +154,7 @@ function(make_clapfirst_plugins)
         endif()
         target_add_vst3_wrapper(TARGET ${VST3_TARGET}
                 OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
-                BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.vst3"
+                BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFIER}.vst3"
                 BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
                 ASSET_OUTPUT_DIRECTORY "${vod}"
                 WINDOWS_FOLDER_VST3 ${C1ST_WINDOWS_FOLDER_VST3}


### PR DESCRIPTION
## Summary

One-character typo fix: `C1ST_BUNDLE_IDENTIFER` → `C1ST_BUNDLE_IDENTIFIER` on the VST3 wrapper path in `cmake/make_clapfirst.cmake:167`.

`cmake_parse_arguments` converts the documented `BUNDLE_IDENTIFIER` named argument into `${prefix}_BUNDLE_IDENTIFIER`. The CLAP wrapper path on line 132 already reads the correct variable name; the VST3 wrapper path was reading the typo'd `${C1ST_BUNDLE_IDENTIFER}` which CMake silently expands to an empty string. Result: any plugin that doesn't explicitly set `BUNDLE_IDENTIFIER` to something matching the parser's expectation ships a VST3 with bundle ID equal to the literal string `.vst3`.

Caught while debugging plugin scanning issues in a downstream CLAP-first plugin (Folium / petals.fm). After this fix, VST3 builds inherit the same bundle identifier value the CLAP build path already produces.

## Test plan

- [x] Built a downstream CLAP-first plugin against this branch and confirmed `defaults read folium-dev.vst3/Contents/Info.plist CFBundleIdentifier` now returns the expected `com.petalsfm.folium.dev.vst3` instead of `.vst3`.
- [x] CLAP build path output unchanged.