### PR TITLE
Fix Windows standalone opening off-screen and crashing on minimize

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             name: Windows External SDK (VST3.7.7)
             vst_ver: v3.7.7_build_19
           - os: macos-latest
@@ -23,7 +23,7 @@ jobs:
             name: Linux External SDK  (VST3.7.7)
             vst_ver: v3.7.7_build_19
 
-          - os: windows-latest
+          - os: windows-2022
             name: Windows External SDK (VST3.8.0)
             vst_ver: v3.8.0_build_66
           - os: macos-latest
@@ -69,43 +69,43 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             cmakeargs: -A x64
             install_ninja: false
             run_aptget: false
             name: Windows 64bit MSVC
 
-          - os: windows-latest
+          - os: windows-2022
             cmakeargs: -A x64 -T ClangCL  -G"Visual Studio 17 2022"
             install_ninja: false
             run_aptget: false
             name: Windows 64bit VS ClangCL
 
-          - os: windows-latest
+          - os: windows-2022
             cmakeargs: -A arm64ec
             install_ninja: false
             run_aptget: false
             name: Windows arm64ec MSVC
 
-          - os: windows-latest
+          - os: windows-2022
             cmakeargs: -A arm64
             install_ninja: false
             run_aptget: false
             name: Windows arm64 MSVC
 
-          - os: windows-latest
+          - os: windows-2022
             cmakeargs: -A x64 -DCLAP_WRAPPER_CXX_STANDARD=20
             install_ninja: false
             run_aptget: false
             name: Windows 64bit C++20 MSVC
 
-          - os: windows-latest
+          - os: windows-2022
             cmakeargs: -GNinja -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc
             install_ninja: true
             run_aptget: false
             name: Windows gcc/minGW
 
-          #- os: windows-latest
+          #- os: windows-2022
           #  cmakeargs: -GNinja -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
           #  install_ninja: true
           #  run_aptget: false
@@ -201,7 +201,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             cmakeargs: -A x64
             install_ninja: false
             run_aptget: false
@@ -211,7 +211,7 @@ jobs:
             name: ClapFirst Windows 64bit Single File MSVC
 
 
-          - os: windows-latest
+          - os: windows-2022
             cmakeargs: -A x64 -DEXAMPLE_USE_WINDOWS_FOLDER=TRUE
             install_ninja: false
             run_aptget: false

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -69,6 +69,15 @@ std::vector<std::string> getArgs()
   return ::GetSystemMenu(hwnd, FALSE);
 }
 
+bool isRectOnAnyMonitor(const Position &position)
+{
+  ::RECT rect{position.x, position.y, position.x + static_cast<::LONG>(position.width),
+              position.y + static_cast<::LONG>(position.height)};
+
+  // MONITOR_DEFAULTTONULL => null when the rectangle doesn't intersect any display.
+  return ::MonitorFromRect(&rect, MONITOR_DEFAULTTONULL) != nullptr;
+}
+
 std::wstring toUTF16(std::string_view input)
 {
   std::wstring output;
@@ -607,7 +616,7 @@ void SystemMenu::populate(::HWND hwnd)
   }
 }
 
-Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin)
+Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
 {
   plugin.clap = clapPlugin;
   plugin.plugin = plugin.clap->_plugin;
@@ -665,18 +674,39 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin)
                    plugin.gui->hide(plugin.plugin);
                  }
 
-                 if (plugin.gui->can_resize(plugin.plugin))
+                 // Never push a degenerate size into the plugin GUI. A minimized window has a
+                 // 0x0 client rect; resizing the editor to that drives size-dependent drawing
+                 // to zero dimensions.
+                 if (!::IsIconic(msg.hwnd) && client.width > 0 && client.height > 0 &&
+                     plugin.gui->can_resize(plugin.plugin))
                  {
                    plugin.gui->adjust_size(plugin.plugin, &client.width, &client.height);
                    plugin.gui->set_size(plugin.plugin, client.width, client.height);
                  }
                }
 
-               position.x = windowPos->x;
-               position.y = windowPos->y;
-               position.width = windowPos->cx;
-               position.height = windowPos->cy;
+               // Only remember the restored (normal) geometry. Capturing while minimized or
+               // maximized would persist the -32000 iconic sentinel and throw the window
+               // off-screen on the next launch. GetWindowRect is the true screen rect (the
+               // WINDOWPOS x/y are unreliable when SWP_NOMOVE is set).
+               if (!::IsIconic(msg.hwnd) && !::IsZoomed(msg.hwnd))
+               {
+                 ::RECT wr{};
+                 ::GetWindowRect(msg.hwnd, &wr);
+                 position.x = wr.left;
+                 position.y = wr.top;
+                 position.width = static_cast<uint32_t>(wr.right - wr.left);
+                 position.height = static_cast<uint32_t>(wr.bottom - wr.top);
+               }
 
+               return 0;
+             });
+
+  message.on(WM_EXITSIZEMOVE,
+             [this](Message msg)
+             {
+               // Persist once a user move/resize finishes rather than on every intermediate
+               // WM_WINDOWPOSCHANGED. (Close also saves via WM_DESTROY.)
                saveSettings();
 
                return 0;
@@ -1092,10 +1122,10 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin)
 
       if (plugin.gui->can_resize(plugin.plugin))
       {
-        // We can restore size here
-        // setWindowPosition(m_window.hwnd.get(), previousWidth, previousHeight);
-        // log("x: {} y: {}", sah->position.x, sah->position.y);
-        if (position.width != 0 || position.height != 0)
+        // Only restore a saved position if it still lands on a connected monitor. Guards
+        // against off-screen/garbage values (e.g. a minimized window's -32000 sentinel
+        // persisted by an older build, or a monitor that's no longer attached).
+        if ((position.width != 0 || position.height != 0) && isRectOnAnyMonitor(position))
         {
           setPosition(position);
         }
@@ -1129,7 +1159,8 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin)
 
   sah->onRequestResize = [this](uint32_t width, uint32_t height)
   {
-    if (placement.showCmd != SW_MAXIMIZE)
+    if (placement.showCmd != SW_MAXIMIZE && placement.showCmd != SW_SHOWMINIMIZED &&
+        !::IsIconic(hwnd.get()))
     {
       adjustSize(width, height);
     }
@@ -1159,7 +1190,9 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin)
 
   startAudio();
 
-  activate();
+  // Honor the show state requested by the launcher (shortcut "Run:" / STARTUPINFO),
+  // falling back to a normal window. SW_HIDE would otherwise leave us invisible-but-running.
+  ::ShowWindow(hwnd.get(), nCmdShow == SW_HIDE ? SW_SHOWNORMAL : nCmdShow);
 }
 
 std::optional<clap_gui_resize_hints> Plugin::getResizeHints()

--- a/src/detail/standalone/windows/windows_standalone.h
+++ b/src/detail/standalone/windows/windows_standalone.h
@@ -129,11 +129,24 @@ struct MessageHandler
 
 struct Position
 {
-  uint32_t x{0};
-  uint32_t y{0};
+  int32_t x{0};
+  int32_t y{0};
   uint32_t width{0};
   uint32_t height{0};
 };
+
+// Clamp a JSON-sourced double into int32 range before narrowing. Avoids UB when a
+// corrupt/out-of-range coordinate (e.g. a minimized window's -32000 sentinel that an
+// older build persisted as a huge unsigned value) is read back.
+inline int32_t jsonNumberToInt32(double value)
+{
+  if (value >= 2147483647.0) return 2147483647;
+  if (value <= -2147483648.0) return -2147483648;
+  return static_cast<int32_t>(value);
+}
+
+// True when the rectangle intersects a connected display.
+bool isRectOnAnyMonitor(const Position &position);
 
 struct Window
 {
@@ -336,8 +349,8 @@ struct Plugin final : public Window
           auto parsedPos{value.GetObject()};
 
           Position buffer;
-          buffer.x = static_cast<uint32_t>(parsedPos.GetNamedNumber(L"x"));
-          buffer.y = static_cast<uint32_t>(parsedPos.GetNamedNumber(L"y"));
+          buffer.x = jsonNumberToInt32(parsedPos.GetNamedNumber(L"x"));
+          buffer.y = jsonNumberToInt32(parsedPos.GetNamedNumber(L"y"));
           buffer.width = static_cast<uint32_t>(parsedPos.GetNamedNumber(L"width"));
           buffer.height = static_cast<uint32_t>(parsedPos.GetNamedNumber(L"height"));
 
@@ -368,7 +381,7 @@ struct Plugin final : public Window
     const clap_plugin_state_t *state;
   };
 
-  explicit Plugin(std::shared_ptr<Clap::Plugin> clapPlugin);
+  explicit Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow = SW_SHOWDEFAULT);
 
   std::optional<clap_gui_resize_hints> getResizeHints();
   void refreshLayout();

--- a/src/wrapasstandalone_windows.cpp
+++ b/src/wrapasstandalone_windows.cpp
@@ -1,7 +1,7 @@
 #include "detail/standalone/windows/windows_standalone.h"
 
 int WINAPI wWinMain(HINSTANCE /* hInstance */, HINSTANCE /* hPrevInstance */, PWSTR /* pCmdLine */,
-                    int /* nCmdShow */)
+                    int nCmdShow)
 {
   auto coUninitialize{wil::CoInitializeEx(COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)};
 
@@ -46,7 +46,7 @@ int WINAPI wWinMain(HINSTANCE /* hInstance */, HINSTANCE /* hPrevInstance */, PW
   auto clapPlugin{freeaudio::clap_wrapper::standalone::mainCreatePlugin(
       entry, PLUGIN_ID, PLUGIN_INDEX, static_cast<int>(argv.size()), argv.data())};
 
-  freeaudio::clap_wrapper::standalone::windows_standalone::Plugin plugin{clapPlugin};
+  freeaudio::clap_wrapper::standalone::windows_standalone::Plugin plugin{clapPlugin, nCmdShow};
 
   return freeaudio::clap_wrapper::standalone::windows_standalone::run();
 }


### PR DESCRIPTION
Restore a saved window position only when it still lands on a connected monitor, so a stale off-screen value no longer brings the app up invisible in the taskbar. Store window coordinates as signed values and only remember the restored (non-minimized, non-maximized) geometry, so a minimized window's sentinel position is never persisted as the next launch position.

Stop resizing the editor while the window is minimized, which drove size-dependent drawing to zero dimensions and crashed.

Persist window settings when a move/resize finishes rather than on every position change, and honor the launcher's requested window state instead of always opening as a normal window.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>