### PR TITLE
C1ST_BUNDLE_IDENTIFER -> C1ST_BUNDLE_IDENTIFIER

### DIFF
--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -233,7 +233,7 @@ function(make_clapfirst_plugins)
         endif()
         target_add_aax_wrapper(TARGET ${AAX_TARGET}
                 OUTPUT_NAME "${C1ST_OUTPUT_NAME}"
-                BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFER}.aaxplugin"
+                BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFIER}.aaxplugin"
                 BUNDLE_VERSION "${C1ST_BUNDLE_VERSION}"
                 ASSET_OUTPUT_DIRECTORY "${vod}"
                 

--- a/tests/clap-first-example/CMakeLists.txt
+++ b/tests/clap-first-example/CMakeLists.txt
@@ -28,7 +28,7 @@ make_clapfirst_plugins(
 
         ENTRY_SOURCE "distortion_clap_entry.cpp"
 
-        BUNDLE_IDENTIFER "org.free-audio.clap-first-bad-distortion"
+        BUNDLE_IDENTIFIER "org.free-audio.clap-first-bad-distortion"
         BUNDLE_VERSION ${PROJECT_VERSION}
 
         COPY_AFTER_BUILD FALSE


### PR DESCRIPTION
Fix remaining C1ST_BUNDLE_IDENTIFIER errors in cmake scripts