### PR TITLE
fixed double fixed COM fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ option(CLAP_WRAPPER_BUILD_TESTS "Build test CLAP wrappers" OFF)
 
 project(clap-wrapper
 	LANGUAGES C CXX
-	VERSION 0.15.0
+	VERSION 0.15.1
 	DESCRIPTION "CLAP-as-X wrappers"
 )
 set(CLAP_WRAPPER_VERSION "${PROJECT_VERSION}" CACHE STRING "Version of the wrapper project")

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -332,16 +332,6 @@ IPluginFactory *GetPluginFactoryEntryPoint()
       memcpy(&lcid, &g, sizeof(TUID));
       makeCIDComCompatible(lcid);
 
-#if !COM_COMPATIBLE
-      // apply the same COM-compatibility flip as for the plugin CID above,
-      // so the compatibility class CID is identical across platforms
-      std::swap(lcid[0], lcid[3]);
-      std::swap(lcid[1], lcid[2]);
-
-      std::swap(lcid[4], lcid[5]);
-      std::swap(lcid[6], lcid[7]);
-#endif
-
       auto ptr = std::make_shared<CreationContext>();
       *ptr = {&gClapLibrary, 0,
               PClassInfo2(lcid, PClassInfo::kManyInstances, kPluginCompatibilityClass, "Compatibility",


### PR DESCRIPTION
the refactor left a duplicate byte-flip that cancelled the fix, that needed to be removed.