### PR TITLE
fixing two bugs in parameters and bypass on AUv2

### DIFF
--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -520,9 +520,9 @@ class WrapAsAUV2 : public ausdk::AUBase,
   void deactivateCLAP();
   bool IsBypassEffect()
   {
-    return false;
+    return _isBypassed;
   }
-  void SetBypassEffect(bool bypass) {};
+  void SetBypassEffect(bool bypass);
 
   // --------------- internals
 
@@ -553,6 +553,10 @@ class WrapAsAUV2 : public ausdk::AUBase,
   std::vector<AudioUnitParameterID> _orderedParameterList;
   bool _paramOrderingProvided{false};
   Clumps _clumps;
+
+  // the CLAP parameter flagged CLAP_PARAM_IS_BYPASS, driven by kAudioUnitProperty_BypassEffect
+  clap_id _bypassParamID = CLAP_INVALID_ID;
+  bool _isBypassed = false;
 
   CFStringRef _current_program_name = 0;
 

--- a/src/detail/auv2/parameter.cpp
+++ b/src/detail/auv2/parameter.cpp
@@ -33,12 +33,15 @@ void Parameter::updateInfo(const clap_plugin_t *plugin, const clap_plugin_params
     else
       flags |= kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_IsWritable;
   }
+  // the unit is a value, not a bitfield, and must not be mixed into the flags
+  _unit = kAudioUnitParameterUnit_Generic;
   if (info.flags & CLAP_PARAM_IS_STEPPED)
   {
-    if (info.max_value == 1 && info.min_value == 0)
-      flags |= kAudioUnitParameterUnit_Boolean;
+    // an enum always has named values, so report it as Indexed even for a two-value range
+    if (info.max_value == 1 && info.min_value == 0 && !(info.flags & CLAP_PARAM_IS_ENUM))
+      _unit = kAudioUnitParameterUnit_Boolean;
     else
-      flags |= kAudioUnitParameterUnit_Indexed;
+      _unit = kAudioUnitParameterUnit_Indexed;
   }
 
   // we need this, otherwise hosts may quantize the parameter to 100 steps

--- a/src/detail/auv2/parameter.h
+++ b/src/detail/auv2/parameter.h
@@ -49,6 +49,10 @@ class Parameter
   {
     return _flags;
   }
+  AudioUnitParameterUnit AudioUnitUnit() const
+  {
+    return _unit;
+  }
 
   void updateInfo(const clap_plugin_t *plugin, const clap_plugin_params_t *clap_param_ext,
                   const clap_param_info_t &i);
@@ -57,6 +61,7 @@ class Parameter
   clap_param_info_t _info;
   CFStringRef _cfstring = nullptr;
   AudioUnitParameterOptions _flags;
+  AudioUnitParameterUnit _unit = kAudioUnitParameterUnit_Generic;
 };
 
 }  // namespace Clap::AUv2

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -351,6 +351,7 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
   _clumps.reset();
   _orderedParameterList.clear();
   _paramOrderingProvided = false;
+  _bypassParamID = CLAP_INVALID_ID;
   auto *p = _plugin->_ext._params;
   if (p)
   {
@@ -426,6 +427,11 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
           else
           {
             piter->second->updateInfo(_plugin->_plugin, p, paraminfo);
+          }
+          if (paraminfo.flags & CLAP_PARAM_IS_BYPASS)
+          {
+            _bypassParamID = paraminfo.id;
+            _isBypassed = (result >= 0.5 * (paraminfo.min_value + paraminfo.max_value));
           }
           Globals()->SetParameter(paraminfo.id, result);
           _orderedParameterList.push_back(static_cast<AudioUnitParameterID>(paraminfo.id));
@@ -517,6 +523,7 @@ OSStatus WrapAsAUV2::GetParameterInfo(AudioUnitScope inScope, AudioUnitParameter
       const auto &info = f->info();
 
       outParameterInfo.flags = f->AudioUnitFlags();
+      outParameterInfo.unit = f->AudioUnitUnit();
 
       // according to the documentation, the name field should be zeroed. In fact, AULab does display anything then.
       // strcpy(outParameterInfo.name, info.name);
@@ -559,6 +566,21 @@ OSStatus WrapAsAUV2::SetParameter(AudioUnitParameterID inID, AudioUnitScope inSc
     }
   }
   return AUBase::SetParameter(inID, inScope, inElement, inValue, inBufferOffsetInFrames);
+}
+
+void WrapAsAUV2::SetBypassEffect(bool bypass)
+{
+  _isBypassed = bypass;
+  if (_bypassParamID != CLAP_INVALID_ID)
+  {
+    auto p = _parametertree.find(_bypassParamID);
+    if (p != _parametertree.end())
+    {
+      const auto &info = p->second->info();
+      SetParameter(_bypassParamID, kAudioUnitScope_Global, 0,
+                   bypass ? info.max_value : info.min_value, 0);
+    }
+  }
 }
 
 OSStatus WrapAsAUV2::CopyClumpName(AudioUnitScope inScope, UInt32 inClumpID, UInt32 inDesiredNameLength,
@@ -1172,6 +1194,21 @@ void WrapAsAUV2::onIdle()
       case queueEvent::type::editvalue:
       {
         Globals()->SetParameter(e._data._id, e._data._value.value);
+        if (e._data._id == _bypassParamID)
+        {
+          auto p = _parametertree.find(_bypassParamID);
+          if (p != _parametertree.end())
+          {
+            const auto &info = p->second->info();
+            const bool bypassed =
+                (e._data._value.value >= 0.5 * (info.min_value + info.max_value));
+            if (bypassed != _isBypassed)
+            {
+              _isBypassed = bypassed;
+              PropertyChanged(kAudioUnitProperty_BypassEffect, kAudioUnitScope_Global, 0);
+            }
+          }
+        }
         AudioUnitEvent myEvent;
         myEvent.mEventType = kAudioUnitEvent_ParameterValueChange;
         myEvent.mArgument.mParameter.mAudioUnit = GetComponentInstance();

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -577,8 +577,8 @@ void WrapAsAUV2::SetBypassEffect(bool bypass)
     if (p != _parametertree.end())
     {
       const auto &info = p->second->info();
-      SetParameter(_bypassParamID, kAudioUnitScope_Global, 0,
-                   bypass ? info.max_value : info.min_value, 0);
+      SetParameter(_bypassParamID, kAudioUnitScope_Global, 0, bypass ? info.max_value : info.min_value,
+                   0);
     }
   }
 }
@@ -1200,8 +1200,7 @@ void WrapAsAUV2::onIdle()
           if (p != _parametertree.end())
           {
             const auto &info = p->second->info();
-            const bool bypassed =
-                (e._data._value.value >= 0.5 * (info.min_value + info.max_value));
+            const bool bypassed = (e._data._value.value >= 0.5 * (info.min_value + info.max_value));
             if (bypassed != _isBypassed)
             {
               _isBypassed = bypassed;


### PR DESCRIPTION
- Fix AUv2 parameter unit reporting and wire up bypass to the CLAP bypass param

- Stepped/enum params now set AudioUnitParameterInfo.unit (Boolean/Indexed) instead of corrupting the flags bitfield, and kAudioUnitProperty_BypassEffect now drives (and follows) the plugin's CLAP_PARAM_IS_BYPASS parameter.