### PR TITLE
macOS: attach the onIdle timer to the main run loop (headless parameter flushes)

### DIFF
--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -80,7 +80,13 @@ void MacOSHelper::attach(IPlugObject *plugobject)
     _timer =
         CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + (kIntervall * 0.001f),
                              kIntervall * 0.001f, 0, 0, timerCallback, &context);
-    if (_timer) CFRunLoopAddTimer(CFRunLoopGetCurrent(), _timer, kCFRunLoopCommonModes);
+    // Attach the timer to the MAIN run loop, not the current thread's: hosts
+    // may call attach() from a worker thread (e.g. Ableton Live while loading
+    // a saved set with the editor never opened). A worker thread's run loop
+    // never runs, so onIdle -- which drives host-side parameter flushes, CLAP
+    // on_main_thread callbacks and timers -- would never fire until a GUI
+    // woke the main thread. The main run loop of a UI host always runs.
+    if (_timer) CFRunLoopAddTimer(CFRunLoopGetMain(), _timer, kCFRunLoopCommonModes);
   }
   _plugs.push_back(plugobject);
 }


### PR DESCRIPTION
## Problem

`MacOSHelper::attach()` creates its `CFRunLoopTimer` on the **current thread's** run loop. Hosts may call `attach()` from a worker thread — Ableton Live does when restoring a saved set while the plugin editor has never been opened. A worker thread's run loop never runs, so `onIdle` (which services host-side parameter flushes, clap `on_main_thread` callbacks and timers) never fires.

**Symptom:** plugins restored from a saved Live set stay silent / mis-parameterized until their editor is opened once — the host's parameter layer keeps its instantiation defaults and writes them back into the plugin during the first `process()` blocks; opening the editor wakes the main thread and the deferred flush finally runs. Related to the state-restore family of issues (#475, #303).

## Fix

Attach the timer to `CFRunLoopGetMain()`: the main run loop of a UI host always runs, editor or not. `CFRunLoopTimerInvalidate` in `detach()` is loop-independent, so the removal path is unchanged.

## Verification

- Ableton Live (macOS, Apple Silicon): saved set with never-opened editors now restores and plays correctly headless; before this patch the same set was silent until the editor was opened.
- pluginval (VST3, strictness 8) and auval (aumu + aumf) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)