### PR TITLE
AUv2: full MIDI 1.0 + MIDI 2.0 (UMP) in/out, plus minor fixes

### DIFF
--- a/.github/workflows/pullreq.yml
+++ b/.github/workflows/pullreq.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build project
         run: |
-          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCLAP_SDK_ROOT=deps/clap -DVST3_SDK_ROOT=deps/vst3sdk -DAAX_SDK_ROOT=deps/aax -DCLAP_WRAPPER_OUTPUT_NAME=testplug
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCLAP_SDK_ROOT=deps/clap -DVST3_SDK_ROOT=deps/vst3sdk -DAAX_SDK_ROOT=deps/aax -DCLAP_WRAPPER_BUILD_AAX=TRUE -DCLAP_WRAPPER_OUTPUT_NAME=testplug
           cmake --build ./build --config Debug
 
       - name: Show Build Results

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@
 # CLAP_WRAPPER_BUILD_AUV2        Build the AUv2 wrapper (.component); requires the AudioUnitSDK
 # CLAP_WRAPPER_BUILD_AUV3        Build the AUv3 app extension (.appex) plus its standalone
 #                                host app; requires the Xcode generator (-G Xcode)
+# CLAP_WRAPPER_BUILD_AAX         Build the AAX wrapper; only effective where AAX is supported
+#                                (macOS and non-ARM MSVC Windows, never Linux) and requires
+#                                the AAX SDK
 # CLAP_WRAPPER_BUILD_STANDALONE  Build a simple standalone executable hosting the CLAP
 # CLAP_WRAPPER_BUILD_TESTS       Build the test CLAP wrappers
 #

--- a/cmake/top_level_default.cmake
+++ b/cmake/top_level_default.cmake
@@ -9,8 +9,12 @@ if (PROJECT_IS_TOP_LEVEL)
 	string(MAKE_C_IDENTIFIER ${CLAP_WRAPPER_OUTPUT_NAME} pluginname)
 
 
-	if (CLAP_WRAPPER_CAN_BUILD_AAX)
-		    # Link the actual plugin library
+	# AAX is opt-in like AUv2/AUv3, and only available where the platform/toolchain
+	# supports it (macOS and non-ARM MSVC Windows, never Linux). Requiring both the
+	# opt-in and the capability avoids fetching the AAX SDK when it was not asked for.
+	if (CLAP_WRAPPER_BUILD_AAX)
+		if (CLAP_WRAPPER_CAN_BUILD_AAX)
+			# Link the actual plugin library
 			add_library(${pluginname}_as_aax MODULE)
 			target_add_aax_wrapper(
 					TARGET ${pluginname}_as_aax
@@ -18,6 +22,10 @@ if (PROJECT_IS_TOP_LEVEL)
 					BUNDLE_IDENTIFIER "${CLAP_WRAPPER_BUNDLE_IDENTIFIER}"
 					BUNDLE_VERSION "${CLAP_WRAPPER_BUNDLE_VERSION}"
 			)
+		else()
+			message(WARNING "clap-wrapper: CLAP_WRAPPER_BUILD_AAX was requested but AAX is not "
+					"supported on this platform/toolchain - skipping the AAX wrapper")
+		endif()
 	endif()
 
 	# Link the actual plugin library

--- a/src/detail/aax/audioconfig.cpp
+++ b/src/detail/aax/audioconfig.cpp
@@ -345,7 +345,14 @@ plugin_bus_info_t getAvailableBusConfigs(Clap::Library *factory, uint32_t index)
                 break;
             }
           }
-          result.stemformats.push_back({f, informat, outformat});
+          // Only record a stem format when the plugin actually has audio ports.
+          // A note-only plugin (0 in / 0 out) must leave stemformats empty so the
+          // placeholder-stem path below can give it a Mono/Stereo passthrough
+          // component; otherwise it would describe a bogus 0-channel component.
+          if (numinputs > 0 || numoutputs > 0)
+          {
+            result.stemformats.push_back({f, informat, outformat});
+          }
         }
       }
       else
@@ -384,6 +391,18 @@ plugin_bus_info_t getAvailableBusConfigs(Clap::Library *factory, uint32_t index)
             }
           }
         }
+      }
+
+      // Pure-MIDI plugin (no audio ports) with MIDI: Pro Tools MIDI-effect
+      // plugins are audio components that pass audio through (see the AAX SDK's
+      // DemoMIDI_Transpose). Offer placeholder Mono and Stereo stems so the
+      // effect can be inserted on mono/stereo Instrument tracks; the wrapper
+      // passes the AAX audio through untouched at process time (the CLAP itself
+      // sees no audio ports).
+      if (result.stemformats.empty() && (result.has_midi_in || result.has_midi_out))
+      {
+        result.stemformats.push_back({"Mono", AAX_eStemFormat_Mono, AAX_eStemFormat_Mono});
+        result.stemformats.push_back({"Stereo", AAX_eStemFormat_Stereo, AAX_eStemFormat_Stereo});
       }
 
 #if (CLAP_WRAPPER_LOGLEVEL == 2)

--- a/src/detail/aax/process.cpp
+++ b/src/detail/aax/process.cpp
@@ -7,6 +7,7 @@
 #include "../shared/midi_translation.h"
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
 namespace
 {
@@ -97,7 +98,8 @@ void AAXProcessAdapter::setupProcessing(const clap_plugin_t *plugin, double samp
                                         const clap_plugin_audio_ports *ext_audio,
                                         Clap::IAutomation *automation,
                                         std::vector<clap_id> &gesturedparameters,
-                                        ParamChangeQueue &inqueue, uint32_t midiportid, bool preferMIDI)
+                                        ParamChangeQueue &inqueue, uint32_t midiportid, bool preferMIDI,
+                                        uint32_t placeholderInChannels, uint32_t placeholderOutChannels)
 {
   _plugin = plugin;
   _ext_param = ext_param;
@@ -107,6 +109,9 @@ void AAXProcessAdapter::setupProcessing(const clap_plugin_t *plugin, double samp
 
   _midi_first_portid = midiportid;
   _midi_prefer_mididialect = preferMIDI;
+
+  _placeholderInChannels = placeholderInChannels;
+  _placeholderOutChannels = placeholderOutChannels;
 
   // other needed references like buffers, MIDINodes etc. are passed
   // via the SAAX_Wrapper_AlgorithmicContext to the process function
@@ -384,6 +389,25 @@ void AAXProcessAdapter::process(SAAX_Wrapper_AlgorithmicContext *context)
       // until the next event or variation in audio input.
     case CLAP_PROCESS_SLEEP:
       break;
+  }
+
+  // Placeholder-stem passthrough: for a pure-MIDI CLAP the component still
+  // carries an AAX audio bus but the CLAP has no audio ports, so it never wrote
+  // the output. Copy the AAX input straight to the output (silence if there is
+  // no matching input channel) so the MIDI-effect insert is audio-transparent,
+  // matching the AAX SDK's DemoMIDI_Transpose.
+  if (_placeholderOutChannels > 0)
+  {
+    const int32_t numSamples = *(context->mNumSamples);
+    for (uint32_t ch = 0; ch < _placeholderOutChannels; ++ch)
+    {
+      float *out = context->mAudioOutputs ? context->mAudioOutputs[ch] : nullptr;
+      if (!out) continue;
+      if (ch < _placeholderInChannels && context->mAudioInputs && context->mAudioInputs[ch])
+        memcpy(out, context->mAudioInputs[ch], sizeof(float) * (size_t)numSamples);
+      else
+        memset(out, 0, sizeof(float) * (size_t)numSamples);
+    }
   }
 
   // Outgoing MIDI was already posted to _outputNode from enqueueOutputEvent()

--- a/src/detail/aax/process.cpp
+++ b/src/detail/aax/process.cpp
@@ -4,6 +4,43 @@
 
 #include "AAX_MIDIUtilities.h"
 
+#include "../shared/midi_translation.h"
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+// MIDI 1.0 channel-voice message length from the status byte: program change
+// (0xC0) and channel pressure (0xD0) are 2 bytes, everything else 3.
+uint32_t midi1CVLength(uint8_t status)
+{
+  const uint8_t hi = status & 0xF0;
+  return (hi == 0xC0 || hi == 0xD0) ? 2 : 3;
+}
+
+// Pro Tools only routes a fixed set of channel-voice messages out of a plug-in
+// (per AAX_IMIDINode::PostMIDIPacket docs): note on/off, poly & channel pressure,
+// pitch bend, program change, and bank-select (controller #0). Everything else
+// (other CCs, system messages, realtime) is dropped before it reaches the node.
+bool proToolsAcceptsMidi1(uint8_t status, uint8_t data1)
+{
+  switch (status & 0xF0)
+  {
+    case 0x80:  // note off
+    case 0x90:  // note on
+    case 0xA0:  // poly key pressure
+    case 0xC0:  // program change (no bank)
+    case 0xD0:  // channel pressure
+    case 0xE0:  // pitch bend
+      return true;
+    case 0xB0:  // control change: PT only accepts bank select (CC #0)
+      return data1 == 0;
+    default:
+      return false;
+  }
+}
+}  // namespace
+
 void AAX_CALLBACK AAXWrapper_AlgorithmProcessProc(
     SAAX_Wrapper_AlgorithmicContext *const inInstancesBegin[], const void *inInstancesEnd)
 {
@@ -156,6 +193,11 @@ void AAXProcessAdapter::process(SAAX_Wrapper_AlgorithmicContext *context)
 {
   // transport
   auto aax_transport = context->mTransportNode->GetTransport();
+
+  // capture the MIDI output node for this cycle. enqueueOutputEvent() posts to
+  // it directly while the plugin is inside _plugin->process() (the CLAP event
+  // buffers are only guaranteed valid during that call). Reset afterwards.
+  _outputNode = context->mOutputNode;
 
   // this clears the vectors (which do not resize to smaller)
   this->_events.clear();
@@ -344,12 +386,9 @@ void AAXProcessAdapter::process(SAAX_Wrapper_AlgorithmicContext *context)
       break;
   }
 
-  // no support for outgoing MIDI at this time
-  //if (context->mOutputNode)
-  //{
-  //  auto midiOutputStream = context->mOutputNode->GetNodeBuffer();
-  //  // do MIDI out
-  //}
+  // Outgoing MIDI was already posted to _outputNode from enqueueOutputEvent()
+  // during _plugin->process(). Drop the node so it can never be used stale.
+  _outputNode = nullptr;
 }
 
 void AAXProcessAdapter::flush()
@@ -389,41 +428,18 @@ bool AAXProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
   {
     case CLAP_EVENT_NOTE_ON:
     {
-      // auto nevt = reinterpret_cast<const clap_event_note*>(event);
-
-      /*
-      Steinberg::Vst::Event oe{};
-      oe.type = Steinberg::Vst::Event::kNoteOnEvent;
-      oe.noteOn.channel = nevt->channel;
-      oe.noteOn.pitch = nevt->key;
-      oe.noteOn.velocity = nevt->velocity;
-      oe.noteOn.length = 0;
-      oe.noteOn.tuning = 0.0f;
-      oe.noteOn.noteId = nevt->note_id;
-      oe.busIndex = 0;  // FIXME - multi-out midi still needs work
-      oe.sampleOffset = nevt->header.time;
-
-      if (_vstdata && _vstdata->outputEvents) _vstdata->outputEvents->addEvent(oe);
-      */
+      auto nevt = reinterpret_cast<const clap_event_note *>(event);
+      uint8_t bytes[3] = {(uint8_t)(0x90 | (nevt->channel & 0x0F)), (uint8_t)(nevt->key & 0x7F),
+                          (uint8_t)(std::lround(nevt->velocity * 127.0) & 0x7F)};
+      postMIDI1(nevt->header.time, bytes, 3);
     }
       return true;
     case CLAP_EVENT_NOTE_OFF:
     {
-      // auto nevt = reinterpret_cast<const clap_event_note*>(event);
-      /*
-      Steinberg::Vst::Event oe{};
-      oe.type = Steinberg::Vst::Event::kNoteOffEvent;
-      oe.noteOff.channel = nevt->channel;
-      oe.noteOff.pitch = nevt->key;
-      oe.noteOff.velocity = nevt->velocity;
-      oe.noteOn.length = 0;
-      oe.noteOff.tuning = 0.0f;
-      oe.noteOff.noteId = nevt->note_id;
-      oe.busIndex = 0;  // FIXME - multi-out midi still needs work
-      oe.sampleOffset = nevt->header.time;
-
-      if (_vstdata && _vstdata->outputEvents) _vstdata->outputEvents->addEvent(oe);
-      */
+      auto nevt = reinterpret_cast<const clap_event_note *>(event);
+      uint8_t bytes[3] = {(uint8_t)(0x80 | (nevt->channel & 0x0F)), (uint8_t)(nevt->key & 0x7F),
+                          (uint8_t)(std::lround(nevt->velocity * 127.0) & 0x7F)};
+      postMIDI1(nevt->header.time, bytes, 3);
     }
       return true;
     case CLAP_EVENT_NOTE_END:
@@ -462,8 +478,42 @@ bool AAXProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
       break;
 
     case CLAP_EVENT_MIDI:
+    {
+      auto mevt = reinterpret_cast<const clap_event_midi *>(event);
+      postMIDI1(mevt->header.time, mevt->data, midi1CVLength(mevt->data[0]));
+    }
+      return true;
+      break;
     case CLAP_EVENT_MIDI_SYSEX:
+    {
+      auto sevt = reinterpret_cast<const clap_event_midi_sysex *>(event);
+      postSysEx(sevt->header.time, sevt->buffer, sevt->size);
+    }
+      return true;
+      break;
     case CLAP_EVENT_MIDI2:
+    {
+      // AAX is a MIDI 1.0 wire, so down-convert. Only channel-voice UMP
+      // messages have a MIDI 1.0 equivalent: MT 0x4 (MIDI 2.0 CV) via the
+      // shared kernel, MT 0x2 (a MIDI 1.0 CV already wrapped in a UMP) by
+      // unpacking the three bytes. SysEx7 (MT 0x3) and utility messages are
+      // dropped (Pro Tools would not route them anyway).
+      auto m2evt = reinterpret_cast<const clap_event_midi2 *>(event);
+      const uint32_t messageType = (m2evt->data[0] >> 28) & 0xFu;
+      if (messageType == 0x4u)
+      {
+        uint8_t out[3];
+        int n = ClapWrapper::detail::shared::midi2ChannelVoiceToMidi1(m2evt->data, out);
+        if (n > 0) postMIDI1(m2evt->header.time, out, (uint32_t)n);
+      }
+      else if (messageType == 0x2u)
+      {
+        const uint8_t status = (uint8_t)((m2evt->data[0] >> 16) & 0xFFu);
+        uint8_t out[3] = {status, (uint8_t)((m2evt->data[0] >> 8) & 0xFFu),
+                          (uint8_t)(m2evt->data[0] & 0xFFu)};
+        postMIDI1(m2evt->header.time, out, midi1CVLength(status));
+      }
+    }
       return true;
       break;
     default:
@@ -498,6 +548,45 @@ void AAXProcessAdapter::removeFromActiveNotes(const clap_event_note *note)
     {
       i.used = false;
     }
+  }
+}
+
+void AAXProcessAdapter::postMIDI1(uint32_t timestamp, const uint8_t *bytes, uint32_t length)
+{
+  // No output node when the plugin declares no MIDI out (the descriptor
+  // installs a private-data placeholder instead) or outside a process() call.
+  if (!_outputNode || length == 0) return;
+  if (length > 4) length = 4;  // AAX_CMidiPacket carries at most 4 bytes
+
+  // Drop anything Pro Tools won't route out of a plug-in.
+  if (!proToolsAcceptsMidi1(bytes[0], length > 1 ? bytes[1] : 0)) return;
+
+  AAX_CMidiPacket packet;
+  packet.mTimestamp = timestamp;
+  packet.mLength = length;
+  packet.mIsImmediate = false;
+  for (uint32_t i = 0; i < 4; ++i) packet.mData[i] = (i < length) ? bytes[i] : 0;
+
+  _outputNode->PostMIDIPacket(&packet);
+}
+
+void AAXProcessAdapter::postSysEx(uint32_t timestamp, const uint8_t *data, uint32_t size)
+{
+  // AAX carries SysEx as a series of AAX_CMidiPackets of up to 4 bytes each,
+  // sharing one timestamp; the host reassembles them. The 0xF0/0xF7 framing is
+  // kept intact. Note: Pro Tools does not list SysEx among the MIDI messages it
+  // routes out of a plug-in, so this is best-effort for hosts that do.
+  if (!_outputNode || !data || size == 0) return;
+
+  for (uint32_t offset = 0; offset < size; offset += 4)
+  {
+    const uint32_t chunk = std::min<uint32_t>(4, size - offset);
+    AAX_CMidiPacket packet;
+    packet.mTimestamp = timestamp;
+    packet.mLength = chunk;
+    packet.mIsImmediate = false;
+    for (uint32_t i = 0; i < 4; ++i) packet.mData[i] = (i < chunk) ? data[offset + i] : 0;
+    _outputNode->PostMIDIPacket(&packet);
   }
 }
 

--- a/src/detail/aax/wrapper.cpp
+++ b/src/detail/aax/wrapper.cpp
@@ -1222,10 +1222,28 @@ void ClapAsAAX::activatePlugin()
   {
     _gesturedparameters.reserve(8192);
 
+    // For a pure-MIDI CLAP (no audio ports) the AAX component still carries a
+    // placeholder Mono/Stereo audio bus (see getAvailableBusConfigs); capture
+    // its channel counts from the negotiated stem format so the process adapter
+    // can pass that audio through. Zero for normal audio plugins.
+    uint32_t placeholderInChannels = 0, placeholderOutChannels = 0;
+    auto ext_audio = _plugin->_ext._audioports;
+    uint32_t clapInPorts = ext_audio ? ext_audio->count(_plugin->_plugin, true) : 0;
+    uint32_t clapOutPorts = ext_audio ? ext_audio->count(_plugin->_plugin, false) : 0;
+    if (clapInPorts == 0 && clapOutPorts == 0 && _aax_ctrl)
+    {
+      AAX_EStemFormat stem_in = AAX_eStemFormat_None, stem_out = AAX_eStemFormat_None;
+      _aax_ctrl->GetInputStemFormat(&stem_in);
+      _aax_ctrl->GetOutputStemFormat(&stem_out);
+      placeholderInChannels = (uint32_t)AAX_STEM_FORMAT_CHANNEL_COUNT(stem_in);
+      placeholderOutChannels = (uint32_t)AAX_STEM_FORMAT_CHANNEL_COUNT(stem_out);
+    }
+
     _processAdapter = std::make_unique<AAXProcessAdapter>();
     _processAdapter->setupProcessing(_plugin->_plugin, _plugin->getSampleRate(), _plugin->_ext._params,
                                      _plugin->_ext._audioports, this, _gesturedparameters,
-                                     _paramsToProcess, _midi_first_portid, _midi_prefer_mididialect);
+                                     _paramsToProcess, _midi_first_portid, _midi_prefer_mididialect,
+                                     placeholderInChannels, placeholderOutChannels);
 
     _activated = true;
     _plugin->activate();

--- a/src/detail/aax/wrapper.cpp
+++ b/src/detail/aax/wrapper.cpp
@@ -161,6 +161,7 @@ static void DescribeAlgorithmComponent(AAX_IComponentDescriptor *outDesc,
   // Register MIDI nodes. To avoid context corruption, register small blocks of private data for fields where a node is not needed
   AAX_CFieldIndex globalNodeID = AAX_FIELD_INDEX(SAAX_Wrapper_AlgorithmicContext, mGlobalNode);
   AAX_CFieldIndex localInputNodeID = AAX_FIELD_INDEX(SAAX_Wrapper_AlgorithmicContext, mInputNode);
+  AAX_CFieldIndex localOutputNodeID = AAX_FIELD_INDEX(SAAX_Wrapper_AlgorithmicContext, mOutputNode);
   AAX_CFieldIndex transportNodeID = AAX_FIELD_INDEX(SAAX_Wrapper_AlgorithmicContext, mTransportNode);
 
   // Global MIDI node — not currently used
@@ -186,11 +187,16 @@ static void DescribeAlgorithmComponent(AAX_IComponentDescriptor *outDesc,
   if (businfo.has_midi_out)
   {
     if (aax_plugin_info && aax_plugin_info->midi_out_name)
-      err = outDesc->AddMIDINode(localInputNodeID, AAX_eMIDINodeType_LocalOutput,
+      err = outDesc->AddMIDINode(localOutputNodeID, AAX_eMIDINodeType_LocalOutput,
                                  aax_plugin_info->midi_out_name, aax_plugin_info->midi_out_channel_mask);
     else
-      err = outDesc->AddMIDINode(localInputNodeID, AAX_eMIDINodeType_LocalOutput,
+      err = outDesc->AddMIDINode(localOutputNodeID, AAX_eMIDINodeType_LocalOutput,
                                  businfo.midi_out_name.c_str(), 0xFFFF);
+  }
+  else
+  {
+    err = outDesc->AddPrivateData(localOutputNodeID, sizeof(float),
+                                  AAX_ePrivateDataOptions_DefaultOptions);
   }
 
   if (true)  // setupInfo.mNeedsTransport)

--- a/src/detail/aax/wrapper.h
+++ b/src/detail/aax/wrapper.h
@@ -82,7 +82,8 @@ class AAXProcessAdapter
   void setupProcessing(const clap_plugin_t *plugin, double samplerate,
                        const clap_plugin_params_t *ext_param, const clap_plugin_audio_ports *ext_audio,
                        Clap::IAutomation *automation, std::vector<clap_id> &gesturedParameters,
-                       ParamChangeQueue &inqueue, uint32_t midiportid, bool preferMIDI);
+                       ParamChangeQueue &inqueue, uint32_t midiportid, bool preferMIDI,
+                       uint32_t placeholderInChannels, uint32_t placeholderOutChannels);
   void process(SAAX_Wrapper_AlgorithmicContext *context);
   void flush();
 
@@ -155,6 +156,14 @@ class AAXProcessAdapter
   // AAX algorithm context. Only valid for the duration of process(); reset to
   // nullptr afterwards so a stale node can never be posted to.
   AAX_IMIDINode *_outputNode = nullptr;
+
+  // Placeholder-stem passthrough: a pure-MIDI CLAP (no audio ports) is wrapped
+  // as an AAX MIDI-effect component that still carries a Mono/Stereo audio bus.
+  // When these are non-zero the CLAP has no audio ports, so process() copies the
+  // AAX audio input straight to the output (matching DemoMIDI_Transpose) instead
+  // of leaving the output uninitialised. Zero for normal audio plugins.
+  uint32_t _placeholderInChannels = 0;
+  uint32_t _placeholderOutChannels = 0;
 };
 
 AAX_Result GetEffectDescriptions(AAX_ICollection *outDescriptions);

--- a/src/detail/aax/wrapper.h
+++ b/src/detail/aax/wrapper.h
@@ -131,6 +131,17 @@ class AAXProcessAdapter
   void addToActiveNotes(const clap_event_note *note);
   void removeFromActiveNotes(const clap_event_note *note);
 
+  // Post a single MIDI 1.0 message (up to 3 bytes) to the AAX local MIDI
+  // output node, filtered to the channel-voice messages Pro Tools routes out
+  // of a plug-in. No-op when the plugin declares no MIDI out (node is a
+  // placeholder / nullptr). Called from enqueueOutputEvent while the plugin
+  // is inside process() and _outputNode is valid.
+  void postMIDI1(uint32_t timestamp, const uint8_t *bytes, uint32_t length);
+
+  // Post a (possibly long) SysEx message as a series of <=4-byte AAX packets
+  // sharing one timestamp. Best-effort: Pro Tools does not route plug-in SysEx.
+  void postSysEx(uint32_t timestamp, const uint8_t *data, uint32_t size);
+
   // the functions for the event list callback
   static uint32_t CLAP_ABI input_events_size(const struct clap_input_events *list);
   static const clap_event_header_t *CLAP_ABI input_events_get(const struct clap_input_events *list,
@@ -139,6 +150,11 @@ class AAXProcessAdapter
   // MIDI
   uint32_t _midi_first_portid = 0;
   bool _midi_prefer_mididialect = true;
+
+  // Local MIDI output node for the current process() call, captured from the
+  // AAX algorithm context. Only valid for the duration of process(); reset to
+  // nullptr afterwards so a stale node can never be posted to.
+  AAX_IMIDINode *_outputNode = nullptr;
 };
 
 AAX_Result GetEffectDescriptions(AAX_ICollection *outDescriptions);

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -168,9 +168,16 @@ class MIDIOutput
   // wrap a MIDI 1.0 channel-voice message into one MT 0x2 UMP word
   void appendUMP1(uint8_t status, uint8_t data1, uint8_t data2)
   {
-    uint32_t word = (0x2u << 28) | (0x0u << 24) | (static_cast<uint32_t>(status) << 16) |
-                    (static_cast<uint32_t>(data1) << 8) | static_cast<uint32_t>(data2);
-    _umpCurrent = MIDIEventListAdd(_umpList, sizeof(_umpBuffer), _umpCurrent, 0, 1, &word);
+    // _umpCurrent is null when running on macOS < 11 (the list is never
+    // initialized there) and once the list is full (MIDIEventListAdd returns
+    // nullptr and must not be called with a null curPacket) - drop the event.
+    if (!_umpCurrent) return;
+    if (__builtin_available(macOS 11.0, *))
+    {
+      uint32_t word = (0x2u << 28) | (0x0u << 24) | (static_cast<uint32_t>(status) << 16) |
+                      (static_cast<uint32_t>(data1) << 8) | static_cast<uint32_t>(data2);
+      _umpCurrent = MIDIEventListAdd(_umpList, sizeof(_umpBuffer), _umpCurrent, 0, 1, &word);
+    }
   }
   // pack a SysEx payload (0xF0/0xF7 framing stripped) into MT 0x3 SysEx7 packets
   void appendUMPSysEx(const uint8_t *data, uint32_t size);
@@ -193,8 +200,13 @@ MIDIOutput::MIDIOutput(int auport, const clap_note_port_info &info) : _info(info
   _current = MIDIPacketListInit(_midiPacketList);
   _numEvents = 0;
 #if AUSDK_MIDI2_AVAILABLE
-  _umpList = (MIDIEventList *)_umpBuffer;
-  _umpCurrent = MIDIEventListInit(_umpList, kMIDIProtocol_1_0);
+  // on macOS < 11 the CoreMIDI EventList API is unavailable; _umpList and
+  // _umpCurrent stay null and every UMP append becomes a no-op
+  if (__builtin_available(macOS 11.0, *))
+  {
+    _umpList = (MIDIEventList *)_umpBuffer;
+    _umpCurrent = MIDIEventListInit(_umpList, kMIDIProtocol_1_0);
+  }
 #endif
 }
 
@@ -203,7 +215,10 @@ void MIDIOutput::clear()
   _current = MIDIPacketListInit(_midiPacketList);
   _numEvents = 0;
 #if AUSDK_MIDI2_AVAILABLE
-  _umpCurrent = MIDIEventListInit(_umpList, kMIDIProtocol_1_0);
+  if (__builtin_available(macOS 11.0, *))
+  {
+    if (_umpList) _umpCurrent = MIDIEventListInit(_umpList, kMIDIProtocol_1_0);
+  }
 #endif
 }
 
@@ -295,6 +310,9 @@ void MIDIOutput::appendUMPSysEx(const uint8_t *data, uint32_t size)
   uint32_t offset = 0;
   do
   {
+    // stop (and drop the rest) when the list is full or was never initialized
+    // (macOS < 11): MIDIEventListAdd must not be called with a null curPacket
+    if (!_umpCurrent) return;
     const uint32_t remaining = n - offset;
     const uint32_t chunk = (remaining > 6) ? 6 : remaining;
     uint8_t statusNibble;
@@ -316,12 +334,77 @@ void MIDIOutput::appendUMPSysEx(const uint8_t *data, uint32_t size)
     uint32_t word1 = (static_cast<uint32_t>(b[2]) << 24) | (static_cast<uint32_t>(b[3]) << 16) |
                      (static_cast<uint32_t>(b[4]) << 8) | static_cast<uint32_t>(b[5]);
     uint32_t words[2] = {word0, word1};
-    _umpCurrent = MIDIEventListAdd(_umpList, sizeof(_umpBuffer), _umpCurrent, 0, 2, words);
+    if (__builtin_available(macOS 11.0, *))
+    {
+      _umpCurrent = MIDIEventListAdd(_umpList, sizeof(_umpBuffer), _umpCurrent, 0, 2, words);
+    }
 
     offset += chunk;
   } while (offset < n);
 }
 #endif
+
+// Down-convert a single MIDI 2.0 channel-voice UMP message (MT 0x4) to a MIDI 1.0
+// 3-byte message. Returns the number of MIDI1 bytes written (0 if not convertible).
+// Wide MIDI2 values are reduced by dropping the low bits (16->7, 32->7, 32->14).
+inline int midi2ChannelVoiceToMidi1(const uint32_t data[4], uint8_t out[3])
+{
+  const uint32_t w0 = data[0];
+  const uint32_t w1 = data[1];
+  if (((w0 >> 28) & 0xFu) != 0x4u) return 0;  // only MIDI 2.0 channel voice
+
+  const uint8_t status = static_cast<uint8_t>((w0 >> 16) & 0xF0u);
+  const uint8_t channel = static_cast<uint8_t>((w0 >> 16) & 0x0Fu);
+  const uint8_t index = static_cast<uint8_t>((w0 >> 8) & 0x7Fu);  // note / cc index
+
+  switch (status)
+  {
+    case 0x80:  // note off
+    case 0x90:  // note on
+    {
+      uint8_t vel = static_cast<uint8_t>((w1 >> 16) >> 9);  // 16-bit velocity -> 7-bit
+      // MIDI 2.0 note-on keeps velocity semantics; guard against an accidental
+      // MIDI1 note-off when a non-zero MIDI2 velocity scales down to 0.
+      if (status == 0x90 && vel == 0) vel = 1;
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = index;
+      out[2] = vel;
+      return 3;
+    }
+    case 0xA0:  // poly pressure
+    case 0xB0:  // control change
+    {
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = index;
+      out[2] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
+      return 3;
+    }
+    case 0xC0:  // program change
+    {
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = static_cast<uint8_t>((w1 >> 24) & 0x7Fu);
+      out[2] = 0;
+      return 2;
+    }
+    case 0xD0:  // channel pressure
+    {
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
+      out[2] = 0;
+      return 2;
+    }
+    case 0xE0:  // pitch bend
+    {
+      const uint32_t v14 = w1 >> 18;  // 32-bit -> 14-bit
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = static_cast<uint8_t>(v14 & 0x7Fu);
+      out[2] = static_cast<uint8_t>((v14 >> 7) & 0x7Fu);
+      return 3;
+    }
+    default:
+      return 0;
+  }
+}
 
 #if AUSDK_MIDI2_AVAILABLE
 // number of 32-bit words in a Universal MIDI Packet message, from the message
@@ -472,8 +555,23 @@ class WrapAsAUV2 : public ausdk::AUBase,
         const uint32_t mt = (w0 >> 28) & 0xFu;
         if (midi2 && mt == 0x4u)
         {
-          // MIDI 2.0 channel voice message
-          _processAdapter->addMIDI2Event(&pkt->words[i], nWords, offset);
+          if (_midi_understands_midi2)
+          {
+            // MIDI 2.0 channel voice message, forwarded raw
+            _processAdapter->addMIDI2Event(&pkt->words[i], nWords, offset);
+          }
+          else
+          {
+            // the plugin's note port never declared the MIDI2 dialect (a host
+            // ignoring our advertised protocol can still send it): down-convert
+            // to MIDI 1.0 and reuse the byte-based translation, which honours
+            // the dialect the plugin actually asked for
+            uint8_t bytes[3];
+            if (midi2ChannelVoiceToMidi1(&pkt->words[i], bytes) > 0)
+            {
+              _processAdapter->addMIDIEvent(bytes[0], bytes[1], bytes[2], offset);
+            }
+          }
         }
         else if (mt == 0x2u)
         {
@@ -505,12 +603,10 @@ class WrapAsAUV2 : public ausdk::AUBase,
     if (!_processAdapter) return;
     const uint8_t statusNibble = (w0 >> 20) & 0xFu;
     const uint8_t numBytes = (w0 >> 16) & 0xFu;
-    const uint8_t bytes[6] = {static_cast<uint8_t>((w0 >> 8) & 0xFFu),
-                              static_cast<uint8_t>(w0 & 0xFFu),
-                              static_cast<uint8_t>((w1 >> 24) & 0xFFu),
-                              static_cast<uint8_t>((w1 >> 16) & 0xFFu),
-                              static_cast<uint8_t>((w1 >> 8) & 0xFFu),
-                              static_cast<uint8_t>(w1 & 0xFFu)};
+    const uint8_t bytes[6] = {
+        static_cast<uint8_t>((w0 >> 8) & 0xFFu),  static_cast<uint8_t>(w0 & 0xFFu),
+        static_cast<uint8_t>((w1 >> 24) & 0xFFu), static_cast<uint8_t>((w1 >> 16) & 0xFFu),
+        static_cast<uint8_t>((w1 >> 8) & 0xFFu),  static_cast<uint8_t>(w1 & 0xFFu)};
 
     if (statusNibble == 0x0 || statusNibble == 0x1) _sysexAssembly.clear();
     for (uint8_t k = 0; k < numBytes && k < 6; ++k) _sysexAssembly.push_back(bytes[k]);

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -142,9 +142,18 @@ class MIDIOutput
   {
     return _midiPacketList;
   }
+#if AUSDK_MIDI2_AVAILABLE
+  // parallel Universal MIDI Packet view of the same events (protocol 1.0 / MT 0x2);
+  // the framework converts to the host's negotiated protocol on delivery.
+  MIDIEventList *getMIDIEventList()
+  {
+    return _umpList;
+  }
+#endif
   bool addNoteOn(uint8_t channel, uint8_t note, uint8_t velocity);
   bool addNoteOff(uint8_t channel, uint8_t note, uint8_t velocity);
   bool addMIDI3Byte(const uint8_t *threebytes);
+  bool addSysEx(const uint8_t *data, uint32_t size);
 
   void clear();
   const clap_note_port_info _info;
@@ -155,10 +164,27 @@ class MIDIOutput
   }
 
  private:
+#if AUSDK_MIDI2_AVAILABLE
+  // wrap a MIDI 1.0 channel-voice message into one MT 0x2 UMP word
+  void appendUMP1(uint8_t status, uint8_t data1, uint8_t data2)
+  {
+    uint32_t word = (0x2u << 28) | (0x0u << 24) | (static_cast<uint32_t>(status) << 16) |
+                    (static_cast<uint32_t>(data1) << 8) | static_cast<uint32_t>(data2);
+    _umpCurrent = MIDIEventListAdd(_umpList, sizeof(_umpBuffer), _umpCurrent, 0, 1, &word);
+  }
+  // pack a SysEx payload (0xF0/0xF7 framing stripped) into MT 0x3 SysEx7 packets
+  void appendUMPSysEx(const uint8_t *data, uint32_t size);
+#endif
+
   MIDIPacket *_current = nullptr;
   MIDIPacketList *_midiPacketList = nullptr;
   uint8_t _buffer[2048];
   uint32_t _numEvents = 0;
+#if AUSDK_MIDI2_AVAILABLE
+  MIDIEventPacket *_umpCurrent = nullptr;
+  MIDIEventList *_umpList = nullptr;
+  uint8_t _umpBuffer[2048];
+#endif
 };
 
 MIDIOutput::MIDIOutput(int auport, const clap_note_port_info &info) : _info(info), _auport(auport)
@@ -166,12 +192,19 @@ MIDIOutput::MIDIOutput(int auport, const clap_note_port_info &info) : _info(info
   _midiPacketList = (MIDIPacketList *)_buffer;
   _current = MIDIPacketListInit(_midiPacketList);
   _numEvents = 0;
+#if AUSDK_MIDI2_AVAILABLE
+  _umpList = (MIDIEventList *)_umpBuffer;
+  _umpCurrent = MIDIEventListInit(_umpList, kMIDIProtocol_1_0);
+#endif
 }
 
 void MIDIOutput::clear()
 {
   _current = MIDIPacketListInit(_midiPacketList);
   _numEvents = 0;
+#if AUSDK_MIDI2_AVAILABLE
+  _umpCurrent = MIDIEventListInit(_umpList, kMIDIProtocol_1_0);
+#endif
 }
 
 bool MIDIOutput::addNoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
@@ -179,6 +212,9 @@ bool MIDIOutput::addNoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
   uint8_t ev[3] = {static_cast<uint8_t>((uint8_t)0x90u | (channel & 0xF)),
                    static_cast<uint8_t>((note & 0x7F)), static_cast<uint8_t>((velocity & 0x7F))};
   _current = MIDIPacketListAdd(_midiPacketList, sizeof(_buffer), _current, 0, 3, (Byte *)ev);
+#if AUSDK_MIDI2_AVAILABLE
+  appendUMP1(ev[0], ev[1], ev[2]);
+#endif
   ++_numEvents;
   return (_current != nullptr);
 }
@@ -187,6 +223,9 @@ bool MIDIOutput::addNoteOff(uint8_t channel, uint8_t note, uint8_t velocity)
   uint8_t ev[3] = {static_cast<uint8_t>((uint8_t)0x80u | (channel & 0xF)),
                    static_cast<uint8_t>((note & 0x7F)), static_cast<uint8_t>((velocity & 0x7F))};
   _current = MIDIPacketListAdd(_midiPacketList, sizeof(_buffer), _current, 0, 3, (Byte *)ev);
+#if AUSDK_MIDI2_AVAILABLE
+  appendUMP1(ev[0], ev[1], ev[2]);
+#endif
   ++_numEvents;
   return (_current != nullptr);
 }
@@ -202,10 +241,16 @@ bool MIDIOutput::addMIDI3Byte(const uint8_t *threebytes)
     case 0x0B:
     case 0x0E:
       _current = MIDIPacketListAdd(_midiPacketList, sizeof(_buffer), _current, 0, 3, threebytes);
+#if AUSDK_MIDI2_AVAILABLE
+      appendUMP1(threebytes[0], threebytes[1], threebytes[2]);
+#endif
       break;
     case 0x0C:
     case 0x0D:
       _current = MIDIPacketListAdd(_midiPacketList, sizeof(_buffer), _current, 0, 2, threebytes);
+#if AUSDK_MIDI2_AVAILABLE
+      appendUMP1(threebytes[0], threebytes[1], 0);
+#endif
       break;
     default:
       return false;
@@ -214,6 +259,102 @@ bool MIDIOutput::addMIDI3Byte(const uint8_t *threebytes)
   ++_numEvents;
   return (_current != nullptr);
 }
+
+bool MIDIOutput::addSysEx(const uint8_t *data, uint32_t size)
+{
+  if (!data || size == 0) return false;
+  // MIDIPacketListAdd splits the payload across packets as needed, but the
+  // whole list is still bounded by our fixed _buffer; very long SysEx that does
+  // not fit is dropped (returns nullptr). The CLAP buffer already contains the
+  // full message including the 0xF0/0xF7 framing.
+  _current = MIDIPacketListAdd(_midiPacketList, sizeof(_buffer), _current, 0, size, (Byte *)data);
+  if (_current == nullptr) return false;
+#if AUSDK_MIDI2_AVAILABLE
+  appendUMPSysEx(data, size);
+#endif
+  ++_numEvents;
+  return true;
+}
+
+#if AUSDK_MIDI2_AVAILABLE
+void MIDIOutput::appendUMPSysEx(const uint8_t *data, uint32_t size)
+{
+  // UMP SysEx7 (MT 0x3) carries the payload WITHOUT the 0xF0/0xF7 framing, up to
+  // 6 data bytes per 64-bit packet, with a status nibble marking complete/start/
+  // continue/end.
+  const uint8_t *p = data;
+  uint32_t n = size;
+  if (n > 0 && p[0] == 0xF0)
+  {
+    ++p;
+    --n;
+  }
+  if (n > 0 && p[n - 1] == 0xF7) --n;
+
+  const uint8_t group = 0;
+  uint32_t offset = 0;
+  do
+  {
+    const uint32_t remaining = n - offset;
+    const uint32_t chunk = (remaining > 6) ? 6 : remaining;
+    uint8_t statusNibble;
+    if (n <= 6)
+      statusNibble = 0x0;  // complete in a single packet
+    else if (offset == 0)
+      statusNibble = 0x1;  // start
+    else if (offset + chunk >= n)
+      statusNibble = 0x3;  // end
+    else
+      statusNibble = 0x2;  // continue
+
+    uint8_t b[6] = {0, 0, 0, 0, 0, 0};
+    for (uint32_t k = 0; k < chunk; ++k) b[k] = p[offset + k];
+
+    uint32_t word0 = (0x3u << 28) | (static_cast<uint32_t>(group) << 24) |
+                     (static_cast<uint32_t>(statusNibble) << 20) | (chunk << 16) |
+                     (static_cast<uint32_t>(b[0]) << 8) | static_cast<uint32_t>(b[1]);
+    uint32_t word1 = (static_cast<uint32_t>(b[2]) << 24) | (static_cast<uint32_t>(b[3]) << 16) |
+                     (static_cast<uint32_t>(b[4]) << 8) | static_cast<uint32_t>(b[5]);
+    uint32_t words[2] = {word0, word1};
+    _umpCurrent = MIDIEventListAdd(_umpList, sizeof(_umpBuffer), _umpCurrent, 0, 2, words);
+
+    offset += chunk;
+  } while (offset < n);
+}
+#endif
+
+#if AUSDK_MIDI2_AVAILABLE
+// number of 32-bit words in a Universal MIDI Packet message, from the message
+// type in the high nibble of its first word (MIDI 2.0 UMP spec).
+inline uint32_t umpMessageWordCount(uint32_t word0)
+{
+  switch ((word0 >> 28) & 0xFu)
+  {
+    case 0x0:  // utility
+    case 0x1:  // system real time / common
+    case 0x2:  // MIDI 1.0 channel voice
+    case 0x6:
+    case 0x7:
+      return 1;
+    case 0x3:  // data / SysEx (64-bit)
+    case 0x4:  // MIDI 2.0 channel voice
+    case 0x8:
+    case 0x9:
+    case 0xA:
+      return 2;
+    case 0xB:
+    case 0xC:
+      return 3;
+    case 0x5:  // data (128-bit)
+    case 0xD:
+    case 0xE:
+    case 0xF:
+      return 4;
+    default:
+      return 1;
+  }
+}
+#endif
 
 class WrapAsAUV2 : public ausdk::AUBase,
                    public Clap::IHost,
@@ -306,26 +447,123 @@ class WrapAsAUV2 : public ausdk::AUBase,
     return noErr;  //  HandleMIDIEvent(strippedStatus, channel, inData1, inData2, inOffsetSampleFrame);
   }
 
-  OSStatus SysEx(const UInt8 *inData, UInt32 inLength) override
+#if AUSDK_MIDI2_AVAILABLE
+  // MIDI 2.0 / Universal MIDI Packet input. The framework delivers events in the
+  // protocol we advertise via kAudioUnitProperty_AudioUnitMIDIProtocol; we honour
+  // whatever protocol the list actually carries. MIDI 2.0 channel-voice messages
+  // are forwarded raw as CLAP_EVENT_MIDI2 (for plugins that prefer MIDI2); MIDI
+  // 1.0 messages reuse the byte-based translation so they pick up the note /
+  // note-expression handling of the MIDI1 path.
+  OSStatus MIDIEventList(UInt32 /*inOffsetSampleFrame*/, const struct MIDIEventList *evtlist) override
   {
+    if (!_processAdapter || !evtlist) return noErr;
+
+    const bool midi2 = (evtlist->protocol == kMIDIProtocol_2_0);
+    const MIDIEventPacket *pkt = &evtlist->packet[0];
+    for (UInt32 p = 0; p < evtlist->numPackets; ++p)
+    {
+      const UInt32 offset = static_cast<UInt32>(pkt->timeStamp);
+      for (UInt32 i = 0; i < pkt->wordCount;)
+      {
+        const uint32_t w0 = pkt->words[i];
+        const uint32_t nWords = umpMessageWordCount(w0);
+        if (i + nWords > pkt->wordCount) break;  // truncated packet, stop
+
+        const uint32_t mt = (w0 >> 28) & 0xFu;
+        if (midi2 && mt == 0x4u)
+        {
+          // MIDI 2.0 channel voice message
+          _processAdapter->addMIDI2Event(&pkt->words[i], nWords, offset);
+        }
+        else if (mt == 0x2u)
+        {
+          // MIDI 1.0 channel voice message packed into one UMP word
+          const UInt32 status = (w0 >> 16) & 0xFFu;
+          const UInt32 data1 = (w0 >> 8) & 0xFFu;
+          const UInt32 data2 = w0 & 0xFFu;
+          _processAdapter->addMIDIEvent(status, data1, data2, offset);
+        }
+        else if (mt == 0x3u)
+        {
+          // UMP SysEx7 (may span several packets); assembled then delivered
+          handleUMPSysEx7(pkt->words[i], (nWords > 1) ? pkt->words[i + 1] : 0u, offset);
+        }
+        // other message types (utility / system) are not translated
+        i += nWords;
+      }
+      pkt = MIDIEventPacketNext(pkt);
+    }
     return noErr;
   }
 
-  // Notes
-  OSStatus StartNote(MusicDeviceInstrumentID /*inInstrument*/, MusicDeviceGroupID /*inGroupID*/,
+  // Reassemble a UMP SysEx7 packet stream into a single CLAP SysEx event. The
+  // status nibble marks complete(0)/start(1)/continue(2)/end(3); data bytes are
+  // accumulated and, on complete/end, wrapped in 0xF0/0xF7 to match our CLAP
+  // SysEx convention before delivery.
+  void handleUMPSysEx7(uint32_t w0, uint32_t w1, UInt32 offset)
+  {
+    if (!_processAdapter) return;
+    const uint8_t statusNibble = (w0 >> 20) & 0xFu;
+    const uint8_t numBytes = (w0 >> 16) & 0xFu;
+    const uint8_t bytes[6] = {static_cast<uint8_t>((w0 >> 8) & 0xFFu),
+                              static_cast<uint8_t>(w0 & 0xFFu),
+                              static_cast<uint8_t>((w1 >> 24) & 0xFFu),
+                              static_cast<uint8_t>((w1 >> 16) & 0xFFu),
+                              static_cast<uint8_t>((w1 >> 8) & 0xFFu),
+                              static_cast<uint8_t>(w1 & 0xFFu)};
+
+    if (statusNibble == 0x0 || statusNibble == 0x1) _sysexAssembly.clear();
+    for (uint8_t k = 0; k < numBytes && k < 6; ++k) _sysexAssembly.push_back(bytes[k]);
+
+    if (statusNibble == 0x0 || statusNibble == 0x3)
+    {
+      std::vector<uint8_t> msg;
+      msg.reserve(_sysexAssembly.size() + 2);
+      msg.push_back(0xF0);
+      msg.insert(msg.end(), _sysexAssembly.begin(), _sysexAssembly.end());
+      msg.push_back(0xF7);
+      _processAdapter->addSysExEvent(msg.data(), static_cast<uint32_t>(msg.size()), offset);
+      _sysexAssembly.clear();
+    }
+  }
+#endif
+
+  OSStatus SysEx(const UInt8 *inData, UInt32 inLength) override
+  {
+    if (_processAdapter)
+    {
+      // the AU SysEx entry point carries no sample offset; deliver at frame 0
+      _processAdapter->addSysExEvent(inData, inLength, 0);
+    }
+    return noErr;
+  }
+
+  // Notes (MusicDevice extended-note API)
+  OSStatus StartNote(MusicDeviceInstrumentID /*inInstrument*/, MusicDeviceGroupID inGroupID,
                      NoteInstanceID *outNoteInstanceID, UInt32 inOffsetSampleFrame,
                      const MusicDeviceNoteParams &inParams) override
   {
-    // _processAdapter
-    // _processAdapter->addMIDIEvent(, <#UInt32 inData1#>, <#UInt32 inData2#>, <#UInt32 inOffsetSampleFrame#>);
-    *outNoteInstanceID = inParams.mPitch;
-    return MIDIEvent(0x90, inParams.mPitch, inParams.mVelocity, inOffsetSampleFrame);
+    if (!_processAdapter) return kAudioUnitErr_Uninitialized;
+
+    const int16_t channel = static_cast<int16_t>(inGroupID & 0x0F);
+    const int32_t key = static_cast<int32_t>(inParams.mPitch + 0.5f) & 0x7F;  // nearest MIDI key
+    // Hand back a unique instance id that also embeds the key in its low 7 bits
+    // so StopNote (which only receives the id) can recover it without a table.
+    const int32_t note_id = ((_noteInstanceCounter++ & 0x7FFF) << 7) | key;
+    *outNoteInstanceID = note_id;
+
+    _processAdapter->startNote(note_id, channel, inParams.mPitch, inParams.mVelocity,
+                               inOffsetSampleFrame);
+    return noErr;
   }
 
-  OSStatus StopNote(MusicDeviceGroupID /*inGroupID*/, NoteInstanceID inNoteInstanceID,
+  OSStatus StopNote(MusicDeviceGroupID inGroupID, NoteInstanceID inNoteInstanceID,
                     UInt32 inOffsetSampleFrame) override
   {
-    return MIDIEvent(0x80, inNoteInstanceID, 0, inOffsetSampleFrame);
+    if (!_processAdapter) return kAudioUnitErr_Uninitialized;
+    const int16_t channel = static_cast<int16_t>(inGroupID & 0x0F);
+    _processAdapter->stopNote(static_cast<int32_t>(inNoteInstanceID), channel, inOffsetSampleFrame);
+    return noErr;
   }
 
   // unfortunately hidden in the base c++ file
@@ -539,9 +777,27 @@ class WrapAsAUV2 : public ausdk::AUBase,
   std::atomic<bool> _initialized = false;
 
   // some info about the wrapped clap
+  // audio-port layout captured at PostConstructor. Scanning the CLAP
+  // audio-ports extension (count/get) is only legal while the plugin is
+  // deactivated, so we snapshot it once and never query it live afterwards.
+  struct AudioPortCache
+  {
+    uint32_t channelCount;
+    bool isMain;
+  };
+  std::vector<AudioPortCache> _inputPortCache;
+  std::vector<AudioPortCache> _outputPortCache;
+
   uint32_t _midi_preferred_dialect = 0;
+  uint32_t _midi_supported_dialects = 0;
   bool _midi_wants_midi_input = false;  // takes any input
   bool _midi_understands_midi2 = false;
+  // rolling counter feeding the NoteInstanceID/note_id handed out by StartNote
+  int32_t _noteInstanceCounter = 0;
+#if AUSDK_MIDI2_AVAILABLE
+  // accumulates UMP SysEx7 payload bytes across multi-packet messages on input
+  std::vector<uint8_t> _sysexAssembly;
+#endif
   // std::vector<clap_note_port_info_t> _midi_outports_info;
 
   std::string _hostname = "CLAP-as-AUv2";
@@ -562,6 +818,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   // ------------- for the MIDI output
   AUMIDIOutputCallbackStruct _midioutput_hostcallback = {nullptr, nullptr};
+#if AUSDK_MIDI2_AVAILABLE
+  // modern MIDI 2.0 / UMP output path (preferred by the host over the callback above)
+  AUMIDIEventListBlock _midioutput_hosteventlistblock = nullptr;
+  MIDIProtocolID _host_midi_protocol = kMIDIProtocol_1_0;
+#endif
 
   std::atomic_bool _requestUICallback = false;
 

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -24,6 +24,7 @@
 #include "process.h"
 #include "parameter.h"
 #include "detail/shared/fixedqueue.h"
+#include "detail/shared/midi_translation.h"
 #include "detail/os/osutil.h"
 #include "detail/clap/automation.h"
 
@@ -174,8 +175,7 @@ class MIDIOutput
     if (!_umpCurrent) return;
     if (__builtin_available(macOS 11.0, *))
     {
-      uint32_t word = (0x2u << 28) | (0x0u << 24) | (static_cast<uint32_t>(status) << 16) |
-                      (static_cast<uint32_t>(data1) << 8) | static_cast<uint32_t>(data2);
+      uint32_t word = ClapWrapper::detail::shared::midi1ToUmpWord(status, data1, data2);
       _umpCurrent = MIDIEventListAdd(_umpList, sizeof(_umpBuffer), _umpCurrent, 0, 1, &word);
     }
   }
@@ -294,147 +294,18 @@ bool MIDIOutput::addSysEx(const uint8_t *data, uint32_t size)
 #if AUSDK_MIDI2_AVAILABLE
 void MIDIOutput::appendUMPSysEx(const uint8_t *data, uint32_t size)
 {
-  // UMP SysEx7 (MT 0x3) carries the payload WITHOUT the 0xF0/0xF7 framing, up to
-  // 6 data bytes per 64-bit packet, with a status nibble marking complete/start/
-  // continue/end.
-  const uint8_t *p = data;
-  uint32_t n = size;
-  if (n > 0 && p[0] == 0xF0)
+  if (__builtin_available(macOS 11.0, *))
   {
-    ++p;
-    --n;
-  }
-  if (n > 0 && p[n - 1] == 0xF7) --n;
-
-  const uint8_t group = 0;
-  uint32_t offset = 0;
-  do
-  {
-    // stop (and drop the rest) when the list is full or was never initialized
-    // (macOS < 11): MIDIEventListAdd must not be called with a null curPacket
-    if (!_umpCurrent) return;
-    const uint32_t remaining = n - offset;
-    const uint32_t chunk = (remaining > 6) ? 6 : remaining;
-    uint8_t statusNibble;
-    if (n <= 6)
-      statusNibble = 0x0;  // complete in a single packet
-    else if (offset == 0)
-      statusNibble = 0x1;  // start
-    else if (offset + chunk >= n)
-      statusNibble = 0x3;  // end
-    else
-      statusNibble = 0x2;  // continue
-
-    uint8_t b[6] = {0, 0, 0, 0, 0, 0};
-    for (uint32_t k = 0; k < chunk; ++k) b[k] = p[offset + k];
-
-    uint32_t word0 = (0x3u << 28) | (static_cast<uint32_t>(group) << 24) |
-                     (static_cast<uint32_t>(statusNibble) << 20) | (chunk << 16) |
-                     (static_cast<uint32_t>(b[0]) << 8) | static_cast<uint32_t>(b[1]);
-    uint32_t word1 = (static_cast<uint32_t>(b[2]) << 24) | (static_cast<uint32_t>(b[3]) << 16) |
-                     (static_cast<uint32_t>(b[4]) << 8) | static_cast<uint32_t>(b[5]);
-    uint32_t words[2] = {word0, word1};
-    if (__builtin_available(macOS 11.0, *))
-    {
-      _umpCurrent = MIDIEventListAdd(_umpList, sizeof(_umpBuffer), _umpCurrent, 0, 2, words);
-    }
-
-    offset += chunk;
-  } while (offset < n);
-}
-#endif
-
-// Down-convert a single MIDI 2.0 channel-voice UMP message (MT 0x4) to a MIDI 1.0
-// 3-byte message. Returns the number of MIDI1 bytes written (0 if not convertible).
-// Wide MIDI2 values are reduced by dropping the low bits (16->7, 32->7, 32->14).
-inline int midi2ChannelVoiceToMidi1(const uint32_t data[4], uint8_t out[3])
-{
-  const uint32_t w0 = data[0];
-  const uint32_t w1 = data[1];
-  if (((w0 >> 28) & 0xFu) != 0x4u) return 0;  // only MIDI 2.0 channel voice
-
-  const uint8_t status = static_cast<uint8_t>((w0 >> 16) & 0xF0u);
-  const uint8_t channel = static_cast<uint8_t>((w0 >> 16) & 0x0Fu);
-  const uint8_t index = static_cast<uint8_t>((w0 >> 8) & 0x7Fu);  // note / cc index
-
-  switch (status)
-  {
-    case 0x80:  // note off
-    case 0x90:  // note on
-    {
-      uint8_t vel = static_cast<uint8_t>((w1 >> 16) >> 9);  // 16-bit velocity -> 7-bit
-      // MIDI 2.0 note-on keeps velocity semantics; guard against an accidental
-      // MIDI1 note-off when a non-zero MIDI2 velocity scales down to 0.
-      if (status == 0x90 && vel == 0) vel = 1;
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = index;
-      out[2] = vel;
-      return 3;
-    }
-    case 0xA0:  // poly pressure
-    case 0xB0:  // control change
-    {
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = index;
-      out[2] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
-      return 3;
-    }
-    case 0xC0:  // program change
-    {
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = static_cast<uint8_t>((w1 >> 24) & 0x7Fu);
-      out[2] = 0;
-      return 2;
-    }
-    case 0xD0:  // channel pressure
-    {
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
-      out[2] = 0;
-      return 2;
-    }
-    case 0xE0:  // pitch bend
-    {
-      const uint32_t v14 = w1 >> 18;  // 32-bit -> 14-bit
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = static_cast<uint8_t>(v14 & 0x7Fu);
-      out[2] = static_cast<uint8_t>((v14 >> 7) & 0x7Fu);
-      return 3;
-    }
-    default:
-      return 0;
-  }
-}
-
-#if AUSDK_MIDI2_AVAILABLE
-// number of 32-bit words in a Universal MIDI Packet message, from the message
-// type in the high nibble of its first word (MIDI 2.0 UMP spec).
-inline uint32_t umpMessageWordCount(uint32_t word0)
-{
-  switch ((word0 >> 28) & 0xFu)
-  {
-    case 0x0:  // utility
-    case 0x1:  // system real time / common
-    case 0x2:  // MIDI 1.0 channel voice
-    case 0x6:
-    case 0x7:
-      return 1;
-    case 0x3:  // data / SysEx (64-bit)
-    case 0x4:  // MIDI 2.0 channel voice
-    case 0x8:
-    case 0x9:
-    case 0xA:
-      return 2;
-    case 0xB:
-    case 0xC:
-      return 3;
-    case 0x5:  // data (128-bit)
-    case 0xD:
-    case 0xE:
-    case 0xF:
-      return 4;
-    default:
-      return 1;
+    ClapWrapper::detail::shared::packSysEx7(
+        data, size,
+        [this](uint32_t w0, uint32_t w1)
+        {
+          // stop appending once the list is full or was never initialized
+          // (macOS < 11): MIDIEventListAdd must not be called with a null curPacket
+          if (!_umpCurrent) return;
+          uint32_t words[2] = {w0, w1};
+          _umpCurrent = MIDIEventListAdd(_umpList, sizeof(_umpBuffer), _umpCurrent, 0, 2, words);
+        });
   }
 }
 #endif
@@ -549,7 +420,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
       for (UInt32 i = 0; i < pkt->wordCount;)
       {
         const uint32_t w0 = pkt->words[i];
-        const uint32_t nWords = umpMessageWordCount(w0);
+        const uint32_t nWords = ClapWrapper::detail::shared::umpMessageWordCount(w0);
         if (i + nWords > pkt->wordCount) break;  // truncated packet, stop
 
         const uint32_t mt = (w0 >> 28) & 0xFu;
@@ -567,7 +438,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
             // to MIDI 1.0 and reuse the byte-based translation, which honours
             // the dialect the plugin actually asked for
             uint8_t bytes[3];
-            if (midi2ChannelVoiceToMidi1(&pkt->words[i], bytes) > 0)
+            if (ClapWrapper::detail::shared::midi2ChannelVoiceToMidi1(&pkt->words[i], bytes) > 0)
             {
               _processAdapter->addMIDIEvent(bytes[0], bytes[1], bytes[2], offset);
             }
@@ -594,32 +465,15 @@ class WrapAsAUV2 : public ausdk::AUBase,
     return noErr;
   }
 
-  // Reassemble a UMP SysEx7 packet stream into a single CLAP SysEx event. The
-  // status nibble marks complete(0)/start(1)/continue(2)/end(3); data bytes are
-  // accumulated and, on complete/end, wrapped in 0xF0/0xF7 to match our CLAP
-  // SysEx convention before delivery.
+  // Reassemble a UMP SysEx7 packet stream into a single CLAP SysEx event using the
+  // shared reassembler; on a complete message it is already framed with 0xF0/0xF7.
   void handleUMPSysEx7(uint32_t w0, uint32_t w1, UInt32 offset)
   {
     if (!_processAdapter) return;
-    const uint8_t statusNibble = (w0 >> 20) & 0xFu;
-    const uint8_t numBytes = (w0 >> 16) & 0xFu;
-    const uint8_t bytes[6] = {
-        static_cast<uint8_t>((w0 >> 8) & 0xFFu),  static_cast<uint8_t>(w0 & 0xFFu),
-        static_cast<uint8_t>((w1 >> 24) & 0xFFu), static_cast<uint8_t>((w1 >> 16) & 0xFFu),
-        static_cast<uint8_t>((w1 >> 8) & 0xFFu),  static_cast<uint8_t>(w1 & 0xFFu)};
-
-    if (statusNibble == 0x0 || statusNibble == 0x1) _sysexAssembly.clear();
-    for (uint8_t k = 0; k < numBytes && k < 6; ++k) _sysexAssembly.push_back(bytes[k]);
-
-    if (statusNibble == 0x0 || statusNibble == 0x3)
+    if (_sysexReassembler.feed(w0, w1))
     {
-      std::vector<uint8_t> msg;
-      msg.reserve(_sysexAssembly.size() + 2);
-      msg.push_back(0xF0);
-      msg.insert(msg.end(), _sysexAssembly.begin(), _sysexAssembly.end());
-      msg.push_back(0xF7);
+      const auto &msg = _sysexReassembler.framedMessage();
       _processAdapter->addSysExEvent(msg.data(), static_cast<uint32_t>(msg.size()), offset);
-      _sysexAssembly.clear();
     }
   }
 #endif
@@ -891,8 +745,8 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // rolling counter feeding the NoteInstanceID/note_id handed out by StartNote
   int32_t _noteInstanceCounter = 0;
 #if AUSDK_MIDI2_AVAILABLE
-  // accumulates UMP SysEx7 payload bytes across multi-packet messages on input
-  std::vector<uint8_t> _sysexAssembly;
+  // reassembles UMP SysEx7 across multi-packet messages on input
+  ClapWrapper::detail::shared::SysEx7Reassembler _sysexReassembler;
 #endif
   // std::vector<clap_note_port_info_t> _midi_outports_info;
 

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -224,6 +224,9 @@ void MIDIOutput::clear()
 
 bool MIDIOutput::addNoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
 {
+  // once the list is full MIDIPacketListAdd returns nullptr; it must never be
+  // called with a null curPacket, so further events this block are dropped
+  if (!_current) return false;
   uint8_t ev[3] = {static_cast<uint8_t>((uint8_t)0x90u | (channel & 0xF)),
                    static_cast<uint8_t>((note & 0x7F)), static_cast<uint8_t>((velocity & 0x7F))};
   _current = MIDIPacketListAdd(_midiPacketList, sizeof(_buffer), _current, 0, 3, (Byte *)ev);
@@ -235,6 +238,7 @@ bool MIDIOutput::addNoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
 }
 bool MIDIOutput::addNoteOff(uint8_t channel, uint8_t note, uint8_t velocity)
 {
+  if (!_current) return false;
   uint8_t ev[3] = {static_cast<uint8_t>((uint8_t)0x80u | (channel & 0xF)),
                    static_cast<uint8_t>((note & 0x7F)), static_cast<uint8_t>((velocity & 0x7F))};
   _current = MIDIPacketListAdd(_midiPacketList, sizeof(_buffer), _current, 0, 3, (Byte *)ev);
@@ -247,6 +251,7 @@ bool MIDIOutput::addNoteOff(uint8_t channel, uint8_t note, uint8_t velocity)
 
 bool MIDIOutput::addMIDI3Byte(const uint8_t *threebytes)
 {
+  if (!_current) return false;
   auto cmd = (threebytes[0] >> 4) & 0xFu;
   switch (cmd)
   {
@@ -277,7 +282,7 @@ bool MIDIOutput::addMIDI3Byte(const uint8_t *threebytes)
 
 bool MIDIOutput::addSysEx(const uint8_t *data, uint32_t size)
 {
-  if (!data || size == 0) return false;
+  if (!_current || !data || size == 0) return false;
   // MIDIPacketListAdd splits the payload across packets as needed, but the
   // whole list is still bounded by our fixed _buffer; very long SysEx that does
   // not fit is dropped (returns nullptr). The CLAP buffer already contains the
@@ -408,7 +413,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // are forwarded raw as CLAP_EVENT_MIDI2 (for plugins that prefer MIDI2); MIDI
   // 1.0 messages reuse the byte-based translation so they pick up the note /
   // note-expression handling of the MIDI1 path.
-  OSStatus MIDIEventList(UInt32 /*inOffsetSampleFrame*/, const struct MIDIEventList *evtlist) override
+  OSStatus MIDIEventList(UInt32 inOffsetSampleFrame, const struct MIDIEventList *evtlist) override
   {
     if (!_processAdapter || !evtlist) return noErr;
 
@@ -416,7 +421,9 @@ class WrapAsAUV2 : public ausdk::AUBase,
     const MIDIEventPacket *pkt = &evtlist->packet[0];
     for (UInt32 p = 0; p < evtlist->numPackets; ++p)
     {
-      const UInt32 offset = static_cast<UInt32>(pkt->timeStamp);
+      // MusicDevice.h: each event's sample offset is inOffsetSampleFrame plus
+      // the packet's timeStamp (itself a sample offset within the render cycle)
+      const UInt32 offset = inOffsetSampleFrame + static_cast<UInt32>(pkt->timeStamp);
       for (UInt32 i = 0; i < pkt->wordCount;)
       {
         const uint32_t w0 = pkt->words[i];
@@ -769,8 +776,13 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // ------------- for the MIDI output
   AUMIDIOutputCallbackStruct _midioutput_hostcallback = {nullptr, nullptr};
 #if AUSDK_MIDI2_AVAILABLE
-  // modern MIDI 2.0 / UMP output path (preferred by the host over the callback above)
-  AUMIDIEventListBlock _midioutput_hosteventlistblock = nullptr;
+  // modern MIDI 2.0 / UMP output path (preferred by the host over the callback
+  // above). Atomic because a host may install or clear the block while Render is
+  // invoking it on the audio thread; replaced blocks are parked in
+  // _retiredEventListBlocks instead of being released under the render thread's
+  // feet, and drained in deactivateCLAP()/~WrapAsAUV2 when no render can run.
+  std::atomic<AUMIDIEventListBlock> _midioutput_hosteventlistblock{nullptr};
+  std::vector<AUMIDIEventListBlock> _retiredEventListBlocks;
   MIDIProtocolID _host_midi_protocol = kMIDIProtocol_1_0;
 #endif
 

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -27,8 +27,8 @@ static uint32_t chooseInputDialect(uint32_t preferred, uint32_t supported)
 {
   if (supported == 0) return preferred;  // no note-port info: trust preferred
   if (supported & preferred) return preferred;
-  for (uint32_t dialect : {CLAP_NOTE_DIALECT_CLAP, CLAP_NOTE_DIALECT_MIDI,
-                           CLAP_NOTE_DIALECT_MIDI_MPE, CLAP_NOTE_DIALECT_MIDI2})
+  for (uint32_t dialect : {CLAP_NOTE_DIALECT_CLAP, CLAP_NOTE_DIALECT_MIDI, CLAP_NOTE_DIALECT_MIDI_MPE,
+                           CLAP_NOTE_DIALECT_MIDI2})
   {
     if (supported & dialect) return dialect;
   }
@@ -367,7 +367,7 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
       _midiouts->send(*nevt);
       return true;
     }
-      break;
+    break;
     case CLAP_EVENT_PARAM_VALUE:
     {
       auto ev = (clap_event_param_value *)event;
@@ -411,14 +411,14 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
       _midiouts->send(*nevt);
       return true;
     }
-      break;
+    break;
     case CLAP_EVENT_MIDI2:
     {
       auto nevt = reinterpret_cast<const clap_multi_event_t *>(event);
       _midiouts->send(*nevt);
       return true;
     }
-      break;
+    break;
     default:
       break;
   }

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -1,4 +1,5 @@
 #include "process.h"
+#include "detail/shared/midi_translation.h"
 
 #include <algorithm>
 #include <cmath>
@@ -16,23 +17,6 @@ inline clap_beattime doubleToBeatTime(double t)
 inline clap_sectime doubleToSecTime(double t)
 {
   return round(t * CLAP_SECTIME_FACTOR);
-}
-
-// Decide which note dialect we feed the plugin on the input path.
-// A CLAP plugin's preferred_dialect is guaranteed to be one of its supported
-// dialects, but be defensive: if the preferred dialect is somehow not offered
-// (or no note-port info was captured), fall back to the first dialect the port
-// does support, favouring typed CLAP notes over raw MIDI.
-static uint32_t chooseInputDialect(uint32_t preferred, uint32_t supported)
-{
-  if (supported == 0) return preferred;  // no note-port info: trust preferred
-  if (supported & preferred) return preferred;
-  for (uint32_t dialect : {CLAP_NOTE_DIALECT_CLAP, CLAP_NOTE_DIALECT_MIDI, CLAP_NOTE_DIALECT_MIDI_MPE,
-                           CLAP_NOTE_DIALECT_MIDI2})
-  {
-    if (supported & dialect) return dialect;
-  }
-  return preferred;
 }
 
 ProcessAdapter::~ProcessAdapter()
@@ -70,7 +54,8 @@ void ProcessAdapter::setupProcessing(ausdk::AUScope &audioInputs, ausdk::AUScope
   _parameters = parameters;
 
   _supported_midi_dialects = supportedMIDIDialects;
-  _preferred_midi_dialect = chooseInputDialect(preferredMIDIDialect, supportedMIDIDialects);
+  _preferred_midi_dialect =
+      ClapWrapper::detail::shared::chooseInputDialect(preferredMIDIDialect, supportedMIDIDialects);
 
   _clapNumInputs = clapAudioInputs;
   _clapNumOutputs = clapAudioOutputs;
@@ -563,12 +548,58 @@ void ProcessAdapter::addMIDIEvent(UInt32 inStatus, UInt32 inData1, UInt32 inData
       this->_eventindices.emplace_back((this->_events.size()));
       this->_events.emplace_back(n);
       break;
+    case 0xD:  // channel pressure (2 bytes) -> channel-wide pressure expression
+      if (_preferred_midi_dialect == CLAP_NOTE_DIALECT_CLAP)
+      {
+        n.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+        n.header.size = sizeof(clap_event_note_expression_t);
+        n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
+        n.noteexpression.note_id = -1;
+        n.noteexpression.port_index = 0;
+        n.noteexpression.channel = channel;
+        n.noteexpression.key = -1;                                // channel-wide (wildcard key)
+        n.noteexpression.value = 1.0 * (inData1 & 0x7F) / 127.0;  // range 0..1
+      }
+      else
+      {
+        n.header.type = CLAP_EVENT_MIDI;
+        n.header.size = sizeof(clap_event_midi_t);
+        n.midi.port_index = 0;
+        n.midi.data[0] = inStatus;
+        n.midi.data[1] = inData1;
+        n.midi.data[2] = inData2;
+      }
+      this->_eventindices.emplace_back((this->_events.size()));
+      this->_events.emplace_back(n);
+      break;
+    case 0xE:  // pitch bend -> channel-wide tuning expression (+/- 2 semitones)
+      if (_preferred_midi_dialect == CLAP_NOTE_DIALECT_CLAP)
+      {
+        const int bend14 = ((inData2 & 0x7F) << 7) | (inData1 & 0x7F);
+        n.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+        n.header.size = sizeof(clap_event_note_expression_t);
+        n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;
+        n.noteexpression.note_id = -1;
+        n.noteexpression.port_index = 0;
+        n.noteexpression.channel = channel;
+        n.noteexpression.key = -1;                                // channel-wide (wildcard key)
+        n.noteexpression.value = (bend14 - 8192) / 8192.0 * 2.0;  // semitones
+      }
+      else
+      {
+        n.header.type = CLAP_EVENT_MIDI;
+        n.header.size = sizeof(clap_event_midi_t);
+        n.midi.port_index = 0;
+        n.midi.data[0] = inStatus;
+        n.midi.data[1] = inData1;
+        n.midi.data[2] = inData2;
+      }
+      this->_eventindices.emplace_back((this->_events.size()));
+      this->_events.emplace_back(n);
+      break;
     case 0xB:  // control change
     case 0xC:  // program change (2 bytes)
-    case 0xD:  // channel pressure (2 bytes)
-    case 0xE:  // pitch bend
-      // CLAP has no generic typed event for these; forward as raw MIDI. (This
-      // matches the VST3 wrapper, which also reconstructs them as raw MIDI.)
+      // CLAP has no generic typed event for these; forward as raw MIDI.
       n.header.type = CLAP_EVENT_MIDI;
       n.header.size = sizeof(clap_event_midi_t);
 

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cassert>
+#include <cstring>
 
 namespace Clap::AUv2
 {
@@ -15,6 +16,23 @@ inline clap_beattime doubleToBeatTime(double t)
 inline clap_sectime doubleToSecTime(double t)
 {
   return round(t * CLAP_SECTIME_FACTOR);
+}
+
+// Decide which note dialect we feed the plugin on the input path.
+// A CLAP plugin's preferred_dialect is guaranteed to be one of its supported
+// dialects, but be defensive: if the preferred dialect is somehow not offered
+// (or no note-port info was captured), fall back to the first dialect the port
+// does support, favouring typed CLAP notes over raw MIDI.
+static uint32_t chooseInputDialect(uint32_t preferred, uint32_t supported)
+{
+  if (supported == 0) return preferred;  // no note-port info: trust preferred
+  if (supported & preferred) return preferred;
+  for (uint32_t dialect : {CLAP_NOTE_DIALECT_CLAP, CLAP_NOTE_DIALECT_MIDI,
+                           CLAP_NOTE_DIALECT_MIDI_MPE, CLAP_NOTE_DIALECT_MIDI2})
+  {
+    if (supported & dialect) return dialect;
+  }
+  return preferred;
 }
 
 ProcessAdapter::~ProcessAdapter()
@@ -43,14 +61,19 @@ void ProcessAdapter::setupProcessing(ausdk::AUScope &audioInputs, ausdk::AUScope
                                      const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
                                      Clap::IAutomation *automationInterface, ParameterTree *parameters,
                                      IMIDIOutputs *midiouts, uint32_t numMaxSamples,
-                                     uint32_t preferredMIDIDialect)
+                                     uint32_t preferredMIDIDialect, uint32_t supportedMIDIDialects,
+                                     uint32_t clapAudioInputs, uint32_t clapAudioOutputs)
 {
   _plugin = plugin;
   _ext_params = ext_params;
   _automation = automationInterface;
   _parameters = parameters;
 
-  _preferred_midi_dialect = preferredMIDIDialect;
+  _supported_midi_dialects = supportedMIDIDialects;
+  _preferred_midi_dialect = chooseInputDialect(preferredMIDIDialect, supportedMIDIDialects);
+
+  _clapNumInputs = clapAudioInputs;
+  _clapNumOutputs = clapAudioOutputs;
 
   _midiouts = midiouts;
 
@@ -71,7 +94,10 @@ void ProcessAdapter::setupProcessing(ausdk::AUScope &audioInputs, ausdk::AUScope
   _numInputs = _audioInputScope->GetNumberOfElements();
   _numOutputs = _audioOutputScope->GetNumberOfElements();
 
-  _processData.audio_inputs_count = _numInputs;
+  // The plugin is handed its own declared port counts, which may be fewer than
+  // the AU-scope element counts (a note-only plugin gets a placeholder silent AU
+  // output bus but zero CLAP audio ports).
+  _processData.audio_inputs_count = _clapNumInputs;
   delete[] _input_ports;
   _input_ports = nullptr;
 
@@ -97,7 +123,7 @@ void ProcessAdapter::setupProcessing(ausdk::AUScope &audioInputs, ausdk::AUScope
     _processData.audio_inputs = nullptr;
   }
 
-  _processData.audio_outputs_count = _numOutputs;
+  _processData.audio_outputs_count = _clapNumOutputs;
   delete[] _output_ports;
   _output_ports = nullptr;
 
@@ -265,6 +291,12 @@ void ProcessAdapter::process(ProcessData &data)
     {
       assert(myOutBuffers.mBuffers[j].mNumberChannels == 1);
       this->_output_ports[i].data32[j] = (float *)myOutBuffers.mBuffers[j].mData;
+      // placeholder AU output busses beyond the plugin's declared CLAP ports are
+      // not written by the plugin, so emit silence rather than leaving them stale.
+      if (i >= _clapNumOutputs)
+      {
+        std::memset(this->_output_ports[i].data32[j], 0, sizeof(float) * data.numSamples);
+      }
     }
   }
 #endif
@@ -276,6 +308,7 @@ void ProcessAdapter::process(ProcessData &data)
   // clean up and prepare the events for the next cycle
   _events.clear();
   _eventindices.clear();
+  _sysexBuffers.clear();
 }
 
 uint32_t ProcessAdapter::input_events_size(const struct clap_input_events *list)
@@ -313,12 +346,6 @@ bool ProcessAdapter::output_events_try_push(const struct clap_output_events *lis
 
 bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
 {
-#if 0
-  clap_multi_event e;
-  memcpy(&e, event, event->size);
-  _outevents.emplace_back(e);
-#endif
-
   switch (event->type)
   {
     case CLAP_EVENT_NOTE_ON:
@@ -335,50 +362,16 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
       return true;
       break;
     case CLAP_EVENT_NOTE_EXPRESSION:
+    {
+      auto nevt = reinterpret_cast<const clap_multi_event_t *>(event);
+      _midiouts->send(*nevt);
       return true;
+    }
       break;
     case CLAP_EVENT_PARAM_VALUE:
     {
       auto ev = (clap_event_param_value *)event;
       _automation->onPerformEdit(ev);
-
-      // auto param = this->_gesturedParameters
-#if 0
-      auto param = (Vst3Parameter*)this->parameters->getParameter(ev->param_id & 0x7FFFFFFF);
-      if (param)
-      {
-        auto param_id = param->getInfo().id;
-
-        // if the parameter is marked as being edited in the UI, pass the value
-        // to the queue so it can be given to the IComponentHandler
-        if (std::find(_gesturedParameters.begin(), _gesturedParameters.end(), param_id) !=
-            _gesturedParameters.end())
-        {
-          _automation->onPerformEdit(ev);
-        }
-
-        // it also needs to be communicated to the audio thread,otherwise the parameter jumps back to the original value
-        Steinberg::int32 index = 0;
-        // addParameterData() does check if there is already a queue and returns it,
-        // actually, it should be called getParameterQueue()
-
-        // the vst3 validator from the VST3 SDK does not provide always an object to output parameters, probably other hosts won't to that, too
-        // therefore we are cautious.
-        if (_vstdata->outputParameterChanges)
-        {
-          auto list = _vstdata->outputParameterChanges->addParameterData(param_id, index);
-
-          // the implementation of addParameterData() in the SDK always returns a queue, but Cubase 12 (perhaps others, too)
-          // sometimes don't return a queue object during the first bunch of process calls. I (df) haven't figured out, why.
-          // therefore we have to check if there is an output queue at all
-          if (list)
-          {
-            Steinberg::int32 index2 = 0;
-            list->addPoint(ev->header.time, param->asVst3Value(ev->value), index2);
-          }
-        }
-      }
-#endif
     }
 
       return true;
@@ -413,8 +406,18 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
       break;
 
     case CLAP_EVENT_MIDI_SYSEX:
-    case CLAP_EVENT_MIDI2:
+    {
+      auto nevt = reinterpret_cast<const clap_multi_event_t *>(event);
+      _midiouts->send(*nevt);
       return true;
+    }
+      break;
+    case CLAP_EVENT_MIDI2:
+    {
+      auto nevt = reinterpret_cast<const clap_multi_event_t *>(event);
+      _midiouts->send(*nevt);
+      return true;
+    }
       break;
     default:
       break;
@@ -486,45 +489,66 @@ void ProcessAdapter::addMIDIEvent(UInt32 inStatus, UInt32 inData1, UInt32 inData
       // no running status
       break;
     case 8:  // note off
-
-      if (_preferred_midi_dialect == CLAP_NOTE_DIALECT_CLAP)
-      {
-        n.header.type = CLAP_EVENT_NOTE_OFF;
-        n.header.size = sizeof(clap_event_note_t);
-
-        n.note.port_index = 0;
-        n.note.note_id = -1;
-        n.note.key = (inData1 & 0x7F);
-        n.note.velocity = 1.f * (inData2 & 0x7F) / 127.f;
-        n.note.channel = channel;
-      }
-      else
-      {
-        n.header.type = CLAP_EVENT_MIDI;
-        n.header.size = sizeof(clap_event_midi_t);
-
-        n.midi.port_index = 0;
-        n.midi.data[0] = inStatus;
-        n.midi.data[1] = inData1;
-        n.midi.data[2] = inData2;
-      }
-      this->_eventindices.emplace_back((this->_events.size()));
-      this->_events.emplace_back(n);
-      removeFromActiveNotes(&n.note);
-      this->output_events_try_push(&this->_out_events, &n.header);
-      break;
     case 9:  // note on
+    {
+      const bool noteOn = (strippedStatus == 9);
+      switch (_preferred_midi_dialect)
+      {
+        case CLAP_NOTE_DIALECT_CLAP:
+          n.header.type = noteOn ? CLAP_EVENT_NOTE_ON : CLAP_EVENT_NOTE_OFF;
+          n.header.size = sizeof(clap_event_note_t);
 
+          n.note.port_index = 0;
+          n.note.note_id = -1;
+          n.note.key = (inData1 & 0x7F);
+          n.note.velocity = 1.f * (inData2 & 0x7F) / 127.f;
+          n.note.channel = channel;
+          break;
+        case CLAP_NOTE_DIALECT_MIDI:
+        case CLAP_NOTE_DIALECT_MIDI_MPE:
+        case CLAP_NOTE_DIALECT_MIDI2:
+        default:
+          // A legacy MIDI1 source note maps to raw MIDI for every non-CLAP
+          // dialect. (Synthesising MIDI2/UMP from a MIDI1 source, when a plugin
+          // prefers MIDI2, is handled on the UMP path, not here.)
+          n.header.type = CLAP_EVENT_MIDI;
+          n.header.size = sizeof(clap_event_midi_t);
+
+          n.midi.port_index = 0;
+          n.midi.data[0] = inStatus;
+          n.midi.data[1] = inData1;
+          n.midi.data[2] = inData2;
+          break;
+      }
+      this->_eventindices.emplace_back((this->_events.size()));
+      this->_events.emplace_back(n);
+      // Active-note bookkeeping backs note-expression translation and is only
+      // meaningful for typed CLAP notes; the n.note union fields are only valid
+      // when the CLAP branch above populated them.
       if (_preferred_midi_dialect == CLAP_NOTE_DIALECT_CLAP)
       {
-        n.header.type = CLAP_EVENT_NOTE_ON;
-        n.header.size = sizeof(clap_event_note_t);
+        if (noteOn)
+          addToActiveNotes(&n.note);
+        else
+          removeFromActiveNotes(&n.note);
+      }
+      break;
+    }
+    case 0xA:  // polyphonic (per-key) pressure / aftertouch
+      if (_preferred_midi_dialect == CLAP_NOTE_DIALECT_CLAP)
+      {
+        // translate to a per-note pressure expression. note_id is a wildcard
+        // (-1) because notes created on the MIDI input path have no id; the
+        // key+channel identify the target note.
+        n.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+        n.header.size = sizeof(clap_event_note_expression_t);
 
-        n.note.port_index = 0;
-        n.note.note_id = -1;
-        n.note.key = (inData1 & 0x7F);
-        n.note.velocity = 1.f * (inData2 & 0x7F) / 127.f;
-        n.note.channel = channel;
+        n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
+        n.noteexpression.note_id = -1;
+        n.noteexpression.port_index = 0;
+        n.noteexpression.channel = channel;
+        n.noteexpression.key = (inData1 & 0x7F);
+        n.noteexpression.value = 1.0 * (inData2 & 0x7F) / 127.0;  // range 0..1
       }
       else
       {
@@ -536,19 +560,15 @@ void ProcessAdapter::addMIDIEvent(UInt32 inStatus, UInt32 inData1, UInt32 inData
         n.midi.data[1] = inData1;
         n.midi.data[2] = inData2;
       }
-
       this->_eventindices.emplace_back((this->_events.size()));
       this->_events.emplace_back(n);
-      addToActiveNotes(&n.note);
-
-      this->output_events_try_push(&this->_out_events, &n.header);
-
       break;
-    case 0xA:  // any other MIDI message with 1 or 2 data bytes
-    case 0xB:
-    case 0xC:
-    case 0xD:
-    case 0xE:
+    case 0xB:  // control change
+    case 0xC:  // program change (2 bytes)
+    case 0xD:  // channel pressure (2 bytes)
+    case 0xE:  // pitch bend
+      // CLAP has no generic typed event for these; forward as raw MIDI. (This
+      // matches the VST3 wrapper, which also reconstructs them as raw MIDI.)
       n.header.type = CLAP_EVENT_MIDI;
       n.header.size = sizeof(clap_event_midi_t);
 
@@ -562,6 +582,154 @@ void ProcessAdapter::addMIDIEvent(UInt32 inStatus, UInt32 inData1, UInt32 inData
       break;
     case 0xF:
       break;
+  }
+}
+
+void ProcessAdapter::addMIDI2Event(const uint32_t *words, uint32_t nWords, UInt32 inOffsetSampleFrame)
+{
+  if (!words || nWords == 0) return;
+
+  auto deltaFrames = inOffsetSampleFrame & kMusicDeviceSampleFrameMask_SampleOffset;
+  bool live = (inOffsetSampleFrame & kMusicDeviceSampleFrameMask_IsScheduled) != 0;
+
+  clap_multi_event n;
+  n.header.time = deltaFrames;
+  n.header.type = CLAP_EVENT_MIDI2;
+  n.header.size = sizeof(clap_event_midi2_t);
+  n.header.flags = 0 + (live ? CLAP_EVENT_IS_LIVE : 0);
+  n.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+
+  n.midi2.port_index = 0;
+  n.midi2.data[0] = words[0];
+  n.midi2.data[1] = (nWords > 1) ? words[1] : 0;
+  n.midi2.data[2] = (nWords > 2) ? words[2] : 0;
+  n.midi2.data[3] = (nWords > 3) ? words[3] : 0;
+
+  this->_eventindices.emplace_back(this->_events.size());
+  this->_events.emplace_back(n);
+}
+
+void ProcessAdapter::addSysExEvent(const uint8_t *data, uint32_t length, UInt32 inOffsetSampleFrame)
+{
+  if (!data || length == 0) return;
+
+  auto deltaFrames = inOffsetSampleFrame & kMusicDeviceSampleFrameMask_SampleOffset;
+  bool live = (inOffsetSampleFrame & kMusicDeviceSampleFrameMask_IsScheduled) != 0;
+
+  // keep the payload alive until the plugin consumes it during process()
+  _sysexBuffers.emplace_back(data, data + length);
+  const auto &owned = _sysexBuffers.back();
+
+  clap_multi_event n;
+  n.header.time = deltaFrames;
+  n.header.type = CLAP_EVENT_MIDI_SYSEX;
+  n.header.size = sizeof(clap_event_midi_sysex_t);
+  n.header.flags = 0 + (live ? CLAP_EVENT_IS_LIVE : 0);
+  n.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+
+  n.sysex.port_index = 0;
+  n.sysex.buffer = owned.data();
+  n.sysex.size = static_cast<uint32_t>(owned.size());
+
+  this->_eventindices.emplace_back(this->_events.size());
+  this->_events.emplace_back(n);
+}
+
+void ProcessAdapter::startNote(int32_t note_id, int16_t channel, float pitch, float velocity,
+                               UInt32 inOffsetSampleFrame)
+{
+  auto deltaFrames = inOffsetSampleFrame & kMusicDeviceSampleFrameMask_SampleOffset;
+  bool live = (inOffsetSampleFrame & kMusicDeviceSampleFrameMask_IsScheduled) != 0;
+  const int16_t key = static_cast<int16_t>(note_id & 0x7F);
+
+  clap_multi_event n;
+  n.header.time = deltaFrames;
+  n.header.flags = 0 + (live ? CLAP_EVENT_IS_LIVE : 0);
+  n.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+
+  if (_preferred_midi_dialect == CLAP_NOTE_DIALECT_CLAP)
+  {
+    n.header.type = CLAP_EVENT_NOTE_ON;
+    n.header.size = sizeof(clap_event_note_t);
+    n.note.port_index = 0;
+    n.note.note_id = note_id;
+    n.note.channel = channel;
+    n.note.key = key;
+    n.note.velocity = velocity / 127.0;
+    this->_eventindices.emplace_back(this->_events.size());
+    this->_events.emplace_back(n);
+    addToActiveNotes(&n.note);
+
+    // carry the fractional part of the pitch as a per-note tuning expression
+    const double frac = static_cast<double>(pitch) - static_cast<double>(key);
+    if (frac != 0.0)
+    {
+      clap_multi_event t;
+      t.header.time = deltaFrames;
+      t.header.flags = n.header.flags;
+      t.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+      t.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+      t.header.size = sizeof(clap_event_note_expression_t);
+      t.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;  // semitones
+      t.noteexpression.note_id = note_id;
+      t.noteexpression.port_index = 0;
+      t.noteexpression.channel = channel;
+      t.noteexpression.key = key;
+      t.noteexpression.value = frac;
+      this->_eventindices.emplace_back(this->_events.size());
+      this->_events.emplace_back(t);
+    }
+  }
+  else
+  {
+    float v = velocity;
+    if (v < 0.f) v = 0.f;
+    if (v > 127.f) v = 127.f;
+    n.header.type = CLAP_EVENT_MIDI;
+    n.header.size = sizeof(clap_event_midi_t);
+    n.midi.port_index = 0;
+    n.midi.data[0] = static_cast<uint8_t>(0x90u | (channel & 0x0F));
+    n.midi.data[1] = static_cast<uint8_t>(key & 0x7F);
+    n.midi.data[2] = static_cast<uint8_t>(v);
+    this->_eventindices.emplace_back(this->_events.size());
+    this->_events.emplace_back(n);
+  }
+}
+
+void ProcessAdapter::stopNote(int32_t note_id, int16_t channel, UInt32 inOffsetSampleFrame)
+{
+  auto deltaFrames = inOffsetSampleFrame & kMusicDeviceSampleFrameMask_SampleOffset;
+  bool live = (inOffsetSampleFrame & kMusicDeviceSampleFrameMask_IsScheduled) != 0;
+  const int16_t key = static_cast<int16_t>(note_id & 0x7F);
+
+  clap_multi_event n;
+  n.header.time = deltaFrames;
+  n.header.flags = 0 + (live ? CLAP_EVENT_IS_LIVE : 0);
+  n.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+
+  if (_preferred_midi_dialect == CLAP_NOTE_DIALECT_CLAP)
+  {
+    n.header.type = CLAP_EVENT_NOTE_OFF;
+    n.header.size = sizeof(clap_event_note_t);
+    n.note.port_index = 0;
+    n.note.note_id = note_id;
+    n.note.channel = channel;
+    n.note.key = key;
+    n.note.velocity = 0.0;
+    this->_eventindices.emplace_back(this->_events.size());
+    this->_events.emplace_back(n);
+    removeFromActiveNotes(&n.note);
+  }
+  else
+  {
+    n.header.type = CLAP_EVENT_MIDI;
+    n.header.size = sizeof(clap_event_midi_t);
+    n.midi.port_index = 0;
+    n.midi.data[0] = static_cast<uint8_t>(0x80u | (channel & 0x0F));
+    n.midi.data[1] = static_cast<uint8_t>(key & 0x7F);
+    n.midi.data[2] = 0;
+    this->_eventindices.emplace_back(this->_events.size());
+    this->_events.emplace_back(n);
   }
 }
 

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -57,9 +57,6 @@ void ProcessAdapter::setupProcessing(ausdk::AUScope &audioInputs, ausdk::AUScope
   _preferred_midi_dialect =
       ClapWrapper::detail::shared::chooseInputDialect(preferredMIDIDialect, supportedMIDIDialects);
 
-  _clapNumInputs = clapAudioInputs;
-  _clapNumOutputs = clapAudioOutputs;
-
   _midiouts = midiouts;
 
   // rewrite the buffer structures
@@ -78,6 +75,14 @@ void ProcessAdapter::setupProcessing(ausdk::AUScope &audioInputs, ausdk::AUScope
 
   _numInputs = _audioInputScope->GetNumberOfElements();
   _numOutputs = _audioOutputScope->GetNumberOfElements();
+
+  // Never hand the plugin more ports than _input_ports/_output_ports have
+  // elements: the AU element counts were fixed at PostConstructor, while the
+  // CLAP counts are re-queried on every (re)activation — a plugin that rescans
+  // its audio ports while deactivated could otherwise make process() index past
+  // the allocation, or receive a null pointer with a non-zero count.
+  _clapNumInputs = std::min(clapAudioInputs, _numInputs);
+  _clapNumOutputs = std::min(clapAudioOutputs, _numOutputs);
 
   // The plugin is handed its own declared port counts, which may be fewer than
   // the AU-scope element counts (a note-only plugin gets a placeholder silent AU
@@ -156,6 +161,7 @@ void ProcessAdapter::setupProcessing(ausdk::AUScope &audioInputs, ausdk::AUScope
   _events.reserve(8192);
   _eventindices.clear();
   _eventindices.reserve(_events.capacity());
+  _sysexBuffers.prepare(16);
 
   _out_events.ctx = this;
 
@@ -183,6 +189,20 @@ void ProcessAdapter::sortEventIndices()
 
 void ProcessAdapter::process(ProcessData &data)
 {
+  // CLAP requires event times within [0, frames_count); a host stamping
+  // MIDIEventList packets with out-of-range timestamps (e.g. mach host time
+  // instead of sample offsets) would otherwise make plugins that index their
+  // buffers by event time read out of bounds — clamp into the block.
+  if (data.numSamples > 0)
+  {
+    for (auto &e : _events)
+    {
+      if (e.header.time >= data.numSamples)
+      {
+        e.header.time = data.numSamples - 1;
+      }
+    }
+  }
   sortEventIndices();
   _processData.frames_count = data.numSamples;
   _transport.flags = 0;
@@ -293,7 +313,7 @@ void ProcessAdapter::process(ProcessData &data)
   // clean up and prepare the events for the next cycle
   _events.clear();
   _eventindices.clear();
-  _sysexBuffers.clear();
+  _sysexBuffers.reset();
 }
 
 uint32_t ProcessAdapter::input_events_size(const struct clap_input_events *list)
@@ -476,7 +496,8 @@ void ProcessAdapter::addMIDIEvent(UInt32 inStatus, UInt32 inData1, UInt32 inData
     case 8:  // note off
     case 9:  // note on
     {
-      const bool noteOn = (strippedStatus == 9);
+      // MIDI 1.0 running-status convention: a note-on with velocity 0 is a note-off
+      const bool noteOn = (strippedStatus == 9) && ((inData2 & 0x7F) != 0);
       switch (_preferred_midi_dialect)
       {
         case CLAP_NOTE_DIALECT_CLAP:
@@ -648,8 +669,7 @@ void ProcessAdapter::addSysExEvent(const uint8_t *data, uint32_t length, UInt32 
   bool live = (inOffsetSampleFrame & kMusicDeviceSampleFrameMask_IsScheduled) != 0;
 
   // keep the payload alive until the plugin consumes it during process()
-  _sysexBuffers.emplace_back(data, data + length);
-  const auto &owned = _sysexBuffers.back();
+  const auto &owned = _sysexBuffers.acquire(data, length);
 
   clap_multi_event n;
   n.header.time = deltaFrames;

--- a/src/detail/auv2/process.h
+++ b/src/detail/auv2/process.h
@@ -29,6 +29,7 @@
 #include <AudioToolbox/AudioUnitUtilities.h>
 #include <AudioUnit/AUComponent.h>
 #include "../clap/automation.h"
+#include "../shared/midi_translation.h"
 #include "parameter.h"
 #include <map>
 
@@ -175,8 +176,9 @@ class ProcessAdapter
 
   // owns the payloads referenced by CLAP_EVENT_MIDI_SYSEX events for the
   // duration of one process() cycle (clap_event_midi_sysex_t only borrows a
-  // pointer). Cleared together with _events at the end of each cycle.
-  std::vector<std::vector<uint8_t>> _sysexBuffers;
+  // pointer). Reset together with _events at the end of each cycle; buffers
+  // are pooled so steady-state cycles do not allocate on the audio thread.
+  ClapWrapper::detail::shared::SysExBufferPool _sysexBuffers;
 
   std::vector<clap_multi_event_t> _outevents;
 

--- a/src/detail/auv2/process.h
+++ b/src/detail/auv2/process.h
@@ -76,6 +76,7 @@ typedef union clap_multi_event
   clap_event_note_t note;
   clap_event_midi_t midi;
   clap_event_midi_sysex_t sysex;
+  clap_event_midi2_t midi2;
   clap_event_param_value_t param;
   clap_event_note_expression_t noteexpression;
 } clap_multi_event_t;
@@ -93,13 +94,23 @@ class ProcessAdapter
   void setupProcessing(ausdk::AUScope &audioInputs, ausdk::AUScope &audioOutputs,
                        const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
                        Clap::IAutomation *automationInterface, ParameterTree *parameters,
-                       IMIDIOutputs *midiouts, uint32_t numMaxSamples, uint32_t preferredMIDIDialect);
+                       IMIDIOutputs *midiouts, uint32_t numMaxSamples, uint32_t preferredMIDIDialect,
+                       uint32_t supportedMIDIDialects, uint32_t clapAudioInputs,
+                       uint32_t clapAudioOutputs);
 
   void process(ProcessData &data);  // AU Data
   void flush();
 
   // interface for AUv2 wrapper:
   void addMIDIEvent(UInt32 inStatus, UInt32 inData1, UInt32 inData2, UInt32 inOffsetSampleFrame);
+  // a single MIDI 2.0 Universal MIDI Packet message (1..4 words) forwarded raw
+  void addMIDI2Event(const uint32_t *words, uint32_t nWords, UInt32 inOffsetSampleFrame);
+  void addSysExEvent(const uint8_t *data, uint32_t length, UInt32 inOffsetSampleFrame);
+  // MusicDevice extended-note API. note_id doubles as the AU NoteInstanceID and
+  // embeds the MIDI key in its low 7 bits; pitch may be fractional.
+  void startNote(int32_t note_id, int16_t channel, float pitch, float velocity,
+                 UInt32 inOffsetSampleFrame);
+  void stopNote(int32_t note_id, int16_t channel, UInt32 inOffsetSampleFrame);
   void addParameterEvent(const clap_param_info_t &info, double value, uint32_t inOffsetSampleFrame);
   // void startNote()
   ~ProcessAdapter();
@@ -140,8 +151,13 @@ class ProcessAdapter
   };
   std::vector<ActiveNote> _activeNotes;
 
+  // number of AU-scope audio elements (may exceed the CLAP port counts when we
+  // present a placeholder silent bus for a note-only plugin)
   uint32_t _numInputs = 0;
   uint32_t _numOutputs = 0;
+  // the plugin's actually-declared CLAP audio port counts (what we hand the plugin)
+  uint32_t _clapNumInputs = 0;
+  uint32_t _clapNumOutputs = 0;
 
   clap_audio_buffer_t *_input_ports = nullptr;
   clap_audio_buffer_t *_output_ports = nullptr;
@@ -157,9 +173,18 @@ class ProcessAdapter
   std::vector<clap_multi_event_t> _events;
   std::vector<size_t> _eventindices;
 
+  // owns the payloads referenced by CLAP_EVENT_MIDI_SYSEX events for the
+  // duration of one process() cycle (clap_event_midi_sysex_t only borrows a
+  // pointer). Cleared together with _events at the end of each cycle.
+  std::vector<std::vector<uint8_t>> _sysexBuffers;
+
   std::vector<clap_multi_event_t> _outevents;
 
+  // the effective note dialect fed to the plugin on the MIDI input path
+  // (the plugin's preferred_dialect, validated against its supported_dialects)
   uint32_t _preferred_midi_dialect = CLAP_NOTE_DIALECT_CLAP;
+  // the full set of dialects the plugin's input note port advertises
+  uint32_t _supported_midi_dialects = CLAP_NOTE_DIALECT_CLAP;
 
   Clap::IAutomation *_automation = nullptr;
   ParameterTree *_parameters = nullptr;

--- a/src/detail/auv3/auv3_audiounit.mm
+++ b/src/detail/auv3/auv3_audiounit.mm
@@ -119,6 +119,7 @@ class AUv3ImplDetail : public Clap::IHost, public Clap::IAutomation, public os::
 
   // MIDI
   uint32_t _midi_preferred_dialect = CLAP_NOTE_DIALECT_CLAP;
+  uint32_t _midi_supported_dialects = 0;
   bool _midi_wants_midi_input = false;
   std::vector<NSString *> _midiOutputNames;
 
@@ -290,6 +291,7 @@ class AUv3ImplDetail : public Clap::IHost, public Clap::IAutomation, public os::
       if (noteports->get(plugin, 0, true, &info))
       {
         _midi_preferred_dialect = info.preferred_dialect;
+        _midi_supported_dialects = info.supported_dialects;
       }
     }
 
@@ -1239,6 +1241,16 @@ static Clap::Library _library;
   return @[];
 }
 
+// Advertise the MIDI protocol we want our input delivered in. Returning
+// kMIDIProtocol_2_0 tells the host to deliver MIDI 2.0 UMP (via
+// AURenderEventMIDIEventList); we request it only when the hosted CLAP prefers
+// the MIDI2 note dialect. Otherwise MIDI 1.0 flows through the richer byte path.
+- (MIDIProtocolID)audioUnitMIDIProtocol
+{
+  if (_impl && _impl->_midi_preferred_dialect == CLAP_NOTE_DIALECT_MIDI2) return kMIDIProtocol_2_0;
+  return kMIDIProtocol_1_0;
+}
+
 // Sample rate for time-based properties. A CLAP with no audio output ports
 // (note effect → aumi) has an empty output bus array, and indexing it raises
 // NSRangeException — fall back to the input side, then to 0 ("unknown").
@@ -1485,7 +1497,7 @@ static Clap::Library _library;
       (uint32_t)inputChs.size(), inputChs.empty() ? nullptr : inputChs.data(),
       (uint32_t)outputChs.size(), outputChs.empty() ? nullptr : outputChs.data(),
       _impl->_plugin->_plugin, _impl->_plugin->_ext._params, _impl.get(), self.maximumFramesToRender,
-      _impl->_midi_preferred_dialect);
+      _impl->_midi_preferred_dialect, _impl->_midi_supported_dialects);
 
   // Set transport state and musical context blocks
   _impl->_processAdapter->setTransportStateBlock(self.transportStateBlock);
@@ -1500,8 +1512,16 @@ static Clap::Library _library;
     _impl->_processAdapter->_cookieCache = _impl->_paramCookieCache;
   }
 
-  // Set MIDI output block
+  // Set MIDI output block (legacy 3-byte path)
   _impl->_processAdapter->midiOutputEventBlock = self.MIDIOutputEventBlock;
+
+  // Modern MIDI 2.0 / UMP output block + the host's desired output protocol
+  // (macOS 12 / iOS 15+). Preferred over the legacy block when present.
+  if (__builtin_available(macOS 12.0, iOS 15.0, *))
+  {
+    _impl->_processAdapter->midiOutputEventListBlock = self.MIDIOutputEventListBlock;
+    _impl->_processAdapter->hostMIDIProtocol = self.hostMIDIProtocol;
+  }
 
   // Publish the adapter for the render block and flip the flag under the
   // cache mutex BEFORE the plugin may start processing: producers

--- a/src/detail/auv3/process.h
+++ b/src/detail/auv3/process.h
@@ -20,12 +20,14 @@
 
 #import <AudioToolbox/AudioToolbox.h>
 #import <AVFoundation/AVFoundation.h>
+#import <CoreMIDI/CoreMIDI.h>
 #include <vector>
 #include <map>
 #include <unordered_map>
 #include <limits>
 #include "../clap/automation.h"
 #include "../shared/fixedqueue.h"
+#include "../shared/midi_translation.h"
 
 namespace Clap::AUv3
 {
@@ -36,6 +38,7 @@ typedef union clap_multi_event
   clap_event_note_t note;
   clap_event_midi_t midi;
   clap_event_midi_sysex_t sysex;
+  clap_event_midi2_t midi2;
   clap_event_param_value_t param;
   clap_event_note_expression_t noteexpression;
 } clap_multi_event_t;
@@ -52,7 +55,7 @@ class ProcessAdapter
                        uint32_t numOutputBusses, const uint32_t *outputChannelCounts,
                        const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
                        Clap::IAutomation *automation, uint32_t numMaxSamples,
-                       uint32_t preferredMIDIDialect);
+                       uint32_t preferredMIDIDialect, uint32_t supportedMIDIDialects);
 
   // Main render call - invoked from the AUv3 internalRenderBlock.
   // Translates AUv3 events, pulls input, calls CLAP process, and writes output.
@@ -88,8 +91,18 @@ class ProcessAdapter
   // cycles ran). Only legal when the render thread is quiesced.
   bool dequeueParameterChange(QueuedParamChange &out);
 
-  // MIDI output event block (set by the AU host)
+  // MIDI output event block (set by the AU host) — legacy 3-byte MIDI 1.0 path
   AUMIDIOutputEventBlock __nullable midiOutputEventBlock;
+
+  // Modern MIDI 2.0 / Universal MIDI Packet output block (macOS 12 / iOS 15+),
+  // preferred over midiOutputEventBlock when the host provides it. Captured at
+  // allocate time like midiOutputEventBlock.
+  API_AVAILABLE(macos(12.0), ios(15.0))
+  AUMIDIEventListBlock __nullable midiOutputEventListBlock;
+
+  // Protocol the host wants our MIDI output delivered in (set from the AU's
+  // hostMIDIProtocol property). Read at render time when building the UMP output.
+  MIDIProtocolID hostMIDIProtocol = kMIDIProtocol_1_0;
 
  private:
   static uint32_t input_events_size(const struct clap_input_events *list);
@@ -102,6 +115,11 @@ class ProcessAdapter
   bool enqueueOutputEvent(const clap_event_header_t *event);
   void translateAUv3Events(const AURenderEvent *head, AUEventSampleTime bufferStartTime,
                            AVAudioFrameCount frameCount);
+
+  // Translate one MIDI 1.0 channel-voice message (3 bytes) into CLAP events using
+  // the canonical rich mapping. Shared by the legacy AURenderEventMIDI path and
+  // the MIDI 1.0 messages arriving inside a UMP AURenderEventMIDIEventList.
+  void translateMidi1Bytes(uint8_t status, uint8_t data1, uint8_t data2, uint32_t sampleOffset);
 
   // Post-sort pass that guards against the AU scheduler reordering
   // same-block NOTE_ON/NOTE_OFF pairs. See process.mm for the full
@@ -139,6 +157,14 @@ class ProcessAdapter
   std::vector<clap_multi_event_t> _outevents;
 
   uint32_t _preferred_midi_dialect = CLAP_NOTE_DIALECT_CLAP;
+  bool _midi_understands_midi2 = false;
+
+  // reassembles UMP SysEx7 across multi-packet messages on input
+  ClapWrapper::detail::shared::SysEx7Reassembler _sysexReassembler;
+  // owns the payloads referenced by CLAP_EVENT_MIDI_SYSEX events assembled from
+  // UMP for one process() cycle (clap_event_midi_sysex_t only borrows a pointer);
+  // cleared at the top of each cycle.
+  std::vector<std::vector<uint8_t>> _sysexBuffers;
 
   // Active note tracking for note expression targeting
   struct ActiveNote

--- a/src/detail/auv3/process.h
+++ b/src/detail/auv3/process.h
@@ -100,8 +100,10 @@ class ProcessAdapter
   API_AVAILABLE(macos(12.0), ios(15.0))
   AUMIDIEventListBlock __nullable midiOutputEventListBlock;
 
-  // Protocol the host wants our MIDI output delivered in (set from the AU's
-  // hostMIDIProtocol property). Read at render time when building the UMP output.
+  // Protocol the host negotiated via the AU's hostMIDIProtocol property. The
+  // UMP output list is deliberately always built as protocol-1.0 — the
+  // framework up-converts it to this protocol; kept for future native
+  // MIDI 2.0 output.
   MIDIProtocolID hostMIDIProtocol = kMIDIProtocol_1_0;
 
  private:
@@ -163,8 +165,14 @@ class ProcessAdapter
   ClapWrapper::detail::shared::SysEx7Reassembler _sysexReassembler;
   // owns the payloads referenced by CLAP_EVENT_MIDI_SYSEX events assembled from
   // UMP for one process() cycle (clap_event_midi_sysex_t only borrows a pointer);
-  // cleared at the top of each cycle.
-  std::vector<std::vector<uint8_t>> _sysexBuffers;
+  // reset at the top of each cycle. Pooled, so steady-state cycles do not
+  // allocate on the render thread.
+  ClapWrapper::detail::shared::SysExBufferPool _sysexBuffers;
+  // owns the payloads of CLAP_EVENT_MIDI_SYSEX events the plugin pushed to the
+  // output queue: the plugin only guarantees the buffer during try_push, but
+  // _outevents is drained after process() returns; reset together with
+  // _outevents. Pooled like _sysexBuffers.
+  ClapWrapper::detail::shared::SysExBufferPool _sysexOutBuffers;
 
   // Active note tracking for note expression targeting
   struct ActiveNote

--- a/src/detail/auv3/process.mm
+++ b/src/detail/auv3/process.mm
@@ -190,6 +190,8 @@ void ProcessAdapter::setupProcessing(uint32_t numInputBusses, const uint32_t *in
   // than drop events — the vector never shrinks, so it amortizes to zero.
   _outevents.clear();
   _outevents.reserve(8192);
+  _sysexBuffers.prepare(16);
+  _sysexOutBuffers.prepare(16);
 
   _activeNotes.clear();
   _activeNotes.reserve(32);
@@ -579,8 +581,7 @@ void ProcessAdapter::translateAUv3Events(const AURenderEvent *head, AUEventSampl
                 if (_sysexReassembler.feed(w0, w1))
                 {
                   const auto &msg = _sysexReassembler.framedMessage();
-                  _sysexBuffers.emplace_back(msg.begin(), msg.end());
-                  const auto &owned = _sysexBuffers.back();
+                  const auto &owned = _sysexBuffers.acquire(msg.data(), (uint32_t)msg.size());
                   clap_multi_event_t s;
                   memset(&s, 0, sizeof(s));
                   s.header.time = sampleOffset;
@@ -639,7 +640,7 @@ AUAudioUnitStatus ProcessAdapter::process(AudioUnitRenderActionFlags *actionFlag
   // Clear events from previous cycle
   _events.clear();
   _eventindices.clear();
-  _sysexBuffers.clear();
+  _sysexBuffers.reset();
 
   // Deliver host parameter changes queued via queueParameterChange()
   // (AUParameter.setValue while rendering) at the top of this cycle.
@@ -823,7 +824,11 @@ AUAudioUnitStatus ProcessAdapter::process(AudioUnitRenderActionFlags *actionFlag
     }
 
     // Emit one MIDI 1.0 message either as an MT 0x2 UMP word or via the legacy block.
-    auto emitMidi1 = [&](AUEventSampleTime t, const uint8_t *bytes, ByteCount len)
+    // `off` is the sample offset within this render cycle: MIDIEventList packet
+    // timestamps are offsets relative to the AudioTimeStamp the list block is
+    // invoked with (AudioUnitProperties.h), while the legacy 3-byte block takes
+    // absolute sample time.
+    auto emitMidi1 = [&](uint32_t off, const uint8_t *bytes, ByteCount len)
     {
       if (useUMP)
       {
@@ -832,18 +837,18 @@ AUAudioUnitStatus ProcessAdapter::process(AudioUnitRenderActionFlags *actionFlag
           if (!umpCur) return;
           uint32_t w = ClapWrapper::detail::shared::midi1ToUmpWord(bytes[0], len > 1 ? bytes[1] : 0,
                                                                    len > 2 ? bytes[2] : 0);
-          umpCur = MIDIEventListAdd(umpList, sizeof(umpBuffer), umpCur, (MIDITimeStamp)t, 1, &w);
+          umpCur = MIDIEventListAdd(umpList, sizeof(umpBuffer), umpCur, (MIDITimeStamp)off, 1, &w);
         }
       }
       else if (midiOutputEventBlock)
       {
-        midiOutputEventBlock(t, 0, len, bytes);
+        midiOutputEventBlock(timestamp->mSampleTime + off, 0, len, bytes);
       }
     };
 
     for (auto &evt : _outevents)
     {
-      const AUEventSampleTime t = timestamp->mSampleTime + evt.header.time;
+      const uint32_t off = evt.header.time;
       switch (evt.header.type)
       {
         case CLAP_EVENT_PARAM_VALUE:
@@ -865,74 +870,40 @@ AUAudioUnitStatus ProcessAdapter::process(AudioUnitRenderActionFlags *actionFlag
           break;
         }
         case CLAP_EVENT_MIDI:
-          emitMidi1(t, evt.midi.data, 3);
+          emitMidi1(off, evt.midi.data, 3);
           break;
         case CLAP_EVENT_NOTE_ON:
         {
           uint8_t data[3] = {(uint8_t)(0x90 | (evt.note.channel & 0x0F)), (uint8_t)(evt.note.key & 0x7F),
                              (uint8_t)(evt.note.velocity * 127.0f)};
-          emitMidi1(t, data, 3);
+          emitMidi1(off, data, 3);
           break;
         }
         case CLAP_EVENT_NOTE_OFF:
         {
           uint8_t data[3] = {(uint8_t)(0x80 | (evt.note.channel & 0x0F)), (uint8_t)(evt.note.key & 0x7F),
                              (uint8_t)(evt.note.velocity * 127.0f)};
-          emitMidi1(t, data, 3);
+          emitMidi1(off, data, 3);
           break;
         }
         case CLAP_EVENT_NOTE_EXPRESSION:
         {
-          auto &ne = evt.noteexpression;
-          if (ne.expression_id == CLAP_NOTE_EXPRESSION_PRESSURE && ne.key >= 0)
-          {
-            // Per-note pressure → Poly Aftertouch
-            uint8_t data[3] = {(uint8_t)(0xA0 | (ne.channel >= 0 ? ne.channel & 0x0F : 0)),
-                               (uint8_t)(ne.key & 0x7F),
-                               (uint8_t)(std::clamp(ne.value, 0.0, 1.0) * 127.0)};
-            emitMidi1(t, data, 3);
-          }
-          else if (ne.expression_id == CLAP_NOTE_EXPRESSION_PRESSURE && ne.key < 0)
-          {
-            // Channel-wide pressure → Channel Pressure
-            uint8_t data[2] = {(uint8_t)(0xD0 | (ne.channel >= 0 ? ne.channel & 0x0F : 0)),
-                               (uint8_t)(std::clamp(ne.value, 0.0, 1.0) * 127.0)};
-            emitMidi1(t, data, 2);
-          }
-          else if (ne.expression_id == CLAP_NOTE_EXPRESSION_TUNING)
-          {
-            // Tuning → Pitch Bend (±2 semitone range)
-            double normalized = std::clamp(ne.value / 2.0, -1.0, 1.0);
-            uint16_t bendValue = (uint16_t)((normalized + 1.0) * 8192.0);
-            if (bendValue > 16383) bendValue = 16383;
-            uint8_t data[3] = {(uint8_t)(0xE0 | (ne.channel >= 0 ? ne.channel & 0x0F : 0)),
-                               (uint8_t)(bendValue & 0x7F), (uint8_t)((bendValue >> 7) & 0x7F)};
-            emitMidi1(t, data, 3);
-          }
-          // Other expression types (volume, pan, vibrato, brightness) have no MIDI 1.0 equivalent
+          // Pressure maps to poly/channel aftertouch and tuning to pitch bend;
+          // expressions MIDI 1.0 cannot represent (volume/pan/vibrato/…) are dropped.
+          uint8_t data[3];
+          int len = ClapWrapper::detail::shared::noteExpressionToMidi1(evt.noteexpression, data);
+          if (len > 0) emitMidi1(off, data, (ByteCount)len);
           break;
         }
         case CLAP_EVENT_MIDI2:
         {
-          if (useUMP)
-          {
-            if (__builtin_available(macOS 12.0, iOS 15.0, *))
-            {
-              if (umpCur)
-              {
-                uint32_t nWords = ClapWrapper::detail::shared::umpMessageWordCount(evt.midi2.data[0]);
-                umpCur = MIDIEventListAdd(umpList, sizeof(umpBuffer), umpCur, (MIDITimeStamp)t, nWords,
-                                          evt.midi2.data);
-              }
-            }
-          }
-          else
-          {
-            // no UMP output available: down-convert to MIDI 1.0
-            uint8_t bytes[3];
-            int len = ClapWrapper::detail::shared::midi2ChannelVoiceToMidi1(evt.midi2.data, bytes);
-            if (len > 0) emitMidi1(t, bytes, (ByteCount)len);
-          }
+          // The output list is declared kMIDIProtocol_1_0, and MT-0x4 words are
+          // only valid in a MIDI 2.0 protocol stream — down-convert for both
+          // delivery paths; the framework up-converts the list to the host's
+          // negotiated protocol.
+          uint8_t bytes[3];
+          int len = ClapWrapper::detail::shared::midi2ChannelVoiceToMidi1(evt.midi2.data, bytes);
+          if (len > 0) emitMidi1(off, bytes, (ByteCount)len);
           break;
         }
         case CLAP_EVENT_MIDI_SYSEX:
@@ -948,14 +919,14 @@ AUAudioUnitStatus ProcessAdapter::process(AudioUnitRenderActionFlags *actionFlag
                     if (!umpCur) return;
                     uint32_t words[2] = {w0, w1};
                     umpCur =
-                        MIDIEventListAdd(umpList, sizeof(umpBuffer), umpCur, (MIDITimeStamp)t, 2, words);
+                        MIDIEventListAdd(umpList, sizeof(umpBuffer), umpCur, (MIDITimeStamp)off, 2, words);
                   });
             }
           }
           else if (midiOutputEventBlock)
           {
             // the legacy block accepts an arbitrary-length MIDI 1.0 byte stream
-            midiOutputEventBlock(t, 0, evt.sysex.size, evt.sysex.buffer);
+            midiOutputEventBlock(timestamp->mSampleTime + off, 0, evt.sysex.size, evt.sysex.buffer);
           }
           break;
         }
@@ -973,6 +944,7 @@ AUAudioUnitStatus ProcessAdapter::process(AudioUnitRenderActionFlags *actionFlag
       }
     }
     _outevents.clear();
+    _sysexOutBuffers.reset();
   }
 
 copyOutput:
@@ -1079,6 +1051,13 @@ bool ProcessAdapter::enqueueOutputEvent(const clap_event_header_t *event)
   {
     clap_multi_event_t e;
     memcpy(&e, event, event->size);
+    if (event->space_id == CLAP_CORE_EVENT_SPACE_ID && event->type == CLAP_EVENT_MIDI_SYSEX)
+    {
+      // the sysex payload is only valid during try_push — take an owning copy
+      // into a pooled buffer (steady state does not allocate)
+      if (!e.sysex.buffer || e.sysex.size == 0) return true;  // empty message, nothing to deliver
+      e.sysex.buffer = _sysexOutBuffers.acquire(e.sysex.buffer, e.sysex.size).data();
+    }
     _outevents.emplace_back(e);
     return true;
   }

--- a/src/detail/auv3/process.mm
+++ b/src/detail/auv3/process.mm
@@ -64,12 +64,14 @@ void ProcessAdapter::setupProcessing(uint32_t numInputBusses, const uint32_t *in
                                      uint32_t numOutputBusses, const uint32_t *outputChannelCounts,
                                      const clap_plugin_t *plugin, const clap_plugin_params_t *ext_params,
                                      Clap::IAutomation *automation, uint32_t numMaxSamples,
-                                     uint32_t preferredMIDIDialect)
+                                     uint32_t preferredMIDIDialect, uint32_t supportedMIDIDialects)
 {
   _plugin = plugin;
   _ext_params = ext_params;
   _automation = automation;
-  _preferred_midi_dialect = preferredMIDIDialect;
+  _preferred_midi_dialect =
+      ClapWrapper::detail::shared::chooseInputDialect(preferredMIDIDialect, supportedMIDIDialects);
+  _midi_understands_midi2 = (supportedMIDIDialects & CLAP_NOTE_DIALECT_MIDI2) != 0;
 
   // Setup silent buffers
   if (numMaxSamples > 0)
@@ -309,6 +311,115 @@ void ProcessAdapter::reorderSameSampleOrphanOffs(AVAudioFrameCount frameCount)
   }
 }
 
+void ProcessAdapter::translateMidi1Bytes(uint8_t status, uint8_t data1, uint8_t data2,
+                                         uint32_t sampleOffset)
+{
+  uint8_t strippedStatus = (status >> 4) & 0x0F;
+  uint8_t channel = status & 0x0F;
+
+  clap_multi_event_t n;
+  memset(&n, 0, sizeof(n));
+  n.header.time = sampleOffset;
+  n.header.flags = 0;
+  n.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+
+  if (_preferred_midi_dialect == CLAP_NOTE_DIALECT_CLAP)
+  {
+    if (strippedStatus == 0x09 && data2 > 0)  // Note On
+    {
+      n.header.type = CLAP_EVENT_NOTE_ON;
+      n.header.size = sizeof(clap_event_note_t);
+      n.note.port_index = 0;
+      n.note.note_id = synthesizeNoteId();
+      n.note.key = data1 & 0x7F;
+      n.note.velocity = (float)(data2 & 0x7F) / 127.0f;
+      n.note.channel = channel;
+
+      _eventindices.emplace_back(_events.size());
+      _events.emplace_back(n);
+      addToActiveNotes(&n.note);
+      return;
+    }
+    else if (strippedStatus == 0x08 || (strippedStatus == 0x09 && data2 == 0))  // Note Off
+    {
+      n.header.type = CLAP_EVENT_NOTE_OFF;
+      n.header.size = sizeof(clap_event_note_t);
+      n.note.port_index = 0;
+      n.note.key = data1 & 0x7F;
+      n.note.velocity = (strippedStatus == 0x08) ? (float)(data2 & 0x7F) / 127.0f : 0.0f;
+      n.note.channel = channel;
+      // Pair with the matching NOTE_ON's synthesized id (must run
+      // before removeFromActiveNotes drops the active record).
+      n.note.note_id = lookupNoteId(n.note.port_index, n.note.channel, n.note.key);
+
+      _eventindices.emplace_back(_events.size());
+      _events.emplace_back(n);
+      removeFromActiveNotes(&n.note);
+      return;
+    }
+    else if (strippedStatus == 0x0A)  // Poly Aftertouch → per-note PRESSURE
+    {
+      n.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+      n.header.size = sizeof(clap_event_note_expression_t);
+      n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
+      n.noteexpression.port_index = 0;
+      n.noteexpression.channel = channel;
+      n.noteexpression.key = data1 & 0x7F;
+      n.noteexpression.note_id =
+          lookupNoteId(n.noteexpression.port_index, n.noteexpression.channel, n.noteexpression.key);
+      n.noteexpression.value = (double)(data2 & 0x7F) / 127.0;
+
+      _eventindices.emplace_back(_events.size());
+      _events.emplace_back(n);
+      return;
+    }
+    else if (strippedStatus == 0x0D)  // Channel Pressure → channel-wide PRESSURE
+    {
+      n.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+      n.header.size = sizeof(clap_event_note_expression_t);
+      n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
+      n.noteexpression.port_index = 0;
+      n.noteexpression.channel = channel;
+      n.noteexpression.key = -1;  // wildcard: all keys on this channel
+      n.noteexpression.note_id = -1;
+      n.noteexpression.value = (double)(data1 & 0x7F) / 127.0;
+
+      _eventindices.emplace_back(_events.size());
+      _events.emplace_back(n);
+      return;
+    }
+    else if (strippedStatus == 0x0E)  // Pitch Bend → channel-wide TUNING
+    {
+      n.header.type = CLAP_EVENT_NOTE_EXPRESSION;
+      n.header.size = sizeof(clap_event_note_expression_t);
+      n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;
+      n.noteexpression.port_index = 0;
+      n.noteexpression.channel = channel;
+      n.noteexpression.key = -1;  // wildcard: all keys on this channel
+      n.noteexpression.note_id = -1;
+      // MIDI pitch bend: 14-bit value (0-16383), center at 8192
+      // Convert to CLAP semitones: ±2 semitones (MIDI default range)
+      uint16_t bendValue = ((uint16_t)(data2 & 0x7F) << 7) | (data1 & 0x7F);
+      n.noteexpression.value = ((double)bendValue - 8192.0) / 8192.0 * 2.0;
+
+      _eventindices.emplace_back(_events.size());
+      _events.emplace_back(n);
+      return;
+    }
+  }
+
+  // Fall through for non-note MIDI or MIDI dialect preference
+  n.header.type = CLAP_EVENT_MIDI;
+  n.header.size = sizeof(clap_event_midi_t);
+  n.midi.port_index = 0;
+  n.midi.data[0] = status;
+  n.midi.data[1] = data1;
+  n.midi.data[2] = data2;
+
+  _eventindices.emplace_back(_events.size());
+  _events.emplace_back(n);
+}
+
 void ProcessAdapter::translateAUv3Events(const AURenderEvent *head, AUEventSampleTime bufferStartTime,
                                          AVAudioFrameCount frameCount)
 {
@@ -390,109 +501,7 @@ void ProcessAdapter::translateAUv3Events(const AURenderEvent *head, AUEventSampl
       {
         auto &me = event->MIDI;
         PROCLOG("translateEvent: %02x %02x %02x", (int)me.data[0], (int)me.data[1], (int)me.data[2]);
-        uint8_t status = me.data[0];
-        uint8_t strippedStatus = (status >> 4) & 0x0F;
-        uint8_t channel = status & 0x0F;
-
-        n.header.time = sampleOffset;
-        n.header.flags = 0;
-        n.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
-
-        if (_preferred_midi_dialect == CLAP_NOTE_DIALECT_CLAP)
-        {
-          if (strippedStatus == 0x09 && me.data[2] > 0)  // Note On
-          {
-            n.header.type = CLAP_EVENT_NOTE_ON;
-            n.header.size = sizeof(clap_event_note_t);
-            n.note.port_index = 0;
-            n.note.note_id = synthesizeNoteId();
-            n.note.key = me.data[1] & 0x7F;
-            n.note.velocity = (float)(me.data[2] & 0x7F) / 127.0f;
-            n.note.channel = channel;
-
-            _eventindices.emplace_back(_events.size());
-            _events.emplace_back(n);
-            addToActiveNotes(&n.note);
-            break;
-          }
-          else if (strippedStatus == 0x08 || (strippedStatus == 0x09 && me.data[2] == 0))  // Note Off
-          {
-            n.header.type = CLAP_EVENT_NOTE_OFF;
-            n.header.size = sizeof(clap_event_note_t);
-            n.note.port_index = 0;
-            n.note.key = me.data[1] & 0x7F;
-            n.note.velocity = (strippedStatus == 0x08) ? (float)(me.data[2] & 0x7F) / 127.0f : 0.0f;
-            n.note.channel = channel;
-            // Pair with the matching NOTE_ON's synthesized id (must run
-            // before removeFromActiveNotes drops the active record).
-            n.note.note_id = lookupNoteId(n.note.port_index, n.note.channel, n.note.key);
-
-            _eventindices.emplace_back(_events.size());
-            _events.emplace_back(n);
-            removeFromActiveNotes(&n.note);
-            break;
-          }
-          else if (strippedStatus == 0x0A)  // Poly Aftertouch → per-note PRESSURE
-          {
-            n.header.type = CLAP_EVENT_NOTE_EXPRESSION;
-            n.header.size = sizeof(clap_event_note_expression_t);
-            n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
-            n.noteexpression.port_index = 0;
-            n.noteexpression.channel = channel;
-            n.noteexpression.key = me.data[1] & 0x7F;
-            n.noteexpression.note_id = lookupNoteId(n.noteexpression.port_index,
-                                                    n.noteexpression.channel, n.noteexpression.key);
-            n.noteexpression.value = (double)(me.data[2] & 0x7F) / 127.0;
-
-            _eventindices.emplace_back(_events.size());
-            _events.emplace_back(n);
-            break;
-          }
-          else if (strippedStatus == 0x0D)  // Channel Pressure → channel-wide PRESSURE
-          {
-            n.header.type = CLAP_EVENT_NOTE_EXPRESSION;
-            n.header.size = sizeof(clap_event_note_expression_t);
-            n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_PRESSURE;
-            n.noteexpression.port_index = 0;
-            n.noteexpression.channel = channel;
-            n.noteexpression.key = -1;  // wildcard: all keys on this channel
-            n.noteexpression.note_id = -1;
-            n.noteexpression.value = (double)(me.data[1] & 0x7F) / 127.0;
-
-            _eventindices.emplace_back(_events.size());
-            _events.emplace_back(n);
-            break;
-          }
-          else if (strippedStatus == 0x0E)  // Pitch Bend → channel-wide TUNING
-          {
-            n.header.type = CLAP_EVENT_NOTE_EXPRESSION;
-            n.header.size = sizeof(clap_event_note_expression_t);
-            n.noteexpression.expression_id = CLAP_NOTE_EXPRESSION_TUNING;
-            n.noteexpression.port_index = 0;
-            n.noteexpression.channel = channel;
-            n.noteexpression.key = -1;  // wildcard: all keys on this channel
-            n.noteexpression.note_id = -1;
-            // MIDI pitch bend: 14-bit value (0-16383), center at 8192
-            // Convert to CLAP semitones: ±2 semitones (MIDI default range)
-            uint16_t bendValue = ((uint16_t)(me.data[2] & 0x7F) << 7) | (me.data[1] & 0x7F);
-            n.noteexpression.value = ((double)bendValue - 8192.0) / 8192.0 * 2.0;
-
-            _eventindices.emplace_back(_events.size());
-            _events.emplace_back(n);
-            break;
-          }
-        }
-
-        // Fall through for non-note MIDI or MIDI dialect preference
-        n.header.type = CLAP_EVENT_MIDI;
-        n.header.size = sizeof(clap_event_midi_t);
-        n.midi.port_index = 0;
-        n.midi.data[0] = me.data[0];
-        n.midi.data[1] = me.data[1];
-        n.midi.data[2] = me.data[2];
-
-        _eventindices.emplace_back(_events.size());
-        _events.emplace_back(n);
+        translateMidi1Bytes(me.data[0], me.data[1], me.data[2], sampleOffset);
         break;
       }
 
@@ -514,8 +523,87 @@ void ProcessAdapter::translateAUv3Events(const AURenderEvent *head, AUEventSampl
         break;
       }
 
+      case AURenderEventMIDIEventList:
+      {
+        if (__builtin_available(macOS 12.0, iOS 15.0, *))
+        {
+          const MIDIEventList *evtlist = &event->MIDIEventsList.eventList;
+          const bool midi2 = (evtlist->protocol == kMIDIProtocol_2_0);
+          const MIDIEventPacket *pkt = &evtlist->packet[0];
+          for (UInt32 p = 0; p < evtlist->numPackets; ++p)
+          {
+            for (UInt32 i = 0; i < pkt->wordCount;)
+            {
+              const uint32_t w0 = pkt->words[i];
+              const uint32_t nWords = ClapWrapper::detail::shared::umpMessageWordCount(w0);
+              if (i + nWords > pkt->wordCount) break;  // truncated packet
+              const uint32_t mt = (w0 >> 28) & 0xFu;
+
+              if (midi2 && mt == 0x4u)
+              {
+                if (_midi_understands_midi2)
+                {
+                  // forward the MIDI 2.0 channel-voice message raw
+                  clap_multi_event_t m;
+                  memset(&m, 0, sizeof(m));
+                  m.header.time = sampleOffset;
+                  m.header.type = CLAP_EVENT_MIDI2;
+                  m.header.size = sizeof(clap_event_midi2_t);
+                  m.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+                  m.midi2.port_index = 0;
+                  m.midi2.data[0] = pkt->words[i];
+                  m.midi2.data[1] = (nWords > 1) ? pkt->words[i + 1] : 0;
+                  m.midi2.data[2] = (nWords > 2) ? pkt->words[i + 2] : 0;
+                  m.midi2.data[3] = (nWords > 3) ? pkt->words[i + 3] : 0;
+                  _eventindices.emplace_back(_events.size());
+                  _events.emplace_back(m);
+                }
+                else
+                {
+                  // plugin doesn't speak MIDI2: down-convert and reuse the
+                  // dialect-aware MIDI 1.0 translation
+                  uint8_t bytes[3];
+                  if (ClapWrapper::detail::shared::midi2ChannelVoiceToMidi1(&pkt->words[i], bytes) > 0)
+                    translateMidi1Bytes(bytes[0], bytes[1], bytes[2], sampleOffset);
+                }
+              }
+              else if (mt == 0x2u)
+              {
+                // MIDI 1.0 channel voice packed in one UMP word
+                translateMidi1Bytes((w0 >> 16) & 0xFF, (w0 >> 8) & 0xFF, w0 & 0xFF, sampleOffset);
+              }
+              else if (mt == 0x3u)
+              {
+                // UMP SysEx7 (may span multiple packets)
+                const uint32_t w1 = (nWords > 1) ? pkt->words[i + 1] : 0u;
+                if (_sysexReassembler.feed(w0, w1))
+                {
+                  const auto &msg = _sysexReassembler.framedMessage();
+                  _sysexBuffers.emplace_back(msg.begin(), msg.end());
+                  const auto &owned = _sysexBuffers.back();
+                  clap_multi_event_t s;
+                  memset(&s, 0, sizeof(s));
+                  s.header.time = sampleOffset;
+                  s.header.type = CLAP_EVENT_MIDI_SYSEX;
+                  s.header.size = sizeof(clap_event_midi_sysex_t);
+                  s.header.space_id = CLAP_CORE_EVENT_SPACE_ID;
+                  s.sysex.port_index = 0;
+                  s.sysex.buffer = owned.data();
+                  s.sysex.size = (uint32_t)owned.size();
+                  _eventindices.emplace_back(_events.size());
+                  _events.emplace_back(s);
+                }
+              }
+              // other message types (utility / system) are not translated
+              i += nWords;
+            }
+            pkt = MIDIEventPacketNext(pkt);
+          }
+        }
+        break;
+      }
+
       default:
-        // AURenderEventMIDIEventList (MIDI 2.0) - not yet supported
         break;
     }
   }
@@ -551,6 +639,7 @@ AUAudioUnitStatus ProcessAdapter::process(AudioUnitRenderActionFlags *actionFlag
   // Clear events from previous cycle
   _events.clear();
   _eventindices.clear();
+  _sysexBuffers.clear();
 
   // Deliver host parameter changes queued via queueParameterChange()
   // (AUParameter.setValue while rendering) at the top of this cycle.
@@ -713,95 +802,178 @@ AUAudioUnitStatus ProcessAdapter::process(AudioUnitRenderActionFlags *actionFlag
   // Process once for all buses
   _plugin->process(_plugin, &_processData);
 
-  // Process output events
-  for (auto &evt : _outevents)
+  // Process output events. Prefer the modern UMP / MIDIEventList block when the
+  // host provided one (built as protocol-1.0 UMP; the framework up-converts to the
+  // host's negotiated protocol), otherwise fall back to the legacy 3-byte block.
+  // Scoped so the earlier `goto copyOutput` (multi-bus copy path) does not jump
+  // across these initializations.
   {
-    switch (evt.header.type)
+    uint8_t umpBuffer[8192];
+    MIDIEventList *umpList = nullptr;
+    MIDIEventPacket *umpCur = nullptr;
+    bool useUMP = false;
+    if (__builtin_available(macOS 12.0, iOS 15.0, *))
     {
-      case CLAP_EVENT_PARAM_VALUE:
-        if (_automation)
-        {
-          _automation->onPerformEdit(&evt.param);
-        }
-        break;
-      case CLAP_EVENT_PARAM_GESTURE_BEGIN:
+      if (midiOutputEventListBlock)
       {
-        auto *ge = (clap_event_param_gesture *)&evt;
-        if (_automation) _automation->onBeginEdit(ge->param_id);
-        break;
+        umpList = (MIDIEventList *)umpBuffer;
+        umpCur = MIDIEventListInit(umpList, kMIDIProtocol_1_0);
+        useUMP = true;
       }
-      case CLAP_EVENT_PARAM_GESTURE_END:
-      {
-        auto *ge = (clap_event_param_gesture *)&evt;
-        if (_automation) _automation->onEndEdit(ge->param_id);
-        break;
-      }
-      case CLAP_EVENT_NOTE_ON:
-      case CLAP_EVENT_NOTE_OFF:
-      case CLAP_EVENT_MIDI:
-      {
-        if (midiOutputEventBlock)
-        {
-          if (evt.header.type == CLAP_EVENT_MIDI)
-          {
-            midiOutputEventBlock(timestamp->mSampleTime + evt.header.time, 0, 3, evt.midi.data);
-          }
-          else if (evt.header.type == CLAP_EVENT_NOTE_ON)
-          {
-            uint8_t data[3] = {(uint8_t)(0x90 | (evt.note.channel & 0x0F)),
-                               (uint8_t)(evt.note.key & 0x7F),
-                               (uint8_t)(uint8_t)(evt.note.velocity * 127.0f)};
-            midiOutputEventBlock(timestamp->mSampleTime + evt.header.time, 0, 3, data);
-          }
-          else if (evt.header.type == CLAP_EVENT_NOTE_OFF)
-          {
-            uint8_t data[3] = {(uint8_t)(0x80 | (evt.note.channel & 0x0F)),
-                               (uint8_t)(evt.note.key & 0x7F),
-                               (uint8_t)(uint8_t)(evt.note.velocity * 127.0f)};
-            midiOutputEventBlock(timestamp->mSampleTime + evt.header.time, 0, 3, data);
-          }
-        }
-        break;
-      }
-      case CLAP_EVENT_NOTE_EXPRESSION:
-      {
-        if (!midiOutputEventBlock) break;
-
-        auto &ne = evt.noteexpression;
-
-        if (ne.expression_id == CLAP_NOTE_EXPRESSION_PRESSURE && ne.key >= 0)
-        {
-          // Per-note pressure → Poly Aftertouch
-          uint8_t data[3] = {(uint8_t)(0xA0 | (ne.channel >= 0 ? ne.channel & 0x0F : 0)),
-                             (uint8_t)(ne.key & 0x7F),
-                             (uint8_t)(std::clamp(ne.value, 0.0, 1.0) * 127.0)};
-          midiOutputEventBlock(timestamp->mSampleTime + evt.header.time, 0, 3, data);
-        }
-        else if (ne.expression_id == CLAP_NOTE_EXPRESSION_PRESSURE && ne.key < 0)
-        {
-          // Channel-wide pressure → Channel Pressure
-          uint8_t data[2] = {(uint8_t)(0xD0 | (ne.channel >= 0 ? ne.channel & 0x0F : 0)),
-                             (uint8_t)(std::clamp(ne.value, 0.0, 1.0) * 127.0)};
-          midiOutputEventBlock(timestamp->mSampleTime + evt.header.time, 0, 2, data);
-        }
-        else if (ne.expression_id == CLAP_NOTE_EXPRESSION_TUNING)
-        {
-          // Tuning → Pitch Bend (±2 semitone range)
-          double normalized = std::clamp(ne.value / 2.0, -1.0, 1.0);
-          uint16_t bendValue = (uint16_t)((normalized + 1.0) * 8192.0);
-          if (bendValue > 16383) bendValue = 16383;
-          uint8_t data[3] = {(uint8_t)(0xE0 | (ne.channel >= 0 ? ne.channel & 0x0F : 0)),
-                             (uint8_t)(bendValue & 0x7F), (uint8_t)((bendValue >> 7) & 0x7F)};
-          midiOutputEventBlock(timestamp->mSampleTime + evt.header.time, 0, 3, data);
-        }
-        // Other expression types (volume, pan, vibrato, brightness) have no MIDI 1.0 equivalent
-        break;
-      }
-      default:
-        break;
     }
+
+    // Emit one MIDI 1.0 message either as an MT 0x2 UMP word or via the legacy block.
+    auto emitMidi1 = [&](AUEventSampleTime t, const uint8_t *bytes, ByteCount len)
+    {
+      if (useUMP)
+      {
+        if (__builtin_available(macOS 12.0, iOS 15.0, *))
+        {
+          if (!umpCur) return;
+          uint32_t w = ClapWrapper::detail::shared::midi1ToUmpWord(bytes[0], len > 1 ? bytes[1] : 0,
+                                                                   len > 2 ? bytes[2] : 0);
+          umpCur = MIDIEventListAdd(umpList, sizeof(umpBuffer), umpCur, (MIDITimeStamp)t, 1, &w);
+        }
+      }
+      else if (midiOutputEventBlock)
+      {
+        midiOutputEventBlock(t, 0, len, bytes);
+      }
+    };
+
+    for (auto &evt : _outevents)
+    {
+      const AUEventSampleTime t = timestamp->mSampleTime + evt.header.time;
+      switch (evt.header.type)
+      {
+        case CLAP_EVENT_PARAM_VALUE:
+          if (_automation)
+          {
+            _automation->onPerformEdit(&evt.param);
+          }
+          break;
+        case CLAP_EVENT_PARAM_GESTURE_BEGIN:
+        {
+          auto *ge = (clap_event_param_gesture *)&evt;
+          if (_automation) _automation->onBeginEdit(ge->param_id);
+          break;
+        }
+        case CLAP_EVENT_PARAM_GESTURE_END:
+        {
+          auto *ge = (clap_event_param_gesture *)&evt;
+          if (_automation) _automation->onEndEdit(ge->param_id);
+          break;
+        }
+        case CLAP_EVENT_MIDI:
+          emitMidi1(t, evt.midi.data, 3);
+          break;
+        case CLAP_EVENT_NOTE_ON:
+        {
+          uint8_t data[3] = {(uint8_t)(0x90 | (evt.note.channel & 0x0F)), (uint8_t)(evt.note.key & 0x7F),
+                             (uint8_t)(evt.note.velocity * 127.0f)};
+          emitMidi1(t, data, 3);
+          break;
+        }
+        case CLAP_EVENT_NOTE_OFF:
+        {
+          uint8_t data[3] = {(uint8_t)(0x80 | (evt.note.channel & 0x0F)), (uint8_t)(evt.note.key & 0x7F),
+                             (uint8_t)(evt.note.velocity * 127.0f)};
+          emitMidi1(t, data, 3);
+          break;
+        }
+        case CLAP_EVENT_NOTE_EXPRESSION:
+        {
+          auto &ne = evt.noteexpression;
+          if (ne.expression_id == CLAP_NOTE_EXPRESSION_PRESSURE && ne.key >= 0)
+          {
+            // Per-note pressure → Poly Aftertouch
+            uint8_t data[3] = {(uint8_t)(0xA0 | (ne.channel >= 0 ? ne.channel & 0x0F : 0)),
+                               (uint8_t)(ne.key & 0x7F),
+                               (uint8_t)(std::clamp(ne.value, 0.0, 1.0) * 127.0)};
+            emitMidi1(t, data, 3);
+          }
+          else if (ne.expression_id == CLAP_NOTE_EXPRESSION_PRESSURE && ne.key < 0)
+          {
+            // Channel-wide pressure → Channel Pressure
+            uint8_t data[2] = {(uint8_t)(0xD0 | (ne.channel >= 0 ? ne.channel & 0x0F : 0)),
+                               (uint8_t)(std::clamp(ne.value, 0.0, 1.0) * 127.0)};
+            emitMidi1(t, data, 2);
+          }
+          else if (ne.expression_id == CLAP_NOTE_EXPRESSION_TUNING)
+          {
+            // Tuning → Pitch Bend (±2 semitone range)
+            double normalized = std::clamp(ne.value / 2.0, -1.0, 1.0);
+            uint16_t bendValue = (uint16_t)((normalized + 1.0) * 8192.0);
+            if (bendValue > 16383) bendValue = 16383;
+            uint8_t data[3] = {(uint8_t)(0xE0 | (ne.channel >= 0 ? ne.channel & 0x0F : 0)),
+                               (uint8_t)(bendValue & 0x7F), (uint8_t)((bendValue >> 7) & 0x7F)};
+            emitMidi1(t, data, 3);
+          }
+          // Other expression types (volume, pan, vibrato, brightness) have no MIDI 1.0 equivalent
+          break;
+        }
+        case CLAP_EVENT_MIDI2:
+        {
+          if (useUMP)
+          {
+            if (__builtin_available(macOS 12.0, iOS 15.0, *))
+            {
+              if (umpCur)
+              {
+                uint32_t nWords = ClapWrapper::detail::shared::umpMessageWordCount(evt.midi2.data[0]);
+                umpCur = MIDIEventListAdd(umpList, sizeof(umpBuffer), umpCur, (MIDITimeStamp)t, nWords,
+                                          evt.midi2.data);
+              }
+            }
+          }
+          else
+          {
+            // no UMP output available: down-convert to MIDI 1.0
+            uint8_t bytes[3];
+            int len = ClapWrapper::detail::shared::midi2ChannelVoiceToMidi1(evt.midi2.data, bytes);
+            if (len > 0) emitMidi1(t, bytes, (ByteCount)len);
+          }
+          break;
+        }
+        case CLAP_EVENT_MIDI_SYSEX:
+        {
+          if (useUMP)
+          {
+            if (__builtin_available(macOS 12.0, iOS 15.0, *))
+            {
+              ClapWrapper::detail::shared::packSysEx7(
+                  evt.sysex.buffer, evt.sysex.size,
+                  [&](uint32_t w0, uint32_t w1)
+                  {
+                    if (!umpCur) return;
+                    uint32_t words[2] = {w0, w1};
+                    umpCur =
+                        MIDIEventListAdd(umpList, sizeof(umpBuffer), umpCur, (MIDITimeStamp)t, 2, words);
+                  });
+            }
+          }
+          else if (midiOutputEventBlock)
+          {
+            // the legacy block accepts an arbitrary-length MIDI 1.0 byte stream
+            midiOutputEventBlock(t, 0, evt.sysex.size, evt.sysex.buffer);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    if (useUMP)
+    {
+      if (__builtin_available(macOS 12.0, iOS 15.0, *))
+      {
+        if (umpList && umpList->numPackets > 0)
+          midiOutputEventListBlock(timestamp->mSampleTime, 0, umpList);
+      }
+    }
+    _outevents.clear();
   }
-  _outevents.clear();
 
 copyOutput:
   // Hand the stored output to the host for this bus. A null mData is the

--- a/src/detail/shared/midi_translation.h
+++ b/src/detail/shared/midi_translation.h
@@ -1,0 +1,245 @@
+#pragma once
+
+/*
+    Shared MIDI translation helpers
+
+    Copyright (c) 2024 the clap-wrapper project
+
+    This file is part of the clap-wrappers project which is released under MIT License.
+    See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+
+    Backend-agnostic, header-only helpers for the format-level parts of MIDI <-> CLAP
+    translation that must behave identically across the AUv2 / AUv3 / AAX wrappers:
+    note-dialect selection, MIDI 1.0 <-> MIDI 2.0 (Universal MIDI Packet) conversion,
+    and UMP SysEx7 packing / reassembly.
+
+    These functions are pure (no wrapper/host state) and deliberately do NOT touch any
+    per-backend event container: each wrapper keeps its own event storage, sample-offset
+    decoding, note-id policy and host I/O, and only calls into here for the fiddly,
+    correctness-critical bit manipulation.
+*/
+
+#include <cstdint>
+#include <vector>
+#include <clap/clap.h>
+
+namespace ClapWrapper::detail::shared
+{
+
+// Decide which note dialect to feed the plugin on the input path.
+// A CLAP plugin's preferred_dialect is guaranteed to be one of its supported
+// dialects, but be defensive: if the preferred dialect is somehow not offered
+// (or no note-port info was captured), fall back to the first dialect the port
+// does support, favouring typed CLAP notes over raw MIDI.
+inline uint32_t chooseInputDialect(uint32_t preferred, uint32_t supported)
+{
+  if (supported == 0) return preferred;  // no note-port info: trust preferred
+  if (supported & preferred) return preferred;
+  for (uint32_t dialect : {CLAP_NOTE_DIALECT_CLAP, CLAP_NOTE_DIALECT_MIDI, CLAP_NOTE_DIALECT_MIDI_MPE,
+                           CLAP_NOTE_DIALECT_MIDI2})
+  {
+    if (supported & dialect) return dialect;
+  }
+  return preferred;
+}
+
+// Number of 32-bit words in a Universal MIDI Packet message, derived from the
+// message type in the high nibble of its first word (MIDI 2.0 UMP spec).
+inline uint32_t umpMessageWordCount(uint32_t word0)
+{
+  switch ((word0 >> 28) & 0xFu)
+  {
+    case 0x0:  // utility
+    case 0x1:  // system real time / common
+    case 0x2:  // MIDI 1.0 channel voice
+    case 0x6:
+    case 0x7:
+      return 1;
+    case 0x3:  // data / SysEx7 (64-bit)
+    case 0x4:  // MIDI 2.0 channel voice
+    case 0x8:
+    case 0x9:
+    case 0xA:
+      return 2;
+    case 0xB:
+    case 0xC:
+      return 3;
+    case 0x5:  // data (128-bit)
+    case 0xD:
+    case 0xE:
+    case 0xF:
+      return 4;
+    default:
+      return 1;
+  }
+}
+
+// Wrap a MIDI 1.0 channel-voice message (status incl. channel, data1, data2) into
+// a single MT 0x2 UMP word, group 0.
+inline uint32_t midi1ToUmpWord(uint8_t status, uint8_t data1, uint8_t data2)
+{
+  return (0x2u << 28) | (0x0u << 24) | (static_cast<uint32_t>(status) << 16) |
+         (static_cast<uint32_t>(data1) << 8) | static_cast<uint32_t>(data2);
+}
+
+// Down-convert a single MIDI 2.0 channel-voice UMP message (MT 0x4) to a MIDI 1.0
+// 3-byte message. Returns the number of MIDI1 bytes written (0 if not convertible).
+// Wide MIDI2 values are reduced by dropping the low bits (16->7, 32->7, 32->14).
+inline int midi2ChannelVoiceToMidi1(const uint32_t data[4], uint8_t out[3])
+{
+  const uint32_t w0 = data[0];
+  const uint32_t w1 = data[1];
+  if (((w0 >> 28) & 0xFu) != 0x4u) return 0;  // only MIDI 2.0 channel voice
+
+  const uint8_t status = static_cast<uint8_t>((w0 >> 16) & 0xF0u);
+  const uint8_t channel = static_cast<uint8_t>((w0 >> 16) & 0x0Fu);
+  const uint8_t index = static_cast<uint8_t>((w0 >> 8) & 0x7Fu);  // note / cc index
+
+  switch (status)
+  {
+    case 0x80:  // note off
+    case 0x90:  // note on
+    {
+      uint8_t vel = static_cast<uint8_t>((w1 >> 16) >> 9);  // 16-bit velocity -> 7-bit
+      // MIDI 2.0 note-on keeps velocity semantics; guard against an accidental
+      // MIDI1 note-off when a non-zero MIDI2 velocity scales down to 0.
+      if (status == 0x90 && vel == 0) vel = 1;
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = index;
+      out[2] = vel;
+      return 3;
+    }
+    case 0xA0:  // poly pressure
+    case 0xB0:  // control change
+    {
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = index;
+      out[2] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
+      return 3;
+    }
+    case 0xC0:  // program change
+    {
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = static_cast<uint8_t>((w1 >> 24) & 0x7Fu);
+      out[2] = 0;
+      return 2;
+    }
+    case 0xD0:  // channel pressure
+    {
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
+      out[2] = 0;
+      return 2;
+    }
+    case 0xE0:  // pitch bend
+    {
+      const uint32_t v14 = w1 >> 18;  // 32-bit -> 14-bit
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = static_cast<uint8_t>(v14 & 0x7Fu);
+      out[2] = static_cast<uint8_t>((v14 >> 7) & 0x7Fu);
+      return 3;
+    }
+    default:
+      return 0;
+  }
+}
+
+// Pack a SysEx payload into MT 0x3 UMP SysEx7 packets. The 0xF0/0xF7 framing is
+// stripped (UMP SysEx7 carries only the content bytes), up to 6 bytes per 64-bit
+// packet, with a status nibble marking complete(0)/start(1)/continue(2)/end(3).
+// `emit(word0, word1)` is invoked once per packet.
+template <class EmitPacket>
+inline void packSysEx7(const uint8_t *data, uint32_t size, EmitPacket &&emit)
+{
+  if (!data || size == 0) return;
+
+  const uint8_t *p = data;
+  uint32_t n = size;
+  if (n > 0 && p[0] == 0xF0)
+  {
+    ++p;
+    --n;
+  }
+  if (n > 0 && p[n - 1] == 0xF7) --n;
+
+  const uint8_t group = 0;
+  uint32_t offset = 0;
+  do
+  {
+    const uint32_t remaining = n - offset;
+    const uint32_t chunk = (remaining > 6) ? 6 : remaining;
+    uint8_t statusNibble;
+    if (n <= 6)
+      statusNibble = 0x0;  // complete in a single packet
+    else if (offset == 0)
+      statusNibble = 0x1;  // start
+    else if (offset + chunk >= n)
+      statusNibble = 0x3;  // end
+    else
+      statusNibble = 0x2;  // continue
+
+    uint8_t b[6] = {0, 0, 0, 0, 0, 0};
+    for (uint32_t k = 0; k < chunk; ++k) b[k] = p[offset + k];
+
+    uint32_t word0 = (0x3u << 28) | (static_cast<uint32_t>(group) << 24) |
+                     (static_cast<uint32_t>(statusNibble) << 20) | (chunk << 16) |
+                     (static_cast<uint32_t>(b[0]) << 8) | static_cast<uint32_t>(b[1]);
+    uint32_t word1 = (static_cast<uint32_t>(b[2]) << 24) | (static_cast<uint32_t>(b[3]) << 16) |
+                     (static_cast<uint32_t>(b[4]) << 8) | static_cast<uint32_t>(b[5]);
+    emit(word0, word1);
+
+    offset += chunk;
+  } while (offset < n);
+}
+
+// Reassembles a UMP SysEx7 (MT 0x3) packet stream into a complete SysEx message.
+// The status nibble marks complete(0)/start(1)/continue(2)/end(3); on complete or
+// end the accumulated content is wrapped in 0xF0/0xF7 framing (matching the CLAP
+// SysEx convention the wrappers use) and made available via framedMessage().
+class SysEx7Reassembler
+{
+ public:
+  // Feed one SysEx7 packet (two UMP words). Returns true when a full message is
+  // ready, at which point framedMessage() holds it.
+  bool feed(uint32_t w0, uint32_t w1)
+  {
+    const uint8_t statusNibble = (w0 >> 20) & 0xFu;
+    const uint8_t numBytes = (w0 >> 16) & 0xFu;
+    const uint8_t bytes[6] = {
+        static_cast<uint8_t>((w0 >> 8) & 0xFFu),  static_cast<uint8_t>(w0 & 0xFFu),
+        static_cast<uint8_t>((w1 >> 24) & 0xFFu), static_cast<uint8_t>((w1 >> 16) & 0xFFu),
+        static_cast<uint8_t>((w1 >> 8) & 0xFFu),  static_cast<uint8_t>(w1 & 0xFFu)};
+
+    if (statusNibble == 0x0 || statusNibble == 0x1) _content.clear();
+    for (uint8_t k = 0; k < numBytes && k < 6; ++k) _content.push_back(bytes[k]);
+
+    if (statusNibble == 0x0 || statusNibble == 0x3)
+    {
+      _framed.clear();
+      _framed.reserve(_content.size() + 2);
+      _framed.push_back(0xF0);
+      _framed.insert(_framed.end(), _content.begin(), _content.end());
+      _framed.push_back(0xF7);
+      _content.clear();
+      return true;
+    }
+    return false;
+  }
+
+  const std::vector<uint8_t> &framedMessage() const
+  {
+    return _framed;
+  }
+
+  void reset()
+  {
+    _content.clear();
+    _framed.clear();
+  }
+
+ private:
+  std::vector<uint8_t> _content;
+  std::vector<uint8_t> _framed;
+};
+
+}  // namespace ClapWrapper::detail::shared

--- a/src/detail/shared/midi_translation.h
+++ b/src/detail/shared/midi_translation.h
@@ -144,6 +144,51 @@ inline int midi2ChannelVoiceToMidi1(const uint32_t data[4], uint8_t out[3])
   }
 }
 
+// Down-convert a CLAP note-expression event to a single MIDI 1.0 channel-voice
+// message: PRESSURE with a key maps to polyphonic key pressure (0xA0), channel-wide
+// PRESSURE (key < 0) to channel pressure (0xD0), and TUNING to pitch bend (0xE0,
+// the conventional ±2 semitone range). Returns the number of MIDI1 bytes written
+// (2 or 3), or 0 for expressions with no MIDI 1.0 equivalent (volume, pan,
+// vibrato, brightness, …).
+inline int noteExpressionToMidi1(const clap_event_note_expression_t &ne, uint8_t out[3])
+{
+  const uint8_t channel = static_cast<uint8_t>(ne.channel >= 0 ? ne.channel & 0x0F : 0);
+  switch (ne.expression_id)
+  {
+    case CLAP_NOTE_EXPRESSION_PRESSURE:
+    {
+      double v = ne.value;
+      if (v < 0.0) v = 0.0;
+      if (v > 1.0) v = 1.0;
+      if (ne.key >= 0)
+      {
+        out[0] = static_cast<uint8_t>(0xA0u | channel);
+        out[1] = static_cast<uint8_t>(ne.key & 0x7F);
+        out[2] = static_cast<uint8_t>(v * 127.0);
+        return 3;
+      }
+      out[0] = static_cast<uint8_t>(0xD0u | channel);
+      out[1] = static_cast<uint8_t>(v * 127.0);
+      out[2] = 0;
+      return 2;
+    }
+    case CLAP_NOTE_EXPRESSION_TUNING:
+    {
+      double normalized = ne.value / 2.0;
+      if (normalized < -1.0) normalized = -1.0;
+      if (normalized > 1.0) normalized = 1.0;
+      uint32_t bend = static_cast<uint32_t>((normalized + 1.0) * 8192.0);
+      if (bend > 16383u) bend = 16383u;
+      out[0] = static_cast<uint8_t>(0xE0u | channel);
+      out[1] = static_cast<uint8_t>(bend & 0x7Fu);
+      out[2] = static_cast<uint8_t>((bend >> 7) & 0x7Fu);
+      return 3;
+    }
+    default:
+      return 0;
+  }
+}
+
 // Pack a SysEx payload into MT 0x3 UMP SysEx7 packets. The 0xF0/0xF7 framing is
 // stripped (UMP SysEx7 carries only the content bytes), up to 6 bytes per 64-bit
 // packet, with a status nibble marking complete(0)/start(1)/continue(2)/end(3).
@@ -240,6 +285,42 @@ class SysEx7Reassembler
  private:
   std::vector<uint8_t> _content;
   std::vector<uint8_t> _framed;
+};
+
+// Per-cycle pool of byte buffers owning SysEx payloads (clap_event_midi_sysex_t
+// only borrows a pointer). acquire() copies into a recycled buffer whose heap
+// capacity survives reset(), so steady-state audio-thread use does not allocate;
+// the pool only grows when one cycle holds more SysEx messages than any before.
+// Handed-out payload pointers stay valid while the pool grows: growth moves the
+// inner vector objects, never their heap storage.
+class SysExBufferPool
+{
+ public:
+  // pre-size the pool (never shrinks) and mark all entries free
+  void prepare(size_t entries)
+  {
+    if (_buffers.size() < entries) _buffers.resize(entries);
+    _used = 0;
+  }
+
+  // copy a payload into the next free buffer and return it
+  const std::vector<uint8_t> &acquire(const uint8_t *data, uint32_t size)
+  {
+    if (_used == _buffers.size()) _buffers.emplace_back();
+    auto &b = _buffers[_used++];
+    b.assign(data, data + size);
+    return b;
+  }
+
+  // mark all entries free without releasing their storage
+  void reset()
+  {
+    _used = 0;
+  }
+
+ private:
+  std::vector<std::vector<uint8_t>> _buffers;
+  size_t _used = 0;
 };
 
 }  // namespace ClapWrapper::detail::shared

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -157,11 +157,9 @@ WrapAsAUV2::WrapAsAUV2(AUV2_Type type, const std::string &clapname, const std::s
 WrapAsAUV2::~WrapAsAUV2()
 {
 #if AUSDK_MIDI2_AVAILABLE
-  if (_midioutput_hosteventlistblock)
-  {
-    Block_release(_midioutput_hosteventlistblock);
-    _midioutput_hosteventlistblock = nullptr;
-  }
+  if (auto blk = _midioutput_hosteventlistblock.exchange(nullptr)) Block_release(blk);
+  for (auto blk : _retiredEventListBlocks) Block_release(blk);
+  _retiredEventListBlocks.clear();
 #endif
   if (_plugin)
   {
@@ -930,19 +928,21 @@ OSStatus WrapAsAUV2::SetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
         break;
 #if AUSDK_MIDI2_AVAILABLE
       case kAudioUnitProperty_MIDIOutputEventListCallback:
+      {
         if (inDataSize < sizeof(AUMIDIEventListBlock)) return kAudioUnitErr_InvalidPropertyValue;
-        if (_midioutput_hosteventlistblock)
-        {
-          Block_release(_midioutput_hosteventlistblock);
-          _midioutput_hosteventlistblock = nullptr;
-        }
+        AUMIDIEventListBlock newblk = nullptr;
         if (inData)
         {
           auto blk = *static_cast<const AUMIDIEventListBlock *>(inData);
-          if (blk) _midioutput_hosteventlistblock = Block_copy(blk);
+          if (blk) newblk = Block_copy(blk);
         }
+        // Render may be invoking the current block on the audio thread right now:
+        // swap atomically and retire the old block instead of releasing it here.
+        // Retired blocks are released in deactivateCLAP()/~WrapAsAUV2.
+        auto oldblk = _midioutput_hosteventlistblock.exchange(newblk);
+        if (oldblk) _retiredEventListBlocks.push_back(oldblk);
         return noErr;
-        break;
+      }
       case kAudioUnitProperty_HostMIDIProtocol:
         if (inDataSize < sizeof(SInt32)) return kAudioUnitErr_InvalidPropertyValue;
         _host_midi_protocol = static_cast<MIDIProtocolID>(*static_cast<const SInt32 *>(inData));
@@ -1101,6 +1101,14 @@ void WrapAsAUV2::deactivateCLAP()
     _plugin->deactivate();
   }
   _midioutput_hostcallback = {nullptr, nullptr};
+#if AUSDK_MIDI2_AVAILABLE
+  // No render can run once the AU is uninitialized: drop the event-list block
+  // too (a stale block would shadow a legacy callback installed on the next
+  // initialization) and release everything retired by SetProperty swaps.
+  if (auto blk = _midioutput_hosteventlistblock.exchange(nullptr)) Block_release(blk);
+  for (auto blk : _retiredEventListBlocks) Block_release(blk);
+  _retiredEventListBlocks.clear();
+#endif
 }
 
 OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags &inFlags, const AudioTimeStamp &inTimeStamp,
@@ -1153,12 +1161,13 @@ OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags &inFlags, const AudioTime
         {
 #if AUSDK_MIDI2_AVAILABLE
           // prefer the modern UMP/EventList path when the host provided one
-          if (_midioutput_hosteventlistblock)
+          // (load once: SetProperty may swap the block concurrently)
+          if (auto evtblock = _midioutput_hosteventlistblock.load())
           {
             auto evtlist = i->getMIDIEventList();
             [[maybe_unused]] OSStatus result =
-                _midioutput_hosteventlistblock(static_cast<AUEventSampleTime>(inTimeStamp.mSampleTime),
-                                               static_cast<uint8_t>(i->_auport), evtlist);
+                evtblock(static_cast<AUEventSampleTime>(inTimeStamp.mSampleTime),
+                         static_cast<uint8_t>(i->_auport), evtlist);
             assert(result == noErr);
           }
           else
@@ -1646,18 +1655,12 @@ void WrapAsAUV2::send(const Clap::AUv2::clap_multi_event_t &event)
     break;
     case CLAP_EVENT_NOTE_EXPRESSION:
     {
-      // Only the expressions MIDI 1.0 can represent are down-converted; the
-      // rest (volume/pan/tuning/vibrato/…) have no per-note MIDI1 equivalent
-      // and are dropped. Pressure maps to polyphonic key pressure (0xA0).
-      const auto &ne = event.noteexpression;
-      if (ne.expression_id == CLAP_NOTE_EXPRESSION_PRESSURE && ne.key >= 0 && ne.channel >= 0)
+      // Pressure maps to poly/channel aftertouch and tuning to pitch bend;
+      // expressions MIDI 1.0 cannot represent (volume/pan/vibrato/…) are dropped.
+      uint8_t bytes[3];
+      if (ClapWrapper::detail::shared::noteExpressionToMidi1(event.noteexpression, bytes) > 0)
       {
-        double v = ne.value;
-        if (v < 0.0) v = 0.0;
-        if (v > 1.0) v = 1.0;
-        uint8_t bytes[3] = {static_cast<uint8_t>(0xA0u | (ne.channel & 0x0F)),
-                            static_cast<uint8_t>(ne.key & 0x7F), static_cast<uint8_t>(v * 127.0)};
-        auto portid = ne.port_index;
+        auto portid = event.noteexpression.port_index;
         for (auto &i : _midi_outports)
         {
           if (i->_info.id == portid)

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -3,6 +3,7 @@
 #include <set>
 #include <limits>
 #include <cassert>
+#include <Block.h>
 
 extern bool fillAudioUnitCocoaView(AudioUnitCocoaViewInfo *viewInfo, std::shared_ptr<Clap::Plugin>);
 
@@ -155,6 +156,13 @@ WrapAsAUV2::WrapAsAUV2(AUV2_Type type, const std::string &clapname, const std::s
 
 WrapAsAUV2::~WrapAsAUV2()
 {
+#if AUSDK_MIDI2_AVAILABLE
+  if (_midioutput_hosteventlistblock)
+  {
+    Block_release(_midioutput_hosteventlistblock);
+    _midioutput_hosteventlistblock = nullptr;
+  }
+#endif
   if (_plugin)
   {
     if (_uiIsOpened && _uiconn._canary)
@@ -309,7 +317,6 @@ void WrapAsAUV2::setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_
   if (!noteports) return;
   auto numMIDIInPorts = noteports->count(plugin, true);
   auto numMIDIOutPorts = noteports->count(plugin, false);
-  (void)numMIDIOutPorts;  // TODO: remove this when MIDI out is implemented
 
   // fprintf(stderr, "\tMIDI in: %d, out: %d\n", (int)numMIDIInPorts, (int)numMIDIOutPorts);
   /*
@@ -327,6 +334,7 @@ void WrapAsAUV2::setupMIDIBusses(const clap_plugin_t *plugin, const clap_plugin_
     if (noteports->get(plugin, 0, true, &info))
     {
       _midi_preferred_dialect = info.preferred_dialect;
+      _midi_supported_dialects = info.supported_dialects;
       _midi_understands_midi2 = (info.supported_dialects & CLAP_NOTE_DIALECT_MIDI2);
     }
   }
@@ -716,7 +724,25 @@ OSStatus WrapAsAUV2::GetPropertyInfo(AudioUnitPropertyID inID, AudioUnitScope in
       case kAudioUnitProperty_MIDIOutputCallback:
         outWritable = true;
         outDataSize = sizeof(AUMIDIOutputCallbackStruct);
+        return noErr;
         break;
+#if AUSDK_MIDI2_AVAILABLE
+      case kAudioUnitProperty_AudioUnitMIDIProtocol:
+        outWritable = false;
+        outDataSize = sizeof(SInt32);
+        return noErr;
+        break;
+      case kAudioUnitProperty_MIDIOutputEventListCallback:
+        outWritable = true;
+        outDataSize = sizeof(AUMIDIEventListBlock);
+        return noErr;
+        break;
+      case kAudioUnitProperty_HostMIDIProtocol:
+        outWritable = true;
+        outDataSize = sizeof(SInt32);
+        return noErr;
+        break;
+#endif
 
         // custom
       case kAudioUnitProperty_ClapWrapper_UIConnection_id:
@@ -852,6 +878,16 @@ OSStatus WrapAsAUV2::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
         *static_cast<UInt32 *>(outData) = 1;
         return noErr;
         break;
+#if AUSDK_MIDI2_AVAILABLE
+      case kAudioUnitProperty_AudioUnitMIDIProtocol:
+        // the protocol we want our MIDI input delivered in: MIDI 2.0 only when
+        // the hosted plugin actually prefers the MIDI2 note dialect, otherwise
+        // MIDI 1.0 so everything flows through the (richer) MIDI1 translation.
+        *static_cast<SInt32 *>(outData) =
+            (_midi_preferred_dialect == CLAP_NOTE_DIALECT_MIDI2) ? kMIDIProtocol_2_0 : kMIDIProtocol_1_0;
+        return noErr;
+        break;
+#endif
       default:
         break;
     }
@@ -892,8 +928,30 @@ OSStatus WrapAsAUV2::SetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
         // this is actually read only
         return noErr;
         break;
+#if AUSDK_MIDI2_AVAILABLE
+      case kAudioUnitProperty_MIDIOutputEventListCallback:
+        if (inDataSize < sizeof(AUMIDIEventListBlock)) return kAudioUnitErr_InvalidPropertyValue;
+        if (_midioutput_hosteventlistblock)
+        {
+          Block_release(_midioutput_hosteventlistblock);
+          _midioutput_hosteventlistblock = nullptr;
+        }
+        if (inData)
+        {
+          auto blk = *static_cast<const AUMIDIEventListBlock *>(inData);
+          if (blk) _midioutput_hosteventlistblock = Block_copy(blk);
+        }
+        return noErr;
+        break;
+      case kAudioUnitProperty_HostMIDIProtocol:
+        if (inDataSize < sizeof(SInt32)) return kAudioUnitErr_InvalidPropertyValue;
+        _host_midi_protocol = static_cast<MIDIProtocolID>(*static_cast<const SInt32 *>(inData));
+        return noErr;
+        break;
+#else
       case kAudioUnitProperty_MIDIOutputEventListCallback:
         break;
+#endif
       case kAudioUnitProperty_MIDIOutputCallback:
         if (inDataSize < sizeof(AUMIDIOutputCallbackStruct)) return kAudioUnitErr_InvalidPropertyValue;
 
@@ -1014,8 +1072,18 @@ void WrapAsAUV2::activateCLAP()
     _plugin->setBlockSizes(minSampleFrames, maxSampleFrames);
     _plugin->setSampleRate(Output(0).GetStreamFormat().mSampleRate);
 
+    // the plugin's actually-declared audio port counts (0 when it has no
+    // audio-ports extension); these may be fewer than the AU element counts
+    uint32_t clapAudioInputs = 0, clapAudioOutputs = 0;
+    if (_plugin->_ext._audioports)
+    {
+      clapAudioInputs = _plugin->_ext._audioports->count(_plugin->_plugin, true);
+      clapAudioOutputs = _plugin->_ext._audioports->count(_plugin->_plugin, false);
+    }
+
     _processAdapter->setupProcessing(Inputs(), Outputs(), _plugin->_plugin, _plugin->_ext._params, this,
-                                     &_parametertree, this, maxSampleFrames, _midi_preferred_dialect);
+                                     &_parametertree, this, maxSampleFrames, _midi_preferred_dialect,
+                                     _midi_supported_dialects, clapAudioInputs, clapAudioOutputs);
 
     _plugin->activate();
     _plugin->start_processing();
@@ -1083,7 +1151,19 @@ OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags &inFlags, const AudioTime
       {
         if (i->hasEvents())
         {
-          if (_midioutput_hostcallback.midiOutputCallback)
+#if AUSDK_MIDI2_AVAILABLE
+          // prefer the modern UMP/EventList path when the host provided one
+          if (_midioutput_hosteventlistblock)
+          {
+            auto evtlist = i->getMIDIEventList();
+            [[maybe_unused]] OSStatus result = _midioutput_hosteventlistblock(
+                static_cast<AUEventSampleTime>(inTimeStamp.mSampleTime),
+                static_cast<uint8_t>(i->_auport), evtlist);
+            assert(result == noErr);
+          }
+          else
+#endif
+              if (_midioutput_hostcallback.midiOutputCallback)
           {
             auto userd = _midioutput_hostcallback.userData;
             auto pktlist = i->getMIDIPacketList();
@@ -1371,54 +1451,21 @@ OSStatus WrapAsAUV2::RestoreState(CFPropertyListRef plist)
 bool WrapAsAUV2::ValidFormat(AudioUnitScope inScope, AudioUnitElement inElement,
                              const AudioStreamBasicDescription &inNewFormat)
 {
-  if (!_plugin->_ext._audioports)
-  {
-    return false;
-  }
-
-  // Logic Pro does not call this in the main thread - so we just pretend..
-  auto guarantee_mainthread = _plugin->AlwaysMainThread();
-
-  auto ap = _plugin->_ext._audioports;
-  auto pl = _plugin->_plugin;
-
-  if (inScope == kAudioUnitScope_Input)
-  {
-    auto numAudioInputs = ap->count(pl, true);
-    if (inElement >= numAudioInputs)
-    {
-      return false;
-    }
-    clap_audio_port_info inf;
-    ap->get(pl, inElement, true, &inf);
-    if (inNewFormat.mChannelsPerFrame == inf.channel_count)
-    {
-      // LOGINFO("In True");
-      return true;
-    }
-  }
-  else if (inScope == kAudioUnitScope_Output)
-  {
-    auto numAudioOutputs = ap->count(pl, false);
-    if (inElement >= numAudioOutputs)
-    {
-      return false;
-    }
-
-    clap_audio_port_info inf;
-    ap->get(pl, inElement, false, &inf);
-    if (inNewFormat.mChannelsPerFrame == inf.channel_count)
-    {
-      // LOGINFO("Out True");
-      return true;
-    }
-  }
-  else if (inScope == kAudioUnitScope_Global)
+  // Validate against the audio-port layout snapshotted at PostConstructor. We
+  // must NOT scan the CLAP audio-ports extension here: hosts (e.g. Logic, auval)
+  // call ValidFormat while the plugin is active, and CLAP only permits port
+  // scanning while deactivated.
+  if (inScope == kAudioUnitScope_Global)
   {
     return true;
   }
-  //LOGINFO("False");
-  return false;
+
+  const auto &cache = (inScope == kAudioUnitScope_Input) ? _inputPortCache : _outputPortCache;
+  if (inElement >= cache.size())
+  {
+    return false;
+  }
+  return inNewFormat.mChannelsPerFrame == cache[inElement].channelCount;
 }
 
 OSStatus WrapAsAUV2::ChangeStreamFormat(AudioUnitScope inScope, AudioUnitElement inElement,
@@ -1433,32 +1480,25 @@ OSStatus WrapAsAUV2::ChangeStreamFormat(AudioUnitScope inScope, AudioUnitElement
 
 UInt32 WrapAsAUV2::SupportedNumChannels(const AUChannelInfo **outInfo)
 {
-  if (cinfo.empty() && _plugin->_ext._audioports)
+  // Built from the PostConstructor snapshot rather than a live port scan (see
+  // ValidFormat) so this is safe to call while the plugin is active.
+  if (cinfo.empty() && !_outputPortCache.empty())
   {
-    auto ap = _plugin->_ext._audioports;
-    auto pl = _plugin->_plugin;
-    auto numAudioInputs = ap->count(pl, true);
-    auto numAudioOutputs = ap->count(pl, false);
-
     std::set<int> inSets, outSets;
 
     bool hasInMain{false};
-    for (int i = 0; i < numAudioInputs; ++i)
+    for (const auto &p : _inputPortCache)
     {
-      clap_audio_port_info inf;
-      ap->get(pl, i, true, &inf);
-      inSets.insert(inf.channel_count);
-      hasInMain |= (inf.flags & CLAP_AUDIO_PORT_IS_MAIN);
+      inSets.insert(p.channelCount);
+      hasInMain |= p.isMain;
     }
     if (!hasInMain) inSets.insert(0);
 
     bool hasOutMain{false};
-    for (int i = 0; i < numAudioOutputs; ++i)
+    for (const auto &p : _outputPortCache)
     {
-      clap_audio_port_info inf;
-      ap->get(pl, i, false, &inf);
-      outSets.insert(inf.channel_count);
-      hasOutMain |= (inf.flags & CLAP_AUDIO_PORT_IS_MAIN);
+      outSets.insert(p.channelCount);
+      hasOutMain |= p.isMain;
     }
     if (!hasOutMain) outSets.insert(0);
 
@@ -1499,6 +1539,7 @@ void WrapAsAUV2::PostConstructor()
     {
       clap_audio_port_info inf;
       ap->get(pl, i, true, &inf);
+      _inputPortCache.push_back({inf.channel_count, (inf.flags & CLAP_AUDIO_PORT_IS_MAIN) != 0});
       auto b = CFStringCreateWithCString(nullptr, inf.name, kCFStringEncodingUTF8);
       Inputs().GetElement(i)->SetName(b);
 
@@ -1517,6 +1558,7 @@ void WrapAsAUV2::PostConstructor()
     {
       clap_audio_port_info inf;
       ap->get(pl, i, false, &inf);
+      _outputPortCache.push_back({inf.channel_count, (inf.flags & CLAP_AUDIO_PORT_IS_MAIN) != 0});
       auto b = CFStringCreateWithCString(nullptr, inf.name, kCFStringEncodingUTF8);
       Outputs().GetElement(i)->SetName(b);
 
@@ -1530,8 +1572,21 @@ void WrapAsAUV2::PostConstructor()
     }
     LOGINFO("[clap-wrapper] PostConstructor: Ins={} Outs={}", numAudioInputs, numAudioOutputs);
   }
-  // The else here would just set elements to 0,0 which is the default
-  // therefore leave it un-elsed
+
+  // A plugin can legitimately declare no audio output ports (a note effect such
+  // as an arpeggiator, or a plugin with no audio-ports extension at all). The AU
+  // model — and auval / Logic — still require at least one audio output element
+  // to exist, otherwise Initialize fails with kAudioUnitErr_InvalidElement.
+  // Present a placeholder silent output bus in that case; the CLAP is still told
+  // its true (zero) audio-port count during processing, so no buffers are handed
+  // to the plugin that it did not declare.
+  if (Outputs().GetNumberOfElements() == 0)
+  {
+    SetNumberOfElements(kAudioUnitScope_Output, 1);
+    Outputs().SetNumberOfElements(1);
+    Outputs().GetElement(0)->SetName(CFSTR("Output"));
+    LOGINFO("[clap-wrapper] PostConstructor: added placeholder silent output bus");
+  }
 }
 
 UInt32 WrapAsAUV2::GetAudioChannelLayout(AudioUnitScope scope, AudioUnitElement element,
@@ -1540,6 +1595,71 @@ UInt32 WrapAsAUV2::GetAudioChannelLayout(AudioUnitScope scope, AudioUnitElement 
   // TODO: This is never called so the layout is never found
   return Base::GetAudioChannelLayout(scope, element, outLayoutPtr, outWritable);
 }
+
+namespace
+{
+// Down-convert a single MIDI 2.0 channel-voice UMP message (MT 0x4) to a MIDI 1.0
+// 3-byte message. Returns the number of MIDI1 bytes written (0 if not convertible).
+// Wide MIDI2 values are reduced by dropping the low bits (16->7, 32->7, 32->14).
+int midi2ChannelVoiceToMidi1(const uint32_t data[4], uint8_t out[3])
+{
+  const uint32_t w0 = data[0];
+  const uint32_t w1 = data[1];
+  if (((w0 >> 28) & 0xFu) != 0x4u) return 0;  // only MIDI 2.0 channel voice
+
+  const uint8_t status = static_cast<uint8_t>((w0 >> 16) & 0xF0u);
+  const uint8_t channel = static_cast<uint8_t>((w0 >> 16) & 0x0Fu);
+  const uint8_t index = static_cast<uint8_t>((w0 >> 8) & 0x7Fu);  // note / cc index
+
+  switch (status)
+  {
+    case 0x80:  // note off
+    case 0x90:  // note on
+    {
+      uint8_t vel = static_cast<uint8_t>((w1 >> 16) >> 9);  // 16-bit velocity -> 7-bit
+      // MIDI 2.0 note-on keeps velocity semantics; guard against an accidental
+      // MIDI1 note-off when a non-zero MIDI2 velocity scales down to 0.
+      if (status == 0x90 && vel == 0) vel = 1;
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = index;
+      out[2] = vel;
+      return 3;
+    }
+    case 0xA0:  // poly pressure
+    case 0xB0:  // control change
+    {
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = index;
+      out[2] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
+      return 3;
+    }
+    case 0xC0:  // program change
+    {
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = static_cast<uint8_t>((w1 >> 24) & 0x7Fu);
+      out[2] = 0;
+      return 2;
+    }
+    case 0xD0:  // channel pressure
+    {
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
+      out[2] = 0;
+      return 2;
+    }
+    case 0xE0:  // pitch bend
+    {
+      const uint32_t v14 = w1 >> 18;  // 32-bit -> 14-bit
+      out[0] = static_cast<uint8_t>(status | channel);
+      out[1] = static_cast<uint8_t>(v14 & 0x7Fu);
+      out[2] = static_cast<uint8_t>((v14 >> 7) & 0x7Fu);
+      return 3;
+    }
+    default:
+      return 0;
+  }
+}
+}  // namespace
 
 void WrapAsAUV2::send(const Clap::AUv2::clap_multi_event_t &event)
 {
@@ -1586,12 +1706,68 @@ void WrapAsAUV2::send(const Clap::AUv2::clap_multi_event_t &event)
       }
     }
     break;
+    case CLAP_EVENT_NOTE_EXPRESSION:
+    {
+      // Only the expressions MIDI 1.0 can represent are down-converted; the
+      // rest (volume/pan/tuning/vibrato/…) have no per-note MIDI1 equivalent
+      // and are dropped. Pressure maps to polyphonic key pressure (0xA0).
+      const auto &ne = event.noteexpression;
+      if (ne.expression_id == CLAP_NOTE_EXPRESSION_PRESSURE && ne.key >= 0 && ne.channel >= 0)
+      {
+        double v = ne.value;
+        if (v < 0.0) v = 0.0;
+        if (v > 1.0) v = 1.0;
+        uint8_t bytes[3] = {static_cast<uint8_t>(0xA0u | (ne.channel & 0x0F)),
+                            static_cast<uint8_t>(ne.key & 0x7F),
+                            static_cast<uint8_t>(v * 127.0)};
+        auto portid = ne.port_index;
+        for (auto &i : _midi_outports)
+        {
+          if (i->_info.id == portid)
+          {
+            i->addMIDI3Byte(bytes);
+            break;
+          }
+        }
+      }
+    }
+    break;
+    case CLAP_EVENT_MIDI_SYSEX:
+    {
+      const auto &sx = event.sysex;
+      auto portid = sx.port_index;
+      for (auto &i : _midi_outports)
+      {
+        if (i->_info.id == portid)
+        {
+          i->addSysEx(sx.buffer, sx.size);
+          break;
+        }
+      }
+    }
+    break;
+    case CLAP_EVENT_MIDI2:
+    {
+      // A plugin emitting raw UMP is rare. Down-convert MIDI 2.0 channel-voice
+      // to MIDI 1.0 and route through the normal output; this works for both the
+      // legacy callback and the UMP EventList path (which the framework then
+      // up-converts to the host's negotiated protocol).
+      uint8_t bytes[3];
+      if (midi2ChannelVoiceToMidi1(event.midi2.data, bytes) > 0)
+      {
+        auto portid = event.midi2.port_index;
+        for (auto &i : _midi_outports)
+        {
+          if (i->_info.id == portid)
+          {
+            i->addMIDI3Byte(bytes);
+            break;
+          }
+        }
+      }
+    }
+    break;
   }
-#if 0
-  MIDIEventList list;
-  MIDIEventListInit(list, MIDIProtocolID protocolkMIDIProtocol_1_0);
-  MIDIEventListAdd(list, <#ByteCount listSize#>, <#MIDIEventPacket * _Nonnull curPacket#>, <#MIDITimeStamp time#>, <#ByteCount wordCount#>, <#const UInt32 * _Nonnull words#>)
-#endif
 }
 
 }  // namespace free_audio::auv2_wrapper

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1156,9 +1156,9 @@ OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags &inFlags, const AudioTime
           if (_midioutput_hosteventlistblock)
           {
             auto evtlist = i->getMIDIEventList();
-            [[maybe_unused]] OSStatus result = _midioutput_hosteventlistblock(
-                static_cast<AUEventSampleTime>(inTimeStamp.mSampleTime),
-                static_cast<uint8_t>(i->_auport), evtlist);
+            [[maybe_unused]] OSStatus result =
+                _midioutput_hosteventlistblock(static_cast<AUEventSampleTime>(inTimeStamp.mSampleTime),
+                                               static_cast<uint8_t>(i->_auport), evtlist);
             assert(result == noErr);
           }
           else
@@ -1463,7 +1463,10 @@ bool WrapAsAUV2::ValidFormat(AudioUnitScope inScope, AudioUnitElement inElement,
   const auto &cache = (inScope == kAudioUnitScope_Input) ? _inputPortCache : _outputPortCache;
   if (inElement >= cache.size())
   {
-    return false;
+    // The placeholder silent output bus of a note-only plugin (see
+    // PostConstructor) has no CLAP port behind it; accept any format there so
+    // hosts can still change the sample rate / channel count on that bus.
+    return (inScope == kAudioUnitScope_Output && cache.empty() && inElement == 0);
   }
   return inNewFormat.mChannelsPerFrame == cache[inElement].channelCount;
 }
@@ -1596,71 +1599,6 @@ UInt32 WrapAsAUV2::GetAudioChannelLayout(AudioUnitScope scope, AudioUnitElement 
   return Base::GetAudioChannelLayout(scope, element, outLayoutPtr, outWritable);
 }
 
-namespace
-{
-// Down-convert a single MIDI 2.0 channel-voice UMP message (MT 0x4) to a MIDI 1.0
-// 3-byte message. Returns the number of MIDI1 bytes written (0 if not convertible).
-// Wide MIDI2 values are reduced by dropping the low bits (16->7, 32->7, 32->14).
-int midi2ChannelVoiceToMidi1(const uint32_t data[4], uint8_t out[3])
-{
-  const uint32_t w0 = data[0];
-  const uint32_t w1 = data[1];
-  if (((w0 >> 28) & 0xFu) != 0x4u) return 0;  // only MIDI 2.0 channel voice
-
-  const uint8_t status = static_cast<uint8_t>((w0 >> 16) & 0xF0u);
-  const uint8_t channel = static_cast<uint8_t>((w0 >> 16) & 0x0Fu);
-  const uint8_t index = static_cast<uint8_t>((w0 >> 8) & 0x7Fu);  // note / cc index
-
-  switch (status)
-  {
-    case 0x80:  // note off
-    case 0x90:  // note on
-    {
-      uint8_t vel = static_cast<uint8_t>((w1 >> 16) >> 9);  // 16-bit velocity -> 7-bit
-      // MIDI 2.0 note-on keeps velocity semantics; guard against an accidental
-      // MIDI1 note-off when a non-zero MIDI2 velocity scales down to 0.
-      if (status == 0x90 && vel == 0) vel = 1;
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = index;
-      out[2] = vel;
-      return 3;
-    }
-    case 0xA0:  // poly pressure
-    case 0xB0:  // control change
-    {
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = index;
-      out[2] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
-      return 3;
-    }
-    case 0xC0:  // program change
-    {
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = static_cast<uint8_t>((w1 >> 24) & 0x7Fu);
-      out[2] = 0;
-      return 2;
-    }
-    case 0xD0:  // channel pressure
-    {
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = static_cast<uint8_t>(w1 >> 25);  // 32-bit -> 7-bit
-      out[2] = 0;
-      return 2;
-    }
-    case 0xE0:  // pitch bend
-    {
-      const uint32_t v14 = w1 >> 18;  // 32-bit -> 14-bit
-      out[0] = static_cast<uint8_t>(status | channel);
-      out[1] = static_cast<uint8_t>(v14 & 0x7Fu);
-      out[2] = static_cast<uint8_t>((v14 >> 7) & 0x7Fu);
-      return 3;
-    }
-    default:
-      return 0;
-  }
-}
-}  // namespace
-
 void WrapAsAUV2::send(const Clap::AUv2::clap_multi_event_t &event)
 {
   // port index maps back to MIDI out
@@ -1718,8 +1656,7 @@ void WrapAsAUV2::send(const Clap::AUv2::clap_multi_event_t &event)
         if (v < 0.0) v = 0.0;
         if (v > 1.0) v = 1.0;
         uint8_t bytes[3] = {static_cast<uint8_t>(0xA0u | (ne.channel & 0x0F)),
-                            static_cast<uint8_t>(ne.key & 0x7F),
-                            static_cast<uint8_t>(v * 127.0)};
+                            static_cast<uint8_t>(ne.key & 0x7F), static_cast<uint8_t>(v * 127.0)};
         auto portid = ne.port_index;
         for (auto &i : _midi_outports)
         {

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1690,7 +1690,7 @@ void WrapAsAUV2::send(const Clap::AUv2::clap_multi_event_t &event)
       // legacy callback and the UMP EventList path (which the framework then
       // up-converts to the host's negotiated protocol).
       uint8_t bytes[3];
-      if (midi2ChannelVoiceToMidi1(event.midi2.data, bytes) > 0)
+      if (ClapWrapper::detail::shared::midi2ChannelVoiceToMidi1(event.midi2.data, bytes) > 0)
       {
         auto portid = event.midi2.port_index;
         for (auto &i : _midi_outports)


### PR DESCRIPTION
Overhaul MIDI handling in the AUv2 wrapper so it reaches parity with the VST3 backend for MIDI 1.0 and adds MIDI 2.0 / Universal MIDI Packet support in both directions. All MIDI 2.0 paths are guarded by AUSDK_MIDI2_AVAILABLE.

Dialect handling:
- Replace the single preferred==CLAP test with a real switch over the input port's preferred_dialect, validated against its supported_dialects with a MIDI2->MPE->MIDI->CLAP fallback (chooseInputDialect). Both dialects are threaded through ProcessAdapter::setupProcessing.

MIDI 1.0 (input):
- Poly key pressure -> CLAP_NOTE_EXPRESSION_PRESSURE on the CLAP dialect (raw MIDI otherwise); CC/PC/channel-pressure/pitch-bend stay raw MIDI.
- Implement SysEx input (WrapAsAUV2::SysEx) via a per-cycle owned buffer pool so the borrowed clap_event_midi_sysex_t.buffer stays valid.
- StartNote/StopNote now emit real CLAP notes carrying a note_id (with the key embedded in its low 7 bits, so StopNote needs no lookup table) plus a tuning note-expression for fractional pitch.
- Scope active-note bookkeeping to the CLAP dialect (the note union fields are only valid there).

MIDI 1.0 (output):
- Forward NOTE_EXPRESSION (pressure -> poly aftertouch) and MIDI_SYSEX instead of dropping them; add MIDIOutput::addSysEx.
- Remove the bug that echoed incoming notes straight to the MIDI output.

MIDI 2.0 / UMP:
- Override AUBase::MIDIEventList: walk UMP packets, forwarding MIDI 2.0 channel-voice (MT 0x4) as CLAP_EVENT_MIDI2 and MIDI 1.0 (MT 0x2) through the existing byte path; reassemble SysEx7 (MT 0x3) into CLAP SysEx events.
- Advertise/handle the protocol properties: AudioUnitMIDIProtocol (read, reports MIDI2 only when the plugin prefers it) and HostMIDIProtocol (write).
- Output via kAudioUnitProperty_MIDIOutputEventListCallback: MIDIOutput builds a parallel protocol-1.0 UMP list (incl. SysEx7); Render prefers the EventList block when the host set one, else the legacy MIDIPacketList callback. Raw CLAP_EVENT_MIDI2 output is down-converted to MIDI 1.0. Native MIDI1->MIDI2 output upscaling is intentionally left to the framework's protocol conversion.

Wrapper fixes surfaced by clap-validator-plugins:
- Note-only / zero-audio-port plugins (aumi, or no audio-ports extension) now initialize: PostConstructor presents a placeholder silent output bus, and the plugin's real CLAP audio-port counts are passed to process() separately from the AU element counts (placeholder busses are zero-filled). Fixes Initialize failing with kAudioUnitErr_InvalidElement (-10877).
- Stop scanning the CLAP audio-ports extension while the plugin is active (CLAP AP01 contract violation): the port layout is snapshotted at PostConstructor and ValidFormat/SupportedNumChannels read the cache.

Also remove dead/placeholder code and tidy inconsistent property handling.

Verified: builds -Werror; auval clean (Validator Synth aumu + NoteFX aumi, zero contract violations, Test MIDI PASS); MIDI in/out confirmed in Logic Pro.