### PR TITLE
Fix AUv2 channel count handling, memory leak

### DIFF
--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1552,8 +1552,8 @@ void WrapAsAUV2::PostConstructor()
       clap_audio_port_info inf;
       ap->get(pl, i, true, &inf);
       _inputPortCache.push_back({inf.channel_count, (inf.flags & CLAP_AUDIO_PORT_IS_MAIN) != 0});
-      auto b = CFStringCreateWithCString(nullptr, inf.name, kCFStringEncodingUTF8);
-      Inputs().GetElement(i)->SetName(b);
+      // SetNumberOfElements resets the bus, reapply the configuration.
+      addInputBus(i, &inf);
 
       /*
       AudioChannelLayout layout;
@@ -1571,8 +1571,8 @@ void WrapAsAUV2::PostConstructor()
       clap_audio_port_info inf;
       ap->get(pl, i, false, &inf);
       _outputPortCache.push_back({inf.channel_count, (inf.flags & CLAP_AUDIO_PORT_IS_MAIN) != 0});
-      auto b = CFStringCreateWithCString(nullptr, inf.name, kCFStringEncodingUTF8);
-      Outputs().GetElement(i)->SetName(b);
+      // SetNumberOfElements resets the bus, reapply the configuration.
+      addOutputBus(i, &inf);
 
       /*
       AudioChannelLayout layout;


### PR DESCRIPTION
With the current clap-wrapper next it does not seem to be possible to create AUv2 aufx in mono. SetNumberOfElements resets the channel count in PostConstructor and nothing restores it. Leading to the au failing in auval (and logic) with
```
ERROR: Unit now reports it cannot support default channel configuration (it previously reported that it did): in:2, out:2
ERROR: -10868 IN CALL Cannot Set Input Num Channels:2 when unit says it can
```
This fixes the issue be reinitializing the bus. It should also stops leaking of the name string.

Might be worth renaming add*Bus or refactoring but as is this works for me.