### PR TITLE
Create silence buffers as empty buffers

### DIFF
--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -62,10 +62,10 @@ void ProcessAdapter::setupProcessing(ausdk::AUScope &audioInputs, ausdk::AUScope
   if (numMaxSamples > 0)
   {
     delete[] _silent_input;
-    _silent_input = new float[numMaxSamples];
+    _silent_input = new float[numMaxSamples]{};
 
     delete[] _silent_output;
-    _silent_output = new float[numMaxSamples];
+    _silent_output = new float[numMaxSamples]{};
   }
 
   _numInputs = _audioInputScope->GetNumberOfElements();


### PR DESCRIPTION
The auv2 uses silent buffers to fill inputs and outputs in validation but on certain change and reconfigure shapes the block wasn't blanked leading to uninitialized memory being fed to buses in auval and elsewhere