### PR TITLE
adding update of parameter values after load

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -270,7 +270,35 @@ tresult PLUGIN_API ClapAsVst3::canProcessSampleSize(int32 symbolicSampleSize)
 
 tresult PLUGIN_API ClapAsVst3::setState(IBStream *state)
 {
-  return (_plugin->load(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
+  auto raise = _plugin->AlwaysMainThread();
+  _param_rescan_has_been_called = false;  // detect rescan/reload during load
+
+  auto result =
+      (_plugin->load(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
+
+  // if the state was loaded correctly, values must be updated
+  if (result == kResultOk && !_param_rescan_has_been_called)
+  {
+    if (_plugin->_ext._params)
+    {
+      auto len = parameters.getParameterCount();
+      for (decltype(len) i = 0; i < len; ++i)
+      {
+        auto p = static_cast<Vst3Parameter *>(parameters.getParameterByIndex(i));
+        if (p->isMidi) continue;
+        double val;
+        if (_plugin->_ext._params->get_value(_plugin->_plugin, p->id, &val))
+        {
+          auto newval = p->asVst3Value(val);
+          if (p->getNormalized() != newval)
+          {
+            p->setNormalized(newval);
+          }
+        }
+      }
+    }
+  }
+  return result;
 }
 
 tresult PLUGIN_API ClapAsVst3::getState(IBStream *state)
@@ -1197,6 +1225,9 @@ void ClapAsVst3::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
 
 void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
 {
+  // check this in ::setState
+  _param_rescan_has_been_called = true;
+
   auto vstflags = 0u;
   if (flags & CLAP_PARAM_RESCAN_ALL)
   {

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -279,26 +279,30 @@ tresult PLUGIN_API ClapAsVst3::setState(IBStream *state)
   // if the state was loaded correctly, values must be updated
   if (result == kResultOk && !_param_rescan_has_been_called)
   {
-    if (_plugin->_ext._params)
+    syncParameterValuesFromClap();
+  }
+  return result;
+}
+
+void ClapAsVst3::syncParameterValuesFromClap()
+{
+  if (!_plugin->_ext._params) return;
+
+  auto len = parameters.getParameterCount();
+  for (decltype(len) i = 0; i < len; ++i)
+  {
+    auto p = static_cast<Vst3Parameter *>(parameters.getParameterByIndex(i));
+    if (p->isMidi) continue;
+    double val;
+    if (_plugin->_ext._params->get_value(_plugin->_plugin, p->id, &val))
     {
-      auto len = parameters.getParameterCount();
-      for (decltype(len) i = 0; i < len; ++i)
+      auto newval = p->asVst3Value(val);
+      if (p->getNormalized() != newval)
       {
-        auto p = static_cast<Vst3Parameter *>(parameters.getParameterByIndex(i));
-        if (p->isMidi) continue;
-        double val;
-        if (_plugin->_ext._params->get_value(_plugin->_plugin, p->id, &val))
-        {
-          auto newval = p->asVst3Value(val);
-          if (p->getNormalized() != newval)
-          {
-            p->setNormalized(newval);
-          }
-        }
+        p->setNormalized(newval);
       }
     }
   }
-  return result;
 }
 
 tresult PLUGIN_API ClapAsVst3::getState(IBStream *state)
@@ -1225,9 +1229,6 @@ void ClapAsVst3::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
 
 void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
 {
-  // check this in ::setState
-  _param_rescan_has_been_called = true;
-
   auto vstflags = 0u;
   if (flags & CLAP_PARAM_RESCAN_ALL)
   {
@@ -1243,32 +1244,26 @@ void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
 
   if (vstflags == 0) return;
 
+  // check this in ::setState
+  _param_rescan_has_been_called = true;
+
   // update parameter values in our own tree
-  auto len = parameters.getParameterCount();
-  for (decltype(len) i = 0; i < len; ++i)
+  syncParameterValuesFromClap();
+
+  if (flags & CLAP_PARAM_RESCAN_INFO)
   {
-    auto p = static_cast<Vst3Parameter *>(parameters.getParameterByIndex(i));
-    if (!p->isMidi)
+    // In this case, the name and module can also change.
+    // For now, don't rebuild the unit tree with modules but
+    // do rescan the name
+    auto len = parameters.getParameterCount();
+    for (decltype(len) i = 0; i < len; ++i)
     {
-      double val;
-      if (_plugin->_ext._params->get_value(_plugin->_plugin, p->id, &val))
+      auto p = static_cast<Vst3Parameter *>(parameters.getParameterByIndex(i));
+      if (p->isMidi) continue;
+      clap_param_info_t info;
+      if (_plugin->_ext._params->get_info(_plugin->_plugin, p->param_index_for_clap_get_info, &info))
       {
-        auto newval = p->asVst3Value(val);
-        if (p->getNormalized() != newval)
-        {
-          p->setNormalized(newval);
-        }
-      }
-      if (flags & CLAP_PARAM_RESCAN_INFO)
-      {
-        // In this case, the name and module can also change.
-        // For now, don't rebuild the unit tree with modules but
-        // do rescan the name
-        clap_param_info_t info;
-        if (_plugin->_ext._params->get_info(_plugin->_plugin, p->param_index_for_clap_get_info, &info))
-        {
-          str8ToStr16(p->getInfo().title, info.name, str16BufferSize(p->getInfo().title));
-        }
+        str8ToStr16(p->getInfo().title, info.name, str16BufferSize(p->getInfo().title));
       }
     }
   }

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -384,6 +384,10 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   Vst::UnitID getOrCreateUnitInfo(const char *modulename);
   std::map<std::string, Vst::UnitID> _moduleToUnit;
 
+  // pulls current values from the CLAP plugin's params extension into our VST3 parameter tree
+  // (used by both setState and param_rescan)
+  void syncParameterValuesFromClap();
+
   Clap::Library *_library = nullptr;
   int _libraryIndex = 0;
   std::shared_ptr<Clap::Plugin> _plugin;

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -417,6 +417,8 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   // the queue from audiothread to UI thread
   ClapWrapper::detail::shared::fixedqueue<queueEvent, 8192> _queueToUI;
 
+  bool _param_rescan_has_been_called{false};
+
   // for IMidiMapping
   bool _useIMidiMapping = false;
   Vst::ParamID _IMidiMappingIDs[16][Vst::ControllerNumbers::kCountCtrlNumber] =


### PR DESCRIPTION
this should solve this issue: https://github.com/free-audio/clap-wrapper/issues/475

parameter values are being updated so the VST3 parameter cache is ready to be read from the VST3 host