### PR TITLE
AUv2: fix a use-after-free reading parameter clump names

### DIFF
--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -20,6 +20,9 @@
 #include <iostream>
 #include <memory>
 #include <map>
+#include <mutex>
+#include <optional>
+#include <string>
 
 #include "process.h"
 #include "parameter.h"
@@ -87,38 +90,54 @@ class ValueEvent : public queueEvent
   }
 };
 
+/*
+ * The parameter group names, by the clump id the host sees in
+ * AudioUnitParameterInfo::clumpID.
+ *
+ * Guarded, and answering by value, because the two sides of this are on
+ * different threads. setupParameters() fills it on the main thread; the host
+ * reads it back through kAudioUnitProperty_ParameterClumpName while building its
+ * parameter tree, which it is free to do wherever it likes -- Logic uses a
+ * parameterTreeBuilderQueue of its own, asynchronously with respect to the
+ * property change that asked for the rebuild. Handing out a const char* into the
+ * map was therefore a use-after-free, and it was reachable by changing presets
+ * with audio running: the next rescan cleared the map while the host was reading
+ * from it.
+ *
+ * There is deliberately no way to empty it. Clump ids outlive the rescan that
+ * minted them -- the host keeps the one it read from AudioUnitParameterInfo and
+ * asks for its name whenever it likes -- so renumbering is what made them wrong,
+ * and clearing is what made them dangerous. addClump() dedupes, so the map
+ * converges on the module paths the plugin reports and stops growing.
+ */
 class Clumps
 {
  public:
-  void reset();
   UInt32 addClump(const char *fullpath);
-  const char *getClump(UInt32 id);
+  std::optional<std::string> getClump(UInt32 id) const;
 
  private:
+  mutable std::mutex _mutex;
   UInt32 _lastclump = 0;
   std::map<std::string, UInt32> _clumps;
 };
 
-void Clumps::reset()
+inline std::optional<std::string> Clumps::getClump(UInt32 id) const
 {
-  _clumps.clear();
-  _lastclump = 0;
-}
-
-const char *Clumps::getClump(UInt32 id)
-{
+  std::lock_guard<std::mutex> guard(_mutex);
   for (const auto &c : _clumps)
   {
     if (c.second == id)
     {
-      return c.first.c_str();
+      return c.first;
     }
   }
-  return nullptr;
+  return std::nullopt;
 }
 
-UInt32 Clumps::addClump(const char *fullpath)
+inline UInt32 Clumps::addClump(const char *fullpath)
 {
+  std::lock_guard<std::mutex> guard(_mutex);
   auto r = _clumps.find(fullpath);
   if (r == _clumps.end())
   {
@@ -771,6 +790,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
   bool _midi_dualscheduling_mode = false;
 #endif
   std::map<uint32_t, std::unique_ptr<Clap::AUv2::Parameter>> _parametertree;
+  // Between setupParameters() on the main thread and the host's property getters,
+  // which arrive on whichever thread the host builds its parameter tree on. Not
+  // taken by the audio thread: SetParameter() and the process adapter read the
+  // tree under render and must not block. See the note on Clumps above.
+  std::mutex _paramTreeMutex;
   std::vector<AudioUnitParameterID> _orderedParameterList;
   bool _paramOrderingProvided{false};
   Clumps _clumps;

--- a/src/detail/auv2/parameter.cpp
+++ b/src/detail/auv2/parameter.cpp
@@ -19,6 +19,13 @@ void Parameter::updateInfo(const clap_plugin_t *plugin, const clap_plugin_params
   }
   _info = i;
   _cfstring = CFStringCreateWithCString(NULL, _info.name, kCFStringEncodingUTF8);
+  if (_cfstring == nullptr)
+  {
+    // A name that is not valid UTF-8 fails the conversion, and the wrapper hands
+    // this string to the host with a CFRetain and releases it in the destructor:
+    // neither survives a null. Latin-1 accepts any byte, so it always answers.
+    _cfstring = CFStringCreateWithCString(NULL, _info.name, kCFStringEncodingISOLatin1);
+  }
 
   const auto &info = _info;
   AudioUnitParameterOptions flags = 0;
@@ -70,7 +77,10 @@ void Parameter::updateInfo(const clap_plugin_t *plugin, const clap_plugin_params
 }
 Parameter::~Parameter()
 {
-  CFRelease(_cfstring);
+  if (_cfstring)
+  {
+    CFRelease(_cfstring);
+  }
 }
 
 }  // namespace Clap::AUv2

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -354,7 +354,11 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
   // creating parameters.
 
-  _clumps.reset();
+  // Held for the whole rebuild, so that a host reading kAudioUnitProperty_ParameterInfo
+  // on its own thread sees the tree either before or after this, never during.
+  std::lock_guard<std::mutex> guard(_paramTreeMutex);
+
+  // _clumps is not cleared here, and cannot be -- see the note on the class.
   _orderedParameterList.clear();
   _paramOrderingProvided = false;
   _bypassParamID = CLAP_INVALID_ID;
@@ -433,6 +437,13 @@ void WrapAsAUV2::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
           else
           {
             piter->second->updateInfo(_plugin->_plugin, p, paraminfo);
+          }
+          // Assign the clump id here rather than leaving it to GetParameterInfo,
+          // so that the ids follow parameter order and are settled before the
+          // host is told there is anything to read.
+          if (paraminfo.module[0] != 0)
+          {
+            _clumps.addClump(paraminfo.module);
           }
           if (paraminfo.flags & CLAP_PARAM_IS_BYPASS)
           {
@@ -522,6 +533,10 @@ OSStatus WrapAsAUV2::GetParameterInfo(AudioUnitScope inScope, AudioUnitParameter
   // const uint64_t stdflag = kAudioUnitParameterFlag_IsReadable | kAudioUnitParameterFlag_IsWritable;
   if (inScope == kAudioUnitScope_Global)
   {
+    // A host may ask from any thread while setupParameters() is rebuilding the
+    // tree on the main one -- the CFRetain below used to race the CFRelease in
+    // Parameter::updateInfo().
+    std::lock_guard<std::mutex> guard(_paramTreeMutex);
     auto pi = _parametertree.find(inParameterID);
     if (pi != _parametertree.end())
     {
@@ -579,12 +594,22 @@ void WrapAsAUV2::SetBypassEffect(bool bypass)
   _isBypassed = bypass;
   if (_bypassParamID != CLAP_INVALID_ID)
   {
-    auto p = _parametertree.find(_bypassParamID);
-    if (p != _parametertree.end())
+    // The value is copied out under the lock rather than the call being made
+    // under it: SetParameter reaches the process adapter, which must not wait on
+    // the main thread's rebuild.
+    std::optional<double> value;
     {
-      const auto &info = p->second->info();
-      SetParameter(_bypassParamID, kAudioUnitScope_Global, 0, bypass ? info.max_value : info.min_value,
-                   0);
+      std::lock_guard<std::mutex> guard(_paramTreeMutex);
+      auto p = _parametertree.find(_bypassParamID);
+      if (p != _parametertree.end())
+      {
+        const auto &info = p->second->info();
+        value = bypass ? info.max_value : info.min_value;
+      }
+    }
+    if (value)
+    {
+      SetParameter(_bypassParamID, kAudioUnitScope_Global, 0, *value, 0);
     }
   }
 }
@@ -595,11 +620,25 @@ OSStatus WrapAsAUV2::CopyClumpName(AudioUnitScope inScope, UInt32 inClumpID, UIn
   if (outClumpName == nullptr) return kAudioUnitErr_InvalidParameter;
   if (inScope == kAudioUnitScope_Global)
   {
+    // By value: the map this came out of belongs to the main thread and may be
+    // rewritten the moment the lock inside getClump() is dropped.
     auto p = _clumps.getClump(inClumpID);
     if (p)
     {
-      auto const len = std::min(strlen(p), (size_t)inDesiredNameLength);
-      *outClumpName = CFStringCreateWithBytes(NULL, (const UInt8 *)p, len, kCFStringEncodingUTF8, false);
+      // A desired length of zero means "no limit", not "the empty string". The
+      // SDK clamps kAudioUnitParameterName_Full (-1) to zero on the way in, and
+      // that is how a host asks for the untruncated name.
+      auto len = p->size();
+      if (inDesiredNameLength > 0)
+      {
+        len = std::min(len, (size_t)inDesiredNameLength);
+      }
+      auto name =
+          CFStringCreateWithBytes(NULL, (const UInt8 *)p->data(), len, kCFStringEncodingUTF8, false);
+      // Truncation can land in the middle of a UTF-8 sequence, which fails the
+      // conversion; a null here with noErr would be released by the host.
+      if (name == nullptr) return kAudioUnitErr_InvalidPropertyValue;
+      *outClumpName = name;
       return noErr;
     }
   }
@@ -1285,16 +1324,23 @@ void WrapAsAUV2::onIdle()
         Globals()->SetParameter(e._data._id, e._data._value.value);
         if (e._data._id == _bypassParamID)
         {
-          auto p = _parametertree.find(_bypassParamID);
-          if (p != _parametertree.end())
+          // Decided under the lock, announced outside it: PropertyChanged runs
+          // the host's listeners synchronously and they are free to come back in
+          // through the property getters.
+          std::optional<bool> bypassed;
           {
-            const auto &info = p->second->info();
-            const bool bypassed = (e._data._value.value >= 0.5 * (info.min_value + info.max_value));
-            if (bypassed != _isBypassed)
+            std::lock_guard<std::mutex> guard(_paramTreeMutex);
+            auto p = _parametertree.find(_bypassParamID);
+            if (p != _parametertree.end())
             {
-              _isBypassed = bypassed;
-              PropertyChanged(kAudioUnitProperty_BypassEffect, kAudioUnitScope_Global, 0);
+              const auto &info = p->second->info();
+              bypassed = (e._data._value.value >= 0.5 * (info.min_value + info.max_value));
             }
+          }
+          if (bypassed && *bypassed != _isBypassed)
+          {
+            _isBypassed = *bypassed;
+            PropertyChanged(kAudioUnitProperty_BypassEffect, kAudioUnitScope_Global, 0);
           }
         }
         AudioUnitEvent myEvent;


### PR DESCRIPTION
Clumps handed out a const char* into its own std::map and CopyClumpName read through it with no lock held, while setupParameters() cleared that map on the main thread on every param rescan. A host is free to build its parameter tree wherever it likes -- Logic does it asynchronously, on a queue of its own, in response to the very PropertyChanged the rescan just sent -- so for plugins which rescan while audio is running the main thread frees the strings the host is in the middle of reading. It faults in CopyClumpName on the host's tree builder thread.

getClump now answers by value under a mutex, and the map is no longer emptied at all. Clump ids outlive the rescan that minted them: a host keeps the id it read from AudioUnitParameterInfo and asks for its name whenever it likes, so renumbering from zero was making them wrong quite apart from the clearing making them dangerous. addClump() dedupes, so the map converges on the module paths the plugin reports; setupParameters() seeds it, so the ids follow parameter order and are settled before the host is told there is anything to read.

_parametertree had the same window. GetParameterInfo CFRetains a Parameter's CFString on the host's thread while updateInfo CFReleases and recreates it on the main one, and the map was being searched and inserted into at once. A mutex now spans setupParameters and the property getters. The audio thread is deliberately not part of it -- SetParameter and the process adapter read the tree under render and must not block -- so SetBypassEffect and onIdle copy what they need out under the lock and act outside it, which also keeps PropertyChanged's synchronous host listeners off it.

Two smaller faults in the same functions:

- CopyClumpName read a desired length of zero as "the empty string". The SDK clamps kAudioUnitParameterName_Full (-1) to zero on the way in, which is exactly how a host asks for the untruncated name, so every clump came back blank. It also returned noErr with a null CFStringRef when the conversion failed, and the host releases that.

- A parameter name that is not valid UTF-8 leaves Parameter::_cfstring null, and it was CFRetained by the caller and CFReleased in the destructor regardless. It falls back to Latin-1, which accepts any byte.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>