### PR TITLE
AUv3: clear created state when GUI creation fails

### DIFF
--- a/src/detail/auv3/auv3_audiounit.mm
+++ b/src/detail/auv3/auv3_audiounit.mm
@@ -2003,6 +2003,10 @@ static Clap::Library _library;
       [self didChangeValueForKey:@"preferredContentSize"];
     }
   }
+  else
+  {
+    _guiCreated = NO;
+  }
 }
 
 // Convergence point for GUI creation. Called from multiple triggers:


### PR DESCRIPTION
The AUv3 wrapper sets `_guiCreated` before calling `createGUIInView`. If the plugin's `create()` returns false, the next layout still calls `can_resize()` on a GUI that was never created.

The proposed change clears `_guiCreated` when creation fails. It stays set during the call, so the existing reentrancy guard is preserved.

Tested with a modified clap-first plugin whose GUI create() returns false. Before this change, `viewDidLayout` called `can_resize()` and the fixture aborted. After the change, creation fails cleanly and no later GUI callbacks are made. 