### PR TITLE
Standalone: keep activate/deactivate balanced when audio can't start

### DIFF
--- a/src/detail/standalone/entry.cpp
+++ b/src/detail/standalone/entry.cpp
@@ -145,7 +145,7 @@ int mainFinish()
       LOGINFO("[WARNING] No Standalone Settings Path; not streaming");
     }
 
-    plugin->deactivate();
+    standaloneHost->deactivatePlugin();
   }
   plugin.reset();
   standaloneHost.reset();

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -48,7 +48,7 @@
     }
     // stay stopped if the plugin refused to reactivate
     standaloneHost->running = standaloneHost->activatePlugin(standaloneHost->currentSampleRate, 1,
-                                                            standaloneHost->currentBufferSize * 2);
+                                                             standaloneHost->currentBufferSize * 2);
   }
 }
 

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -46,9 +46,9 @@
       ClapWrapper::detail::shared::SpinLockGuard g(standaloneHost->processLock);
       standaloneHost->running = false;
     }
-    standaloneHost->activatePlugin(standaloneHost->currentSampleRate, 1,
-                                   standaloneHost->currentBufferSize * 2);
-    standaloneHost->running = true;
+    // stay stopped if the plugin refused to reactivate
+    standaloneHost->running = standaloneHost->activatePlugin(standaloneHost->currentSampleRate, 1,
+                                                            standaloneHost->currentBufferSize * 2);
   }
 }
 

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -45,6 +45,8 @@ std::optional<fs::path> getStandaloneSettingsPath()
 
 StandaloneHost::~StandaloneHost()
 {
+  // safety net for shutdown paths which don't run through mainFinish
+  deactivatePlugin();
 }
 
 void StandaloneHost::setupAudioBusses(const clap_plugin_t *plugin,
@@ -364,23 +366,44 @@ bool StandaloneHost::tryLoadStandaloneAndPluginSettings(const fs::path &fromDir,
   return true;
 }
 
-void StandaloneHost::activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlock)
+bool StandaloneHost::activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlock)
 {
-  if (isActive)
-  {
-    clapPlugin->stop_processing();
-    clapPlugin->deactivate();
-    isActive = false;
-  }
+  if (!clapPlugin) return false;
+
+  deactivatePlugin();
 
   LOGINFO("Activating plugin : sampleRate={} blockBounds={} to {}", sr, minBlock, maxBlock);
   clapPlugin->setSampleRate(sr);
   clapPlugin->setBlockSizes(minBlock, maxBlock);
-  clapPlugin->activate();
+  if (!clapPlugin->activate())
+  {
+    LOGINFO("[ERROR] Plugin activate() failed; plugin remains deactivated");
+    return false;
+  }
+  isActive = true;
 
   clapPlugin->start_processing();
+  isProcessing = true;
 
-  isActive = true;
+  return true;
+}
+
+void StandaloneHost::deactivatePlugin()
+{
+  // activate/deactivate has to stay balanced, so only ever deactivate what we
+  // know we activated. Without an audio device the plugin never gets activated
+  // at all, and the shutdown path would otherwise deactivate it regardless.
+  if (!clapPlugin || !isActive) return;
+
+  if (isProcessing)
+  {
+    clapPlugin->stop_processing();
+    isProcessing = false;
+  }
+
+  LOGINFO("Deactivating plugin");
+  clapPlugin->deactivate();
+  isActive = false;
 }
 
 }  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -266,6 +266,11 @@ struct StandaloneHost : Clap::IHost
                           int32_t sampleRate);
   void stopAudioThread();
 
+  // the actual work of startAudioThreadOn, wrapped there by an exception guard
+  void startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t inputChannels, bool useInput,
+                              unsigned int outputDeviceID, uint32_t outputChannels, bool useOutput,
+                              int32_t sampleRate);
+
   bool startupAudioSet{false};
   unsigned int startAudioIn{0}, startAudioOut{0};
   int startSampleRate{0};
@@ -277,8 +282,13 @@ struct StandaloneHost : Clap::IHost
     startSampleRate = sr;
   }
 
-  void activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlock);
+  // returns true if the plugin is activated and processing afterwards
+  bool activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlock);
+  // no-op unless activatePlugin() succeeded before, so the plugin never sees
+  // an unbalanced deactivate()
+  void deactivatePlugin();
   bool isActive{false};
+  bool isProcessing{false};
 
   std::vector<RtAudio::Api> getCompiledApi();
   std::vector<RtAudio::DeviceInfo> getInputAudioDevices();

--- a/src/detail/standalone/standalone_host_audio.cpp
+++ b/src/detail/standalone/standalone_host_audio.cpp
@@ -13,6 +13,8 @@
 #pragma GCC diagnostic pop
 #endif
 
+#include <exception>
+
 #include "standalone_host.h"
 #include "entry.h"
 
@@ -86,19 +88,35 @@ std::tuple<unsigned int, unsigned int, int32_t> StandaloneHost::getDefaultAudioI
 }
 void StandaloneHost::startAudioThread()
 {
-  guaranteeRtAudioDAC();
+  try
+  {
+    guaranteeRtAudioDAC();
 
-  if (startupAudioSet)
-  {
-    auto in = startAudioIn;
-    auto out = startAudioOut;
-    auto sr = startSampleRate;
-    startAudioThreadOn(in, 2, in > 0 && numAudioInputs > 0, out, 2, out > 0 && numAudioOutputs > 0, sr);
+    if (startupAudioSet)
+    {
+      auto in = startAudioIn;
+      auto out = startAudioOut;
+      auto sr = startSampleRate;
+      startAudioThreadOn(in, 2, in > 0 && numAudioInputs > 0, out, 2, out > 0 && numAudioOutputs > 0,
+                         sr);
+    }
+    else
+    {
+      auto [in, out, sr] = getDefaultAudioInOutSampleRate();
+      startAudioThreadOn(in, 2, numAudioInputs > 0, out, 2, numAudioOutputs > 0, sr);
+    }
   }
-  else
+  catch (const std::exception &e)
   {
-    auto [in, out, sr] = getDefaultAudioInOutSampleRate();
-    startAudioThreadOn(in, 2, numAudioInputs > 0, out, 2, numAudioOutputs > 0, sr);
+    // Device enumeration itself can throw when nothing usable is attached
+    LOGINFO("[ERROR] Exception while setting up audio : '{}'", e.what());
+    if (displayAudioError) displayAudioError(e.what());
+  }
+  catch (...)
+  {
+    // winrt/COM errors don't derive from std::exception
+    LOGINFO("[ERROR] Unknown exception while setting up audio");
+    if (displayAudioError) displayAudioError("Unknown error while setting up audio");
   }
 }
 
@@ -169,6 +187,33 @@ std::vector<uint32_t> StandaloneHost::getBufferSizes()
 void StandaloneHost::startAudioThreadOn(unsigned int inputDeviceID, uint32_t inputChannels,
                                         bool useInput, unsigned int outputDeviceID,
                                         uint32_t outputChannels, bool useOutput, int32_t reqSampleRate)
+{
+  // Backends can throw when no usable device is present. Letting that escape
+  // would leave the standalone half-started, so trap it here; the plugin simply
+  // stays deactivated and the app runs on without audio.
+  try
+  {
+    startAudioThreadOnImpl(inputDeviceID, inputChannels, useInput, outputDeviceID, outputChannels,
+                           useOutput, reqSampleRate);
+  }
+  catch (const std::exception &e)
+  {
+    LOGINFO("[ERROR] Exception starting audio : '{}'", e.what());
+    deactivatePlugin();
+    if (displayAudioError) displayAudioError(e.what());
+  }
+  catch (...)
+  {
+    LOGINFO("[ERROR] Unknown exception starting audio");
+    deactivatePlugin();
+    if (displayAudioError) displayAudioError("Unknown error while starting audio");
+  }
+}
+
+void StandaloneHost::startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t inputChannels,
+                                            bool useInput, unsigned int outputDeviceID,
+                                            uint32_t outputChannels, bool useOutput,
+                                            int32_t reqSampleRate)
 {
   guaranteeRtAudioDAC();
 
@@ -257,7 +302,12 @@ void StandaloneHost::startAudioThreadOn(unsigned int inputDeviceID, uint32_t inp
     return;
   }
 
-  activatePlugin(sampleRate, 1, currentBufferSize * 2);
+  if (!activatePlugin(sampleRate, 1, currentBufferSize * 2))
+  {
+    LOGINFO("[ERROR] Plugin activation failed; not starting the audio stream");
+    rtaDac->closeStream();
+    return;
+  }
 
   LOGDETAIL("RtAudio Attached Devices");
   if (useOutput)

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -1013,8 +1013,9 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
                      ClapWrapper::detail::shared::SpinLockGuard g(sah->processLock);
                      sah->running = false;
                    }
-                   sah->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
-                   sah->running = true;
+                   // stay stopped if the plugin refused to reactivate
+                   sah->running =
+                       sah->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
                  }
                }
 
@@ -1259,7 +1260,7 @@ void Plugin::refreshApis()
 
   for (auto &api : sah->getCompiledApi())
   {
-    settings.api.add(sah->rtaDac->getApiDisplayName(api));
+    settings.api.add(RtAudio::getApiDisplayName(api));
   }
 }
 
@@ -1381,8 +1382,10 @@ bool Plugin::loadSettings()
       if (auto parsed{settings.json.TryParse(buffer, settings.json)}; parsed)
       {
         sah->audioApiName = settings.get<std::string>("audioApiName");
-        sah->audioApi = sah->rtaDac->getCompiledApiByName(sah->audioApiName);
-        sah->audioApiDisplayName = sah->rtaDac->getApiDisplayName(sah->audioApi);
+        // These are static on RtAudio - we run before any RtAudio instance exists,
+        // so they must not be reached through sah->rtaDac, which is still null here.
+        sah->audioApi = RtAudio::getCompiledApiByName(sah->audioApiName);
+        sah->audioApiDisplayName = RtAudio::getApiDisplayName(sah->audioApi);
         sah->audioInputDeviceID = static_cast<unsigned int>(settings.get<double>("audioInputDeviceID"));
         sah->audioOutputDeviceID =
             static_cast<unsigned int>(settings.get<double>("audioOutputDeviceID"));


### PR DESCRIPTION
activate() is only called from activatePlugin(), which runs after RtAudio opens
a stream. But mainFinish() called plugin->deactivate() unconditionally. With no
usable audio device the plugin got a deactivate() with no matching activate(),
which clap-helpers flags.

Activation state now lives in StandaloneHost. activatePlugin() returns whether
it succeeded, and only marks the plugin active once activate() returns true.
The new deactivatePlugin() is a no-op unless activation actually happened. It
also pairs stop_processing() with start_processing(), which the old shutdown
path skipped entirely.

The audio startup path is now guarded against exceptions, including COM/winrt
errors that don't derive from std::exception. A throwing backend leaves the app
running without audio instead of half-started. A failed activation closes the
stream rather than processing into an inactive plugin. The restart handlers on
Windows and macOS derive `running` from the activation result, so a failed
reactivation doesn't resume the audio callback.

Also fixes a null dereference in the Windows loadSettings(). It reached
RtAudio's static API-name helpers through sah->rtaDac, before any RtAudio
instance exists.

Fixes #390