### PR TITLE
clang-format check also for .m and .mm files

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -16,3 +16,7 @@ jobs:
         with:
           clang-format-version: '21'
           check-path: ${{ matrix.path }}
+          # The action's default regex only matches extensions starting with c/C
+          # or h/H, so Objective-C(++) went unchecked. This is that default plus
+          # mm and m.
+          include-regex: '^.*\.((((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))|(ino|pde|proto|cu|mm|m))$'

--- a/src/detail/auv3/process.mm
+++ b/src/detail/auv3/process.mm
@@ -912,15 +912,15 @@ AUAudioUnitStatus ProcessAdapter::process(AudioUnitRenderActionFlags *actionFlag
           {
             if (__builtin_available(macOS 12.0, iOS 15.0, *))
             {
-              ClapWrapper::detail::shared::packSysEx7(
-                  evt.sysex.buffer, evt.sysex.size,
-                  [&](uint32_t w0, uint32_t w1)
-                  {
-                    if (!umpCur) return;
-                    uint32_t words[2] = {w0, w1};
-                    umpCur =
-                        MIDIEventListAdd(umpList, sizeof(umpBuffer), umpCur, (MIDITimeStamp)off, 2, words);
-                  });
+              ClapWrapper::detail::shared::packSysEx7(evt.sysex.buffer, evt.sysex.size,
+                                                      [&](uint32_t w0, uint32_t w1)
+                                                      {
+                                                        if (!umpCur) return;
+                                                        uint32_t words[2] = {w0, w1};
+                                                        umpCur = MIDIEventListAdd(
+                                                            umpList, sizeof(umpBuffer), umpCur,
+                                                            (MIDITimeStamp)off, 2, words);
+                                                      });
             }
           }
           else if (midiOutputEventBlock)


### PR DESCRIPTION
the github actions regex missed .m/.mm files for clang-format. Added it and also formatted process.mm so validation works.