### PR TITLE
Allow users to set the bundle identifier for the Standalone

### DIFF
--- a/cmake/make_clapfirst.cmake
+++ b/cmake/make_clapfirst.cmake
@@ -379,6 +379,7 @@ function(make_clapfirst_plugins)
                         OUTPUT_NAME "${saname}"
                         STATICALLY_LINKED_CLAP_ENTRY TRUE
                         PLUGIN_ID "${clapid}"
+                        BUNDLE_IDENTIFIER "${C1ST_BUNDLE_IDENTIFIER}.standalone"
                         MACOS_ICON "${C1ST_STANDALONE_MACOS_ICON}"
                         WINDOWS_ICON "${C1ST_STANDALONE_WINDOWS_ICON}"
                         RESOURCE_DIRECTORY "${C1ST_RESOURCE_DIRECTORY}"

--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -39,6 +39,12 @@ function(target_add_standalone_wrapper)
         set(SA_OUTPUT_NAME ${SA_TARGET})
     endif()
 
+    if (NOT DEFINED SA_BUNDLE_IDENTIFIER)
+        # What Info.plist.in used to hardcode. Kept as the default so a caller
+        # that does not pass one keeps the identifier it already shipped.
+        set(SA_BUNDLE_IDENTIFIER "${SA_OUTPUT_NAME}.standalone")
+    endif()
+
     if (NOT DEFINED SA_WINDOWS_ICON)
         set(SA_WINDOWS_ICON "")
     endif()
@@ -100,11 +106,13 @@ function(target_add_standalone_wrapper)
                 BUNDLE_EXTENSION app
                 OUTPUT_NAME ${SA_OUTPUT_NAME}
                 MACOSX_BUNDLE_BUNDLE_NAME ${SA_OUTPUT_NAME}
+                MACOSX_BUNDLE_GUI_IDENTIFIER "${SA_BUNDLE_IDENTIFIER}"
                 MACOSX_BUNDLE_SHORT_VERSION_STRING ${SA_BUNDLE_VERSION}
                 MACOSX_BUNDLE_LONG_VERSION_STRING ${SA_BUNDLE_VERSION}
                 MACOSX_BUNDLE_BUNDLE_VERSION ${SA_BUNDLE_VERSION}
                 MACOSX_BUNDLE TRUE
                 MACOSX_BUNDLE_INFO_PLIST ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/macos/Info.plist.in
+                XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${SA_BUNDLE_IDENTIFIER}"
                 RESOURCE "${GEN_XIB}"
                 )
 

--- a/src/detail/standalone/macos/Info.plist.in
+++ b/src/detail/standalone/macos/Info.plist.in
@@ -13,7 +13,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>${MACOSX_BUNDLE_BUNDLE_NAME}.standalone</string>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
It used to be just "Product.standalone" even if you set a bundle id in your clap first setup. This retains that default but allows you to set it and follows the bundle id.