### PR TITLE
AUv3: two iOS fixes — UIKit macro vs newer CLAP headers, adjust_size before set_size

### DIFF
--- a/src/detail/auv3/auv3_audiounit.mm
+++ b/src/detail/auv3/auv3_audiounit.mm
@@ -1769,7 +1769,15 @@ static Clap::Library _library;
 {
   if (!_impl || !_impl->_plugin || !_impl->_plugin->_ext._gui) return NO;
   auto mainGuard = _impl->_plugin->AlwaysMainThread();
-  return _impl->_plugin->_ext._gui->set_size(_impl->_plugin->_plugin, width, height) ? YES : NO;
+
+  // CLAP contract: a host must pass set_size a size the plugin agreed to.
+  // Container bounds are arbitrary (rotation, split view), so run them
+  // through adjust_size first — a fixed-aspect plugin snaps them here, and
+  // strict clap-helpers builds treat an unadjusted set_size as host
+  // misbehaviour.
+  auto *gui = _impl->_plugin->_ext._gui;
+  if (gui->adjust_size) gui->adjust_size(_impl->_plugin->_plugin, &width, &height);
+  return gui->set_size(_impl->_plugin->_plugin, width, height) ? YES : NO;
 }
 
 - (void)setViewController:(ClapAUv3ViewController *)vc

--- a/src/detail/auv3/auv3_platform.h
+++ b/src/detail/auv3/auv3_platform.h
@@ -36,6 +36,13 @@ typedef NSView CLAPWRAP_ViewClass;
 
 // Private CLAP window-API identifier for UIKit. Kept in sync with the
 // constant of the same name in the hosted plugin's editor code.
+//
+// Newer CLAP declares CLAP_WINDOW_API_UIKIT as a variable in ext/gui.h; if
+// this macro is defined before that header is parsed, it rewrites the
+// declaration into garbage. Parse the header first — it is #pragma once, so
+// it will not be parsed again after the macro exists.
+#include <clap/clap.h>
+
 #ifndef CLAP_WINDOW_API_UIKIT
 #define CLAP_WINDOW_API_UIKIT "uikit"
 #endif


### PR DESCRIPTION
Two small fixes found while building a clap-first AUv3 instrument for iOS (visage UI, strict clap-helpers configuration).

**1. `auv3_platform.h`: include clap headers before the `CLAP_WINDOW_API_UIKIT` fallback macro**

Newer CLAP declares `CLAP_WINDOW_API_UIKIT` as a variable in `ext/gui.h`. If the fallback macro from `auv3_platform.h` is defined before that header is parsed, the preprocessor rewrites the declaration into garbage. Including `<clap/clap.h>` first is safe in both directions — the header is pragma-once, so it is never parsed again after the fallback macro is defined for older CLAP.

**2. `auv3_audiounit.mm`: run container sizes through `adjust_size` before `set_size`**

CLAP requires hosts to pass `set_size` a size the plugin has agreed to. The AUv3 container's bounds are arbitrary (rotation, split view, host chrome), so hand them to `adjust_size` first: a fixed-aspect plugin snaps them to its ratio, and clap-helpers built with `MisbehaviourHandler::Terminate` + `CheckingLevel::Maximal` no longer aborts the appex over the unadjusted `set_size`.

Both verified on device against an 820x615 fixed-4:3 editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)