### PR TITLE
Don't release the hosted CLAP from static destruction

### DIFF
--- a/src/detail/aax/factory.cpp
+++ b/src/detail/aax/factory.cpp
@@ -5,7 +5,10 @@
 
 namespace CLAPAAX
 {
-static Clap::Library gClapLibrary;
+// Intentionally never destroyed - see the note in wrapasvst3_entry.cpp: at
+// process exit the hosted .clap is finalized before this binary, so calling
+// clap_entry.deinit() from a static destructor aborts the host.
+static Clap::Library &gClapLibrary = *new Clap::Library();
 
 bool findPlugin(Clap::Library &lib, const std::string &pluginfilename)
 {

--- a/src/detail/auv3/auv3_audiounit.mm
+++ b/src/detail/auv3/auv3_audiounit.mm
@@ -774,7 +774,10 @@ class AUv3ImplDetail : public Clap::IHost, public Clap::IAutomation, public os::
 // Static CLAP library holder
 // -----------------------------------------------------------------------
 
-static Clap::Library _library;
+// Intentionally never destroyed - see the note in wrapasvst3_entry.cpp: at
+// process exit the hosted .clap is finalized before this binary, so calling
+// clap_entry.deinit() from a static destructor aborts the host.
+static Clap::Library &_library = *new Clap::Library();
 
 // -----------------------------------------------------------------------
 // ClapAUv3AudioUnit implementation

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -10,7 +10,13 @@ extern bool fillAudioUnitCocoaView(AudioUnitCocoaViewInfo *viewInfo, std::shared
 namespace free_audio::auv2_wrapper
 {
 
-Clap::Library _library;  // holds the library with plugins
+// Holds the library with plugins. Intentionally never destroyed: at process
+// exit dyld finalizes the hosted .clap before this binary, so running
+// clap_entry.deinit() from a static destructor reaches into a plugin whose
+// own statics are already gone and aborts the host. AUv2 has no
+// module-unload hook to release it from, so it is leaked and the OS reclaims
+// it. See the same note in wrapasvst3_entry.cpp.
+Clap::Library &_library = *new Clap::Library();
 
 #if 0
 --- 8< ---

--- a/src/wrapasvst3_entry.cpp
+++ b/src/wrapasvst3_entry.cpp
@@ -1,3 +1,7 @@
+// Must precede every include: moduleinit.h below resolves
+// std::numeric_limits<>::max(), which the windows.h `max` macro breaks.
+#define NOMINMAX 1
+
 /*
     CLAP AS VST3 - Entrypoint
 
@@ -47,6 +51,7 @@
 #include "detail/shared/sha1.h"
 #include "wrapasvst3.h"
 #include "public.sdk/source/main/pluginfactory.h"
+#include "public.sdk/source/main/moduleinit.h"
 #include "pluginterfaces/base/iplugincompatibility.h"
 #include <array>
 #include <string>
@@ -70,6 +75,37 @@ struct CreationContext
   int index = 0;
   PClassInfo2 classinfo;
 };
+
+// The hosted CLAP outlives static destruction on purpose.
+//
+// A CLAP is a separate binary that dyld loaded after this one, so at process
+// exit it is finalized *first*. Releasing the library from a static destructor
+// therefore calls clap_entry.deinit() into a plugin whose own statics are
+// already gone - locking a std::mutex that has been through
+// pthread_mutex_destroy throws std::system_error out of a noexcept destructor
+// and the host aborts after it has already done its work.
+//
+// Instead the library is leaked at exit (the OS reclaims it anyway) and
+// released from a VST3 module terminator, which the SDK runs from
+// DeinitModule() on a genuine module unload - a plugin rescan, say - while
+// every image involved is still alive.
+namespace
+{
+Clap::Library *gHostedClapLibrary = nullptr;
+
+Clap::Library &hostedClapLibrary()
+{
+  if (!gHostedClapLibrary) gHostedClapLibrary = new Clap::Library();
+  return *gHostedClapLibrary;
+}
+
+static Steinberg::ModuleTerminator gReleaseHostedClapLibrary(
+    []()
+    {
+      delete gHostedClapLibrary;
+      gHostedClapLibrary = nullptr;
+    });
+}  // namespace
 
 bool findPlugin(Clap::Library &lib, const std::string &pluginfilename)
 {
@@ -153,7 +189,8 @@ IPluginFactory *GetPluginFactoryEntryPoint()
 #endif
 
   // static IPtr<Steinberg::CPluginFactory> gPluginFactory = nullptr;
-  static Clap::Library gClapLibrary;
+  // Never destroyed by static destruction - see gHostedClapLibrary.
+  auto &gClapLibrary = hostedClapLibrary();
 
   static std::vector<std::shared_ptr<CreationContext>> gCreationContexts;
 


### PR DESCRIPTION
## The problem

A CLAP is a separate binary that dyld loaded *after* the wrapper, so at process exit it is finalized **first**. Releasing `Clap::Library` from a static destructor therefore calls `clap_entry.deinit()` into a plugin whose own statics are already gone.

This shows up with any hosted CLAP that guards its factory teardown with a `std::mutex`: by the time `~Library()` runs, the mutex has been through `pthread_mutex_destroy`, `lock()` fails with `EINVAL`, and the resulting `std::system_error` escapes a `noexcept` destructor into `std::terminate`.

```
std::mutex::lock -> __throw_system_error      EINVAL
<plugin>::destroyAllInstances
<plugin> factoryDeinit
Clap::Library::~Library                       fsutil.cpp:436
__cxa_finalize_ranges  <-  exit
```

Both validators abort with SIGABRT *after* they have already printed their results, so the failure is easy to miss in a log and impossible to miss in an exit code:

```
Result: 46 tests passed, 1 tests failed
libc++abi: terminating due to uncaught exception of type
           std::__1::system_error: mutex lock failed: Invalid argument
```

## The change

Leak the library at process exit — the OS reclaims it anyway — and keep releasing it for genuine module unloads, where every image involved is still alive.

VST3 gets that for free: `moduleinit.cpp` is already part of `base-sdk-vst3`, so a `Steinberg::ModuleTerminator` runs the release from `DeinitModule()` on a real unload (a plugin rescan, say) and is simply not called at exit. AUv2, AUv3 and AAX have no equivalent hook, so there the library is never destroyed.

`~Library()` is deliberately unchanged — it is still correct for callers that own a `Library` with a bounded lifetime, such as the auv2/auv3 build helpers.
