### PR TITLE
AUv3 standalone: brace-scope the mic-permission switch case (fixes #512)

### DIFF
--- a/src/detail/standalone/macos/auv3/AUv3HostAppDelegate.mm
+++ b/src/detail/standalone/macos/auv3/AUv3HostAppDelegate.mm
@@ -243,6 +243,7 @@ static MIDIPortRef sMIDIInputPort = 0;
   switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio])
   {
     case AVAuthorizationStatusNotDetermined:
+    {
       [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
                                completionHandler:^(BOOL granted) {
                                  if (!granted) return;
@@ -258,6 +259,7 @@ static MIDIPortRef sMIDIInputPort = 0;
                                  });
                                }];
       break;
+    }
     default:
       break;
   }


### PR DESCRIPTION
Fixes #512, as requested there — against `next`.

> **Note on authorship:** as in the issue, this was drafted with AI assistance (Claude). The diagnosis and patch came from it; I ran the builds and verified every result below on my own machine.

### The change

Two lines: brace-scope the body of `case AVAuthorizationStatusNotDetermined:` in `doSetup`.

The case contains an Objective-C block literal that strongly captures `self` (the microphone-permission completion handler), so the block's lifetime begins inside the case, and the following `default:` label jumps over it. Older clang allowed this; the clang in Xcode 26 (AppleClang 21) rejects it:

```
error: cannot jump from switch statement to this case label
note: jump enters lifetime of block which strongly captures a variable
```

Braces end the block's lifetime at the closing brace, so `default:` no longer jumps into it. No behavioural change.

### Scope

Only the standalone host app is affected — the AUv3 `.appex` target itself builds fine. It still blocks AUv3 work on macOS in practice, since an appex only registers with the system once its containing app has been launched.

### Verified

macOS 15.7.7 (x86_64) · Xcode 26.6 (17F113) · AppleClang 21.0.0 · CMake 4.4.2 with `-G Xcode`, via `make_clapfirst_plugins` with `PLUGIN_FORMATS CLAP VST3 AUV2 AUV3`:

- the standalone builds and launches
- `pluginkit -m -v -p com.apple.AudioUnit-UI` registers the appex
- `auval -v <type> <subtype> <manu>` → **AU VALIDATION SUCCEEDED**
- the AUv3 loads and plays in Ableton Live

Happy to adjust if you would rather restructure the `switch` differently.
