### PR TITLE
Accept the resize the macOS standalone has just performed

### DIFF
--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -128,7 +128,10 @@
     sz.width = w;
     sz.height = h;
     [[self window] setContentSize:sz];
-    return false;
+    // The size was accepted -- it has just been applied. Returning false said the
+    // opposite, and a plugin that believed it left its own GUI a size behind the
+    // window it is drawn in. Windows answers true from the same place.
+    return true;
   };
 
   if (plugin->_ext._gui)


### PR DESCRIPTION
gui_request_resize applies the size to the window and then returned false, which clap_host_gui defines as "the new size is not accepted". Windows returns true from the same place and Linux returns what its resize actually did; only macOS disagreed with itself.

A plugin that believes the answer stops there, so its own GUI stays the size it was while the window around it has already changed. On a JUCE plugin that shows up as the editor sliding up or down inside the window -- a view in a foreign NSView is anchored at Cocoa's bottom left, so a height the plugin never applied moves the content rather than clipping it.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>