### PR TITLE
Windows standalone: settings persistence, audio API lifecycle, MIDI selection (#516)

### DIFF
--- a/cmake/wrap_standalone.cmake
+++ b/cmake/wrap_standalone.cmake
@@ -71,6 +71,7 @@ function(target_add_standalone_wrapper)
             ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/standalone_host.cpp
             ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/standalone_host_audio.cpp
             ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/standalone_host_midi.cpp
+            ${CLAP_WRAPPER_CMAKE_CURRENT_SOURCE_DIR}/src/detail/standalone/standalone_settings.cpp
             )
     target_link_libraries(${salib}
             PUBLIC
@@ -166,7 +167,9 @@ function(target_add_standalone_wrapper)
             target_compile_definitions(${SA_TARGET} PRIVATE _SILENCE_CLANG_COROUTINE_MESSAGE)
         endif()
 
-        target_link_libraries(${SA_TARGET} PRIVATE base-sdk-wil ComCtl32.Lib RuntimeObject.Lib)
+        # RuntimeObject was only ever needed for the C++/WinRT JSON parser the
+        # settings code used to use; the shared settings store replaced it.
+        target_link_libraries(${SA_TARGET} PRIVATE base-sdk-wil ComCtl32.Lib)
 
     elseif(UNIX)
         target_sources(${SA_TARGET} PRIVATE

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -451,26 +451,35 @@ bool StandaloneHost::isKnownDevice(unsigned int deviceID)
 {
   if (!rtaDac) return false;
 
-  SilenceAudioErrors silence(this);
-
-  for (auto id : rtaDac->getDeviceIds())
+  for (const auto &device : deviceList())
   {
-    if (id == deviceID) return true;
+    if (device.ID == deviceID) return true;
   }
 
   return false;
 }
 
+RtAudio::DeviceInfo StandaloneHost::deviceInfoFor(unsigned int deviceID)
+{
+  for (const auto &device : deviceList())
+  {
+    if (device.ID == deviceID) return device;
+  }
+
+  return {};
+}
+
 std::string StandaloneHost::deviceName(unsigned int deviceID)
 {
-  if (!isKnownDevice(deviceID)) return {};
+  // Answer from the cached enumeration rather than getDeviceInfo(): an id RtAudio
+  // does not recognise raises an error through the error callback, which a
+  // frontend may well be putting in front of the user as a modal dialog.
+  for (const auto &device : deviceList())
+  {
+    if (device.ID == deviceID) return device.name;
+  }
 
-  SilenceAudioErrors silence(this);
-
-  // Only ask once we know the id is real. getDeviceInfo() on an unknown id makes
-  // RtAudio raise an error through the error callback, which a frontend may well
-  // be putting in front of the user as a modal dialog.
-  return rtaDac->getDeviceInfo(deviceID).name;
+  return {};
 }
 
 unsigned int StandaloneHost::resolveInputDevice(const std::string &name)

--- a/src/detail/standalone/standalone_host.cpp
+++ b/src/detail/standalone/standalone_host.cpp
@@ -366,6 +366,147 @@ bool StandaloneHost::tryLoadStandaloneAndPluginSettings(const fs::path &fromDir,
   return true;
 }
 
+std::optional<fs::path> StandaloneHost::standaloneSettingsFile()
+{
+  if (!clapPlugin || !clapPlugin->_plugin || !clapPlugin->_plugin->desc) return std::nullopt;
+
+  auto base = getStandaloneSettingsPath();
+  if (!base.has_value()) return std::nullopt;
+
+  return *base / clapPlugin->_plugin->desc->id / "standalone-settings.conf";
+}
+
+bool StandaloneHost::loadStandaloneSettings()
+{
+  auto path = standaloneSettingsFile();
+  if (!path.has_value()) return false;
+
+  settingsLoaded = settings.load(*path);
+
+  return settingsLoaded;
+}
+
+bool StandaloneHost::saveStandaloneSettings()
+{
+  auto path = standaloneSettingsFile();
+  if (!path.has_value()) return false;
+
+  // The plugin-id directory is shared with the state blobs and usually exists by
+  // now, but a first run which never saved state has yet to create it.
+  try
+  {
+    fs::create_directories(path->parent_path());
+  }
+  catch (const fs::filesystem_error &e)
+  {
+    LOGINFO("[ERROR] Unable to create settings directory '{}': '{}'", path->parent_path().u8string(),
+            e.what());
+    return false;
+  }
+
+  return settings.save(*path);
+}
+
+void StandaloneHost::captureAudioSettings()
+{
+  settings.audioApiName = audioApiName;
+  settings.outputDeviceName = deviceName(audioOutputDeviceID);
+  settings.inputDeviceName = deviceName(audioInputDeviceID);
+  settings.audioOutputUsed = audioOutputUsed;
+  settings.audioInputUsed = audioInputUsed;
+  settings.sampleRate = currentSampleRate;
+  settings.bufferSize = currentBufferSize;
+}
+
+void StandaloneHost::applyAudioSettings()
+{
+  // The API has to be selected first: every device id below is an index into a
+  // particular RtAudio instance's enumeration, so that instance has to be the one
+  // we are about to open a stream on.
+  auto api = RtAudio::Api::UNSPECIFIED;
+  if (!settings.audioApiName.empty())
+  {
+    api = RtAudio::getCompiledApiByName(settings.audioApiName);
+    if (api == RtAudio::Api::UNSPECIFIED)
+    {
+      LOGINFO("[WARNING] Audio API '{}' is not available in this build; using the default",
+              settings.audioApiName);
+    }
+  }
+  setAudioApi(api);
+
+  audioOutputDeviceID = resolveOutputDevice(settings.outputDeviceName);
+  audioInputDeviceID = resolveInputDevice(settings.inputDeviceName);
+
+  // A machine with no capture device still reports a default input device id, so
+  // "did we get an id back" is not the question - "is it a real device" is.
+  audioOutputUsed = settings.audioOutputUsed && isKnownDevice(audioOutputDeviceID);
+  audioInputUsed = settings.audioInputUsed && isKnownDevice(audioInputDeviceID);
+
+  currentSampleRate = settings.sampleRate;
+  currentBufferSize = settings.bufferSize;
+}
+
+bool StandaloneHost::isKnownDevice(unsigned int deviceID)
+{
+  if (!rtaDac) return false;
+
+  SilenceAudioErrors silence(this);
+
+  for (auto id : rtaDac->getDeviceIds())
+  {
+    if (id == deviceID) return true;
+  }
+
+  return false;
+}
+
+std::string StandaloneHost::deviceName(unsigned int deviceID)
+{
+  if (!isKnownDevice(deviceID)) return {};
+
+  SilenceAudioErrors silence(this);
+
+  // Only ask once we know the id is real. getDeviceInfo() on an unknown id makes
+  // RtAudio raise an error through the error callback, which a frontend may well
+  // be putting in front of the user as a modal dialog.
+  return rtaDac->getDeviceInfo(deviceID).name;
+}
+
+unsigned int StandaloneHost::resolveInputDevice(const std::string &name)
+{
+  guaranteeRtAudioDAC();
+
+  if (!name.empty())
+  {
+    for (const auto &device : getInputAudioDevices())
+    {
+      if (device.name == name) return device.ID;
+    }
+
+    LOGINFO("[WARNING] Input device '{}' is not available; using the default", name);
+  }
+
+  return rtaDac->getDefaultInputDevice();
+}
+
+unsigned int StandaloneHost::resolveOutputDevice(const std::string &name)
+{
+  guaranteeRtAudioDAC();
+
+  if (!name.empty())
+  {
+    for (const auto &device : getOutputAudioDevices())
+    {
+      if (device.name == name) return device.ID;
+    }
+
+    LOGINFO("[WARNING] Output device '{}' is not available; using the default", name);
+  }
+
+  return rtaDac->getDefaultOutputDevice();
+}
+
 bool StandaloneHost::activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlock)
 {
   if (!clapPlugin) return false;
@@ -385,6 +526,14 @@ bool StandaloneHost::activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlo
   clapPlugin->start_processing();
   isProcessing = true;
 
+  // Only now let the callback back in. Taking the lock keeps a callback which is
+  // mid-pass from seeing running flip to true against a half-built state.
+  {
+    ClapWrapper::detail::shared::SpinLockGuard g(processLock);
+    finishedRunning = false;
+    running = true;
+  }
+
   return true;
 }
 
@@ -394,6 +543,13 @@ void StandaloneHost::deactivatePlugin()
   // know we activated. Without an audio device the plugin never gets activated
   // at all, and the shutdown path would otherwise deactivate it regardless.
   if (!clapPlugin || !isActive) return;
+
+  // Stop the callback and wait for it to say so before touching the plugin.
+  // Without this, any caller other than the Windows restart handler - an API
+  // switch, a device change, OK in a settings panel - could deactivate() while
+  // process() was in flight. Making the handshake part of deactivate is what
+  // stops each frontend from having to remember it.
+  quiesceProcessing();
 
   if (isProcessing)
   {

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -267,6 +267,16 @@ struct StandaloneHost : Clap::IHost
   std::vector<std::unique_ptr<RtMidiIn>> midiIns;
   uint32_t numMidiPorts{0};
   std::vector<uint32_t> currentMidiPorts;
+  // Port names as the MIDI system reports them right now; also refreshes
+  // numMidiPorts. Returns empty (rather than throwing or exiting) when there is
+  // no usable MIDI system.
+  std::vector<std::string> getMidiPortNames();
+
+  // Close whatever is open and open exactly these, matched by name. bindAll
+  // ignores the list and opens everything - which is a different thing from an
+  // empty list, that being a user who deliberately wants no MIDI input.
+  void openMidiPorts(const std::vector<std::string> &names, bool bindAll);
+
   void startMIDIThread();
   void stopMIDIThread();
   void processMIDIEvents(double deltatime, std::vector<unsigned char> *message);

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -9,6 +9,7 @@
 #include <tuple>
 
 #include "standalone_details.h"
+#include "standalone_settings.h"
 
 #include "detail/clap/fsutil.h"
 
@@ -127,6 +128,34 @@ struct StandaloneHost : Clap::IHost
 
   bool saveStandaloneAndPluginSettings(const fs::path &intoDir, const fs::path &withName);
   bool tryLoadStandaloneAndPluginSettings(const fs::path &fromDir, const fs::path &withName);
+
+  // The audio/MIDI configuration, as opposed to the plugin state blob above.
+  // Frontends read and write this rather than rolling their own store; see
+  // standalone_settings.h for the format and for why devices are held by name.
+  StandaloneSettings settings;
+  bool settingsLoaded{false};
+
+  // <settings path>/<plugin id>/standalone-settings.conf, or nullopt when the
+  // platform has no settings path or no plugin is loaded yet.
+  std::optional<fs::path> standaloneSettingsFile();
+  bool loadStandaloneSettings();
+  bool saveStandaloneSettings();
+
+  // Current audio configuration -> settings, and back. applyAudioSettings()
+  // selects the API and resolves the persisted device *names* against the
+  // devices this machine actually has right now.
+  void captureAudioSettings();
+  void applyAudioSettings();
+
+  // Device id for a persisted name, falling back to the system default when the
+  // name is empty or no longer present. Never throws, never fails.
+  unsigned int resolveInputDevice(const std::string &name);
+  unsigned int resolveOutputDevice(const std::string &name);
+
+  // True when RtAudio's current enumeration contains this id. Ask before calling
+  // getDeviceInfo(): an unknown id raises an error through the error callback.
+  bool isKnownDevice(unsigned int deviceID);
+  std::string deviceName(unsigned int deviceID);
 
   uint32_t numAudioInputs{0}, numAudioOutputs{0};
   std::vector<uint32_t> inputChannelByBus;
@@ -249,11 +278,36 @@ struct StandaloneHost : Clap::IHost
   // Actual audio IO In standalone_host_audio.cpp
   std::unique_ptr<RtAudio> rtaDac;
   std::function<void(const std::string &)> displayAudioError{nullptr};
+
+  // RtAudio reports enumeration failures through the same error callback it uses
+  // for stream failures, and we enumerate every time a settings panel refreshes.
+  // Those are not events to put in front of the user, so the enumeration helpers
+  // below silence the dialog for their duration. Logging is never silenced.
+  std::atomic<int> audioErrorSilence{0};
+  bool audioErrorsAreSilent() const
+  {
+    return audioErrorSilence.load() > 0;
+  }
+  struct SilenceAudioErrors
+  {
+    StandaloneHost *host;
+    explicit SilenceAudioErrors(StandaloneHost *h) : host(h)
+    {
+      host->audioErrorSilence.fetch_add(1);
+    }
+    ~SilenceAudioErrors()
+    {
+      host->audioErrorSilence.fetch_sub(1);
+    }
+  };
   RtAudio::Api audioApi{RtAudio::Api::UNSPECIFIED};
   std::string audioApiName{RtAudio::getApiName(RtAudio::Api::UNSPECIFIED)};
   std::string audioApiDisplayName{RtAudio::getApiDisplayName(RtAudio::Api::UNSPECIFIED)};
   unsigned int audioInputDeviceID{0}, audioOutputDeviceID{0};
   bool audioInputUsed{true}, audioOutputUsed{true};
+  // How many channels to ask the *device* for. Distinct from
+  // totalInput/OutputChannels above, which are the plugin's bus totals.
+  uint32_t deviceInputChannels{2}, deviceOutputChannels{2};
   int32_t currentSampleRate{0};
   uint32_t currentBufferSize{0};
   uint32_t currentInputChannels{0}, currentOutputChannels{0};
@@ -266,21 +320,15 @@ struct StandaloneHost : Clap::IHost
                           int32_t sampleRate);
   void stopAudioThread();
 
+  // Park the audio callback: clear running under processLock, then wait for the
+  // callback to acknowledge. Returns false if the acknowledgement never came.
+  // Callers which are about to touch plugin state must go through this.
+  bool quiesceProcessing();
+
   // the actual work of startAudioThreadOn, wrapped there by an exception guard
   void startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t inputChannels, bool useInput,
                               unsigned int outputDeviceID, uint32_t outputChannels, bool useOutput,
                               int32_t sampleRate);
-
-  bool startupAudioSet{false};
-  unsigned int startAudioIn{0}, startAudioOut{0};
-  int startSampleRate{0};
-  void setStartupAudio(unsigned int in, unsigned int out, int sr)
-  {
-    startupAudioSet = true;
-    startAudioIn = in;
-    startAudioOut = out;
-    startSampleRate = sr;
-  }
 
   // returns true if the plugin is activated and processing afterwards
   bool activatePlugin(int32_t sr, int32_t minBlock, int32_t maxBlock);

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -156,7 +156,24 @@ struct StandaloneHost : Clap::IHost
   // getDeviceInfo(): an unknown id raises an error through the error callback.
   bool isKnownDevice(unsigned int deviceID);
   std::string deviceName(unsigned int deviceID);
+  RtAudio::DeviceInfo deviceInfoFor(unsigned int deviceID);
 
+  // Enumerating is not cheap and is not side-effect free. RtAudio's ASIO backend
+  // loads, ASIOInit()s and unloads *every* installed ASIO driver on each probe,
+  // and some drivers do not survive that being done repeatedly - the Generic Low
+  // Latency driver starts failing to allocate buffers. So the device list is
+  // enumerated once and reused until something happens that could change it.
+  const std::vector<RtAudio::DeviceInfo> &deviceList();
+  void invalidateDeviceList()
+  {
+    deviceListValid = false;
+  }
+
+ private:
+  std::vector<RtAudio::DeviceInfo> deviceListCache;
+  bool deviceListValid{false};
+
+ public:
   uint32_t numAudioInputs{0}, numAudioOutputs{0};
   std::vector<uint32_t> inputChannelByBus;
   std::vector<uint32_t> outputChannelByBus;

--- a/src/detail/standalone/standalone_host_audio.cpp
+++ b/src/detail/standalone/standalone_host_audio.cpp
@@ -156,8 +156,8 @@ void StandaloneHost::startAudioThread()
     }
 
     startAudioThreadOn(audioInputDeviceID, deviceInputChannels, audioInputUsed && numAudioInputs > 0,
-                       audioOutputDeviceID, deviceOutputChannels,
-                       audioOutputUsed && numAudioOutputs > 0, currentSampleRate);
+                       audioOutputDeviceID, deviceOutputChannels, audioOutputUsed && numAudioOutputs > 0,
+                       currentSampleRate);
   }
   catch (const std::exception &e)
   {
@@ -263,8 +263,7 @@ std::vector<uint32_t> StandaloneHost::getBufferSizes()
   // a menu of plausible sizes, not a claim about the device. 16 used to head the
   // list and was taken as the Windows first-run default, which is far too small
   // to run reliably on any backend.
-  std::vector<uint32_t> res{32,  48,  64,  96,  128,  144,  160,
-                            192, 224, 256, 480, 512, 1024, 2048, 4096};
+  std::vector<uint32_t> res{32, 48, 64, 96, 128, 144, 160, 192, 224, 256, 480, 512, 1024, 2048, 4096};
   return res;
 }
 

--- a/src/detail/standalone/standalone_host_audio.cpp
+++ b/src/detail/standalone/standalone_host_audio.cpp
@@ -13,6 +13,7 @@
 #pragma GCC diagnostic pop
 #endif
 
+#include <algorithm>
 #include <exception>
 
 #include "standalone_host.h"
@@ -34,16 +35,7 @@ int rtaCallback(void *outputBuffer, void *inputBuffer, unsigned int nBufferFrame
 
 void rtaErrorCallback(RtAudioErrorType errorType, const std::string &errorText)
 {
-  if (errorType != RTAUDIO_OUTPUT_UNDERFLOW && errorType != RTAUDIO_INPUT_OVERFLOW)
-  {
-    LOGINFO("[ERROR] RtAudio reports '{}' [{}]", errorText, (int)errorType);
-    auto ae = getStandaloneHost()->displayAudioError;
-    if (ae)
-    {
-      ae(errorText);
-    }
-  }
-  else
+  if (errorType == RTAUDIO_OUTPUT_UNDERFLOW || errorType == RTAUDIO_INPUT_OVERFLOW)
   {
     static bool reported = false;
     if (!reported)
@@ -51,6 +43,28 @@ void rtaErrorCallback(RtAudioErrorType errorType, const std::string &errorText)
       LOGINFO("[ERROR] RtAudio reports under/overflow '{}' [{}]", errorText, (int)errorType);
       reported = true;
     }
+    return;
+  }
+
+  LOGINFO("[ERROR] RtAudio reports '{}' [{}]", errorText, (int)errorType);
+
+  auto sh = getStandaloneHost();
+
+  // Everything is logged; deciding what to *show* is a separate question. RtAudio
+  // raises errors from device enumeration, not just from opening a stream, and we
+  // enumerate constantly while populating a settings panel. On a machine with no
+  // audio devices at all that meant one modal dialog per probe, stacked up on the
+  // message loop - which reads to the user as a hang, not as an error.
+  if (sh->audioErrorsAreSilent())
+  {
+    return;
+  }
+
+  auto ae = sh->displayAudioError;
+  if (ae)
+  {
+    LOGINFO("[ERROR] Surfacing to the user: '{}'", errorText);
+    ae(errorText);
   }
 }
 
@@ -65,18 +79,50 @@ void StandaloneHost::guaranteeRtAudioDAC()
 
 void StandaloneHost::setAudioApi(RtAudio::Api api)
 {
+  if (rtaDac && audioApi == api) return;
+
+  // Tear the old backend down completely before the new one is constructed.
+  // Constructing an RtAudio probes the backend's drivers, and some of those
+  // (ASIO above all) reach into process-global SDK state; doing that while the
+  // outgoing backend's realtime thread is still calling us is the WASAPI->ASIO
+  // crash. Destroying the old instance by assigning over it was worse still:
+  // no stop, no running=false handshake, and the isStreamRunning() guard in
+  // startAudioThreadOnImpl could not help because by then rtaDac already
+  // pointed at the new instance.
+  if (rtaDac)
+  {
+    stopAudioThread();
+    deactivatePlugin();
+    rtaDac.reset();
+  }
+
   rtaDac = std::make_unique<RtAudio>(api, &rtaErrorCallback);
-  audioApi = api;
-  audioApiName = rtaDac->getApiName(api);
-  audioApiDisplayName = rtaDac->getApiDisplayName(api);
+
+  // Record what RtAudio actually chose, not what we asked for. Asking for
+  // UNSPECIFIED means "you pick", and persisting that would re-run the probe
+  // (and possibly land somewhere else) on the next launch.
+  audioApi = rtaDac->getCurrentApi();
+  audioApiName = RtAudio::getApiName(audioApi);
+  audioApiDisplayName = RtAudio::getApiDisplayName(audioApi);
   rtaDac->showWarnings(true);
+
+  running = true;
+  finishedRunning = false;
 }
 
 std::tuple<unsigned int, unsigned int, int32_t> StandaloneHost::getDefaultAudioInOutSampleRate()
 {
   guaranteeRtAudioDAC();
+  SilenceAudioErrors silence(this);
+
   auto iid = rtaDac->getDefaultInputDevice();
   auto oid = rtaDac->getDefaultOutputDevice();
+
+  // With no output device attached RtAudio still returns a default id, and asking
+  // it for info raises an error the frontend may show to the user. Report a rate
+  // of 0 instead and let the caller decide what to do about having no output.
+  if (!isKnownDevice(oid)) return {iid, oid, 0};
+
   auto outInfo = rtaDac->getDeviceInfo(oid);
   auto sr = outInfo.currentSampleRate;
   if (sr < 1)
@@ -90,21 +136,28 @@ void StandaloneHost::startAudioThread()
 {
   try
   {
-    guaranteeRtAudioDAC();
-
-    if (startupAudioSet)
+    // Persisted configuration wins when we have some; otherwise take the system
+    // defaults. A frontend which drives the settings UI itself (Windows) applies
+    // them before it gets here and simply calls startAudioThreadOn directly.
+    if (loadStandaloneSettings())
     {
-      auto in = startAudioIn;
-      auto out = startAudioOut;
-      auto sr = startSampleRate;
-      startAudioThreadOn(in, 2, in > 0 && numAudioInputs > 0, out, 2, out > 0 && numAudioOutputs > 0,
-                         sr);
+      applyAudioSettings();
     }
     else
     {
+      guaranteeRtAudioDAC();
+
       auto [in, out, sr] = getDefaultAudioInOutSampleRate();
-      startAudioThreadOn(in, 2, numAudioInputs > 0, out, 2, numAudioOutputs > 0, sr);
+      audioInputDeviceID = in;
+      audioOutputDeviceID = out;
+      audioInputUsed = isKnownDevice(in);
+      audioOutputUsed = isKnownDevice(out);
+      currentSampleRate = sr;
     }
+
+    startAudioThreadOn(audioInputDeviceID, deviceInputChannels, audioInputUsed && numAudioInputs > 0,
+                       audioOutputDeviceID, deviceOutputChannels,
+                       audioOutputUsed && numAudioOutputs > 0, currentSampleRate);
   }
   catch (const std::exception &e)
   {
@@ -114,7 +167,7 @@ void StandaloneHost::startAudioThread()
   }
   catch (...)
   {
-    // winrt/COM errors don't derive from std::exception
+    // COM errors don't derive from std::exception
     LOGINFO("[ERROR] Unknown exception while setting up audio");
     if (displayAudioError) displayAudioError("Unknown error while setting up audio");
   }
@@ -150,26 +203,52 @@ std::vector<RtAudio::Api> StandaloneHost::getCompiledApi()
 std::vector<RtAudio::DeviceInfo> StandaloneHost::getInputAudioDevices()
 {
   guaranteeRtAudioDAC();
+  SilenceAudioErrors silence(this);
   return filterDevicesBy(rtaDac, [](auto &a) { return a.inputChannels > 0; });
 }
 
 std::vector<RtAudio::DeviceInfo> StandaloneHost::getOutputAudioDevices()
 {
   guaranteeRtAudioDAC();
+  SilenceAudioErrors silence(this);
   return filterDevicesBy(rtaDac, [](auto &a) { return a.outputChannels > 0; });
 }
 
 std::vector<int32_t> StandaloneHost::getSampleRates()
 {
   guaranteeRtAudioDAC();
+  SilenceAudioErrors silence(this);
 
   std::vector<int32_t> res;
 
-  auto samplesRates{rtaDac->getDeviceInfo(audioInputDeviceID).sampleRates};
+  // The rates the *stream* could run at: the output device's, narrowed to the
+  // input device's when both are going to be opened. This used to read the input
+  // device's rates only - even when input was unused, and even when the id named
+  // no device at all, which raised an RtAudio error the frontend then showed as
+  // a modal dialog.
+  const bool useOutput{audioOutputUsed && isKnownDevice(audioOutputDeviceID)};
+  const bool useInput{audioInputUsed && isKnownDevice(audioInputDeviceID)};
 
-  for (auto &sampleRate : rtaDac->getDeviceInfo(audioInputDeviceID).sampleRates)
+  if (!useOutput && !useInput) return res;
+
+  const auto primary{useOutput ? audioOutputDeviceID : audioInputDeviceID};
+  for (auto sampleRate : rtaDac->getDeviceInfo(primary).sampleRates)
   {
-    res.push_back(sampleRate);
+    res.push_back(static_cast<int32_t>(sampleRate));
+  }
+
+  if (useOutput && useInput)
+  {
+    auto inputRates{rtaDac->getDeviceInfo(audioInputDeviceID).sampleRates};
+
+    res.erase(std::remove_if(res.begin(), res.end(),
+                             [&inputRates](int32_t sampleRate)
+                             {
+                               return std::find(inputRates.begin(), inputRates.end(),
+                                                static_cast<unsigned int>(sampleRate)) ==
+                                      inputRates.end();
+                             }),
+              res.end());
   }
 
   return res;
@@ -179,7 +258,12 @@ std::vector<uint32_t> StandaloneHost::getBufferSizes()
 {
   guaranteeRtAudioDAC();
 
-  std::vector<uint32_t> res{16,  32,  48,  64,  96,  128,  144,  160,
+  // RtAudio has no way to ask a device what it supports; you find out by trying
+  // to open it, and openStream reports back what it actually granted. So this is
+  // a menu of plausible sizes, not a claim about the device. 16 used to head the
+  // list and was taken as the Windows first-run default, which is far too small
+  // to run reliably on any backend.
+  std::vector<uint32_t> res{32,  48,  64,  96,  128,  144,  160,
                             192, 224, 256, 480, 512, 1024, 2048, 4096};
   return res;
 }
@@ -217,20 +301,50 @@ void StandaloneHost::startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t
 {
   guaranteeRtAudioDAC();
 
-  if (rtaDac->isStreamRunning())
-  {
-    stopAudioThread();
-    running = true;
-    finishedRunning = false;
-  }
+  // activatePlugin below is what lets the callback back in, so there is no need
+  // to reset running/finishedRunning here.
+  stopAudioThread();
 
   audioInputDeviceID = inputDeviceID;
   audioInputUsed = useInput;
   audioOutputDeviceID = outputDeviceID;
   audioOutputUsed = useOutput;
 
-  auto dids = rtaDac->getDeviceIds();
-  auto dnms = rtaDac->getDeviceNames();
+  // Enumeration only - these exist to name the devices in the log below.
+  std::vector<unsigned int> dids;
+  std::vector<std::string> dnms;
+  {
+    SilenceAudioErrors silence(this);
+    dids = rtaDac->getDeviceIds();
+    dnms = rtaDac->getDeviceNames();
+  }
+
+  // getDeviceInfo() on an id RtAudio doesn't know raises an error through the
+  // error callback, which frontends put in front of the user as a modal dialog.
+  // That happens on entirely ordinary machines: a box with no capture device at
+  // all still reports a default input device id of 0, which is not a real device.
+  // So check before asking, and drop the side we cannot open rather than failing
+  // the whole stream.
+  if (useOutput && !isKnownDevice(outputDeviceID))
+  {
+    LOGINFO("[ERROR] Output device id {} is not present; no audio output", outputDeviceID);
+    useOutput = false;
+    audioOutputUsed = false;
+  }
+
+  if (useInput && !isKnownDevice(inputDeviceID))
+  {
+    LOGINFO("[WARNING] Input device id {} is not present; continuing without audio input",
+            inputDeviceID);
+    useInput = false;
+    audioInputUsed = false;
+  }
+
+  if (!useOutput && !useInput)
+  {
+    LOGINFO("[ERROR] Neither an input nor an output device is available; audio is not starting");
+    return;
+  }
 
   RtAudio::StreamParameters oParams;
   int32_t sampleRate{reqSampleRate};
@@ -281,18 +395,15 @@ void StandaloneHost::startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t
   RtAudio::StreamOptions options;
   options.flags = RTAUDIO_SCHEDULE_REALTIME;
 
-  /*
-   * RTAudio doesn't tell you what the possible frame sizes are but instead
-   * just tells you to try open stream with power of twos you want. So leave
-   * this for now at 256 and return to it shortly.
-   */
-  LOGINFO("[WARNING] Hardcoding frame size to 256 samples for now");
-
   if (currentBufferSize == 0)
   {
-    currentBufferSize = 256;
+    currentBufferSize = StandaloneSettings::defaultBufferSize;
   }
 
+  // openStream writes the size it actually granted back through this, which may
+  // not be what we asked for, so everything downstream - activation bounds, the
+  // settings we persist, the value shown in a settings panel - has to read it
+  // back rather than assume the request was honoured.
   if (rtaDac->openStream((useOutput) ? &oParams : nullptr, (useInput) ? &iParams : nullptr,
                          RTAUDIO_FLOAT32, sampleRate, &currentBufferSize, &rtaCallback, (void *)this,
                          &options))
@@ -301,6 +412,8 @@ void StandaloneHost::startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t
     rtaDac->closeStream();
     return;
   }
+
+  LOGDETAIL("RtAudio granted a buffer size of {} frames", currentBufferSize);
 
   if (!activatePlugin(sampleRate, 1, currentBufferSize * 2))
   {
@@ -344,29 +457,55 @@ void StandaloneHost::startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t
 
 void StandaloneHost::stopAudioThread()
 {
-  LOGINFO("Shutting down audio");
   if (!rtaDac) return;
 
   if (!rtaDac->isStreamRunning())
   {
+    // Nothing is running, but the stream may still be open from a failed start.
+    if (rtaDac->isStreamOpen()) rtaDac->closeStream();
+    return;
   }
-  else
+
+  LOGINFO("Shutting down audio");
+
+  if (!quiesceProcessing())
   {
-    running = false;
-
-    // bit of a hack. Wait until we get an ack from audio callback
-    for (auto i = 0; i < 10000 && !finishedRunning; ++i)
-    {
-      using namespace std::chrono_literals;
-      std::this_thread::sleep_for(1ms);
-    }
-
-    if (rtaDac && rtaDac->isStreamRunning())
-    {
-      rtaDac->stopStream();
-      rtaDac->closeStream();
-    }
+    // Shut the stream down anyway: leaving it running is strictly worse than
+    // closing one whose last callback we could not confirm.
+    LOGINFO("[ERROR] Audio callback did not acknowledge the stop; closing the stream regardless");
   }
-  return;
+
+  if (rtaDac->isStreamRunning())
+  {
+    rtaDac->stopStream();
+    rtaDac->closeStream();
+  }
+}
+
+bool StandaloneHost::quiesceProcessing()
+{
+  {
+    // Setting this under the lock means a callback either observes running==false
+    // for its whole pass, or completes the pass it had already begun. It cannot
+    // see the flag change mid-process().
+    ClapWrapper::detail::shared::SpinLockGuard g(processLock);
+    running = false;
+  }
+
+  if (!rtaDac || !rtaDac->isStreamRunning())
+  {
+    // No callback is going to run, so there is no ack coming and none needed.
+    return true;
+  }
+
+  // Wait for the callback to tell us it has seen the flag. A block can legitimately
+  // take a while at large buffer sizes, but two seconds means it is never coming.
+  using namespace std::chrono_literals;
+  for (auto i = 0; i < 2000 && !finishedRunning; ++i)
+  {
+    std::this_thread::sleep_for(1ms);
+  }
+
+  return finishedRunning;
 }
 }  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_host_audio.cpp
+++ b/src/detail/standalone/standalone_host_audio.cpp
@@ -96,6 +96,10 @@ void StandaloneHost::setAudioApi(RtAudio::Api api)
     rtaDac.reset();
   }
 
+  // Device ids belong to the instance that enumerated them, so the cached list
+  // means nothing once the backend changes.
+  invalidateDeviceList();
+
   rtaDac = std::make_unique<RtAudio>(api, &rtaErrorCallback);
 
   // Record what RtAudio actually chose, not what we asked for. Asking for
@@ -173,15 +177,12 @@ void StandaloneHost::startAudioThread()
   }
 }
 
-std::vector<RtAudio::DeviceInfo> filterDevicesBy(const std::unique_ptr<RtAudio> &rtaDac,
+std::vector<RtAudio::DeviceInfo> filterDevicesBy(const std::vector<RtAudio::DeviceInfo> &devices,
                                                  std::function<bool(const RtAudio::DeviceInfo &)> f)
 {
   std::vector<RtAudio::DeviceInfo> res;
-  auto dids = rtaDac->getDeviceIds();
-  auto dnms = rtaDac->getDeviceNames();
-  for (auto d : dids)
+  for (const auto &inf : devices)
   {
-    auto inf = rtaDac->getDeviceInfo(d);
     if (f(inf))
     {
       res.push_back(inf);
@@ -200,18 +201,34 @@ std::vector<RtAudio::Api> StandaloneHost::getCompiledApi()
   return compiledApi;
 }
 
-std::vector<RtAudio::DeviceInfo> StandaloneHost::getInputAudioDevices()
+const std::vector<RtAudio::DeviceInfo> &StandaloneHost::deviceList()
 {
   guaranteeRtAudioDAC();
-  SilenceAudioErrors silence(this);
-  return filterDevicesBy(rtaDac, [](auto &a) { return a.inputChannels > 0; });
+
+  if (!deviceListValid)
+  {
+    SilenceAudioErrors silence(this);
+
+    deviceListCache.clear();
+    for (auto id : rtaDac->getDeviceIds())
+    {
+      deviceListCache.push_back(rtaDac->getDeviceInfo(id));
+    }
+
+    deviceListValid = true;
+  }
+
+  return deviceListCache;
+}
+
+std::vector<RtAudio::DeviceInfo> StandaloneHost::getInputAudioDevices()
+{
+  return filterDevicesBy(deviceList(), [](auto &a) { return a.inputChannels > 0; });
 }
 
 std::vector<RtAudio::DeviceInfo> StandaloneHost::getOutputAudioDevices()
 {
-  guaranteeRtAudioDAC();
-  SilenceAudioErrors silence(this);
-  return filterDevicesBy(rtaDac, [](auto &a) { return a.outputChannels > 0; });
+  return filterDevicesBy(deviceList(), [](auto &a) { return a.outputChannels > 0; });
 }
 
 std::vector<int32_t> StandaloneHost::getSampleRates()
@@ -226,20 +243,29 @@ std::vector<int32_t> StandaloneHost::getSampleRates()
   // device's rates only - even when input was unused, and even when the id named
   // no device at all, which raised an RtAudio error the frontend then showed as
   // a modal dialog.
+  auto ratesOf = [this](unsigned int deviceID)
+  {
+    for (const auto &device : deviceList())
+    {
+      if (device.ID == deviceID) return device.sampleRates;
+    }
+    return std::vector<unsigned int>{};
+  };
+
   const bool useOutput{audioOutputUsed && isKnownDevice(audioOutputDeviceID)};
   const bool useInput{audioInputUsed && isKnownDevice(audioInputDeviceID)};
 
   if (!useOutput && !useInput) return res;
 
   const auto primary{useOutput ? audioOutputDeviceID : audioInputDeviceID};
-  for (auto sampleRate : rtaDac->getDeviceInfo(primary).sampleRates)
+  for (auto sampleRate : ratesOf(primary))
   {
     res.push_back(static_cast<int32_t>(sampleRate));
   }
 
   if (useOutput && useInput)
   {
-    auto inputRates{rtaDac->getDeviceInfo(audioInputDeviceID).sampleRates};
+    auto inputRates{ratesOf(audioInputDeviceID)};
 
     res.erase(std::remove_if(res.begin(), res.end(),
                              [&inputRates](int32_t sampleRate)
@@ -309,15 +335,6 @@ void StandaloneHost::startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t
   audioOutputDeviceID = outputDeviceID;
   audioOutputUsed = useOutput;
 
-  // Enumeration only - these exist to name the devices in the log below.
-  std::vector<unsigned int> dids;
-  std::vector<std::string> dnms;
-  {
-    SilenceAudioErrors silence(this);
-    dids = rtaDac->getDeviceIds();
-    dnms = rtaDac->getDeviceNames();
-  }
-
   // getDeviceInfo() on an id RtAudio doesn't know raises an error through the
   // error callback, which frontends put in front of the user as a modal dialog.
   // That happens on entirely ordinary machines: a box with no capture device at
@@ -347,11 +364,12 @@ void StandaloneHost::startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t
 
   RtAudio::StreamParameters oParams;
   int32_t sampleRate{reqSampleRate};
+  RtAudio::DeviceInfo outInfo, inInfo;
 
   if (useOutput)
   {
     oParams.deviceId = outputDeviceID;
-    auto outInfo = rtaDac->getDeviceInfo(oParams.deviceId);
+    outInfo = deviceInfoFor(outputDeviceID);
     oParams.nChannels = std::min(outputChannels, outInfo.outputChannels);
     oParams.firstChannel = 0;
     if (sampleRate < 0)
@@ -377,7 +395,7 @@ void StandaloneHost::startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t
   if (useInput)
   {
     iParams.deviceId = inputDeviceID;
-    auto inInfo = rtaDac->getDeviceInfo(iParams.deviceId);
+    inInfo = deviceInfoFor(inputDeviceID);
     iParams.nChannels = std::min(inputChannels, inInfo.inputChannels);
     iParams.firstChannel = 0;
     if (sampleRate < 0) sampleRate = inInfo.preferredSampleRate;
@@ -421,24 +439,15 @@ void StandaloneHost::startAudioThreadOnImpl(unsigned int inputDeviceID, uint32_t
     return;
   }
 
-  LOGDETAIL("RtAudio Attached Devices");
   if (useOutput)
   {
-    for (auto i = 0U; i < dids.size(); ++i)
-    {
-      if (oParams.deviceId == dids[i]) LOGDETAIL("  - Output : '{}'", dnms[i]);
-    }
     currentOutputChannels = oParams.nChannels;
-    LOGDETAIL("RtAudio Output Stream Channels {}", oParams.nChannels);
+    LOGDETAIL("RtAudio output : '{}', {} channels", outInfo.name, oParams.nChannels);
   }
   if (useInput)
   {
-    for (auto i = 0U; i < dids.size(); ++i)
-    {
-      if (iParams.deviceId == dids[i]) LOGDETAIL("  - Input : '{}'", dnms[i]);
-    }
     currentInputChannels = iParams.nChannels;
-    LOGDETAIL("RtAudio Input Stream Channels {}", iParams.nChannels);
+    LOGDETAIL("RtAudio input : '{}', {} channels", inInfo.name, iParams.nChannels);
   }
 
   if (!rtaDac->isStreamOpen())

--- a/src/detail/standalone/standalone_host_midi.cpp
+++ b/src/detail/standalone/standalone_host_midi.cpp
@@ -50,8 +50,7 @@ void StandaloneHost::openMidiPorts(const std::vector<std::string> &names, bool b
 
   for (unsigned int port = 0; port < available.size(); ++port)
   {
-    if (!bindAll &&
-        std::find(names.begin(), names.end(), available[port]) == names.end())
+    if (!bindAll && std::find(names.begin(), names.end(), available[port]) == names.end())
     {
       continue;
     }

--- a/src/detail/standalone/standalone_host_midi.cpp
+++ b/src/detail/standalone/standalone_host_midi.cpp
@@ -1,6 +1,8 @@
 #include "standalone_host.h"
 #include "standalone_details.h"
 
+#include <algorithm>
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"  // other peoples errors are outside my scope
@@ -14,36 +16,82 @@
 
 namespace freeaudio::clap_wrapper::standalone
 {
-void StandaloneHost::startMIDIThread()
+std::vector<std::string> StandaloneHost::getMidiPortNames()
 {
+  std::vector<std::string> names;
+
   try
   {
-    LOGINFO("Initializing Midi");
     auto midiIn = std::make_unique<RtMidiIn>();
     numMidiPorts = midiIn->getPortCount();
+
+    for (unsigned int i = 0; i < numMidiPorts; ++i)
+    {
+      names.push_back(midiIn->getPortName(i));
+    }
   }
   catch (RtMidiError &error)
   {
-    error.printMessage();
-    exit(EXIT_FAILURE);
+    // No MIDI system at all - on Linux this is the routine "ALSA sequencer is not
+    // available" case. Report no ports; it is not a reason to end the process.
+    LOGINFO("[ERROR] Unable to enumerate MIDI inputs: '{}'", error.getMessage());
+    numMidiPorts = 0;
+    names.clear();
   }
 
-  LOGDETAIL("MIDI: There are {} MIDI input sources available. Binding all.", numMidiPorts);
-  for (unsigned int i = 0; i < numMidiPorts; i++)
+  return names;
+}
+
+void StandaloneHost::openMidiPorts(const std::vector<std::string> &names, bool bindAll)
+{
+  stopMIDIThread();
+
+  auto available = getMidiPortNames();
+
+  for (unsigned int port = 0; port < available.size(); ++port)
   {
+    if (!bindAll &&
+        std::find(names.begin(), names.end(), available[port]) == names.end())
+    {
+      continue;
+    }
+
     try
     {
       auto midiIn = std::make_unique<RtMidiIn>();
-      LOGDETAIL("  - '{}'", midiIn->getPortName(i));
-      midiIn->openPort(i);
+      LOGDETAIL("MIDI: opening '{}'", available[port]);
+      midiIn->openPort(port);
       midiIn->setCallback(midiCallback, this);
       midiIns.push_back(std::move(midiIn));
+      currentMidiPorts.push_back(port);
     }
     catch (RtMidiError &error)
     {
-      error.printMessage();
+      LOGINFO("[ERROR] Unable to open MIDI input '{}': '{}'", available[port], error.getMessage());
     }
   }
+
+  // Ports selected in a previous session which are not plugged in now.
+  if (!bindAll)
+  {
+    for (const auto &wanted : names)
+    {
+      if (std::find(available.begin(), available.end(), wanted) == available.end())
+      {
+        LOGINFO("[WARNING] MIDI input '{}' is not available", wanted);
+      }
+    }
+  }
+}
+
+void StandaloneHost::startMIDIThread()
+{
+  LOGINFO("Initializing Midi");
+
+  // Honour the persisted selection. This used to bind every port unconditionally
+  // while the settings UI showed nothing as selected, and it ended the whole
+  // process with exit(EXIT_FAILURE) if constructing the first RtMidiIn threw.
+  openMidiPorts(settings.midiPortNames, settings.midiBindAllPorts);
 }
 
 void StandaloneHost::processMIDIEvents(double deltatime, std::vector<unsigned char> *message)
@@ -67,10 +115,10 @@ void StandaloneHost::midiCallback(double deltatime, std::vector<unsigned char> *
 
 void StandaloneHost::stopMIDIThread()
 {
-  for (auto &m : midiIns)
-  {
-    m.reset();
-  }
+  // Resetting the pointers left the vector full of empty slots, so a second call
+  // walked a list of nothing and a reopen appended to the stale entries.
+  midiIns.clear();
+  currentMidiPorts.clear();
 }
 
 }  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_settings.cpp
+++ b/src/detail/standalone/standalone_settings.cpp
@@ -169,9 +169,10 @@ bool StandaloneSettings::load(const fs::path &fromFile)
 
     if (loaded.version > currentVersion)
     {
-      LOGINFO("[WARNING] Standalone settings are version {} but this build understands {}; "
-              "reading what we recognise",
-              loaded.version, currentVersion);
+      LOGINFO(
+          "[WARNING] Standalone settings are version {} but this build understands {}; "
+          "reading what we recognise",
+          loaded.version, currentVersion);
     }
 
     if (!sawMidiSelection)

--- a/src/detail/standalone/standalone_settings.cpp
+++ b/src/detail/standalone/standalone_settings.cpp
@@ -1,0 +1,258 @@
+#include "standalone_settings.h"
+#include "standalone_details.h"
+
+#include <cstdlib>
+#include <fstream>
+
+namespace freeaudio::clap_wrapper::standalone
+{
+namespace
+{
+std::string trim(const std::string &in)
+{
+  auto isSpace = [](unsigned char c) { return c == ' ' || c == '\t' || c == '\r' || c == '\n'; };
+
+  size_t b{0}, e{in.size()};
+  while (b < e && isSpace(static_cast<unsigned char>(in[b]))) ++b;
+  while (e > b && isSpace(static_cast<unsigned char>(in[e - 1]))) --e;
+
+  return in.substr(b, e - b);
+}
+
+// Only the characters which would break the line-oriented format need escaping.
+// Everything else, UTF-8 included, is written through as-is.
+std::string escape(const std::string &in)
+{
+  std::string out;
+  out.reserve(in.size());
+
+  for (auto c : in)
+  {
+    switch (c)
+    {
+      case '\\':
+        out += "\\\\";
+        break;
+      case '\n':
+        out += "\\n";
+        break;
+      case '\r':
+        out += "\\r";
+        break;
+      default:
+        out += c;
+        break;
+    }
+  }
+
+  return out;
+}
+
+std::string unescape(const std::string &in)
+{
+  std::string out;
+  out.reserve(in.size());
+
+  for (size_t i = 0; i < in.size(); ++i)
+  {
+    if (in[i] != '\\' || i + 1 == in.size())
+    {
+      out += in[i];
+      continue;
+    }
+
+    switch (in[++i])
+    {
+      case 'n':
+        out += '\n';
+        break;
+      case 'r':
+        out += '\r';
+        break;
+      case '\\':
+        out += '\\';
+        break;
+      default:
+        // An escape we don't know: keep both characters rather than eat one.
+        out += '\\';
+        out += in[i];
+        break;
+    }
+  }
+
+  return out;
+}
+
+bool asBool(const std::string &v)
+{
+  return v == "true" || v == "1" || v == "yes";
+}
+
+const char *fromBool(bool v)
+{
+  return v ? "true" : "false";
+}
+}  // namespace
+
+bool StandaloneSettings::load(const fs::path &fromFile)
+{
+  try
+  {
+    std::ifstream ifs(fromFile, std::ios::in | std::ios::binary);
+    if (!ifs.is_open()) return false;
+
+    StandaloneSettings loaded;
+
+    // Distinguish "this file predates MIDI selection" from "the user deselected
+    // every port". Only an explicit key means the latter.
+    bool sawMidiSelection{false};
+    bool sawAnyKey{false};
+
+    std::string line;
+    while (std::getline(ifs, line))
+    {
+      auto trimmed = trim(line);
+      if (trimmed.empty() || trimmed[0] == '#') continue;
+
+      auto eq = trimmed.find('=');
+      if (eq == std::string::npos) continue;
+
+      // Split on the first '=' only: device names are allowed to contain one.
+      auto key = trim(trimmed.substr(0, eq));
+      auto value = unescape(trim(trimmed.substr(eq + 1)));
+      if (key.empty()) continue;
+
+      sawAnyKey = true;
+
+      if (key == "version")
+        loaded.version = std::atoi(value.c_str());
+      else if (key == "audioApiName")
+        loaded.audioApiName = value;
+      else if (key == "inputDeviceName")
+        loaded.inputDeviceName = value;
+      else if (key == "outputDeviceName")
+        loaded.outputDeviceName = value;
+      else if (key == "audioInputUsed")
+        loaded.audioInputUsed = asBool(value);
+      else if (key == "audioOutputUsed")
+        loaded.audioOutputUsed = asBool(value);
+      else if (key == "sampleRate")
+        loaded.sampleRate = static_cast<int32_t>(std::atol(value.c_str()));
+      else if (key == "bufferSize")
+        loaded.bufferSize = static_cast<uint32_t>(std::atol(value.c_str()));
+      else if (key == "midiBindAllPorts")
+      {
+        loaded.midiBindAllPorts = asBool(value);
+        sawMidiSelection = true;
+      }
+      else if (key == "midiPort")
+      {
+        loaded.midiPortNames.push_back(value);
+        sawMidiSelection = true;
+      }
+      else if (key == "windowX")
+      {
+        loaded.windowX = static_cast<int32_t>(std::atol(value.c_str()));
+        loaded.hasWindowPosition = true;
+      }
+      else if (key == "windowY")
+        loaded.windowY = static_cast<int32_t>(std::atol(value.c_str()));
+      else if (key == "windowWidth")
+        loaded.windowWidth = static_cast<uint32_t>(std::atol(value.c_str()));
+      else if (key == "windowHeight")
+        loaded.windowHeight = static_cast<uint32_t>(std::atol(value.c_str()));
+      else
+        loaded.unknownKeys.emplace_back(key, value);
+    }
+
+    if (!sawAnyKey) return false;
+
+    if (loaded.version > currentVersion)
+    {
+      LOGINFO("[WARNING] Standalone settings are version {} but this build understands {}; "
+              "reading what we recognise",
+              loaded.version, currentVersion);
+    }
+
+    if (!sawMidiSelection)
+    {
+      // Written before port selection existed: keep binding everything.
+      loaded.midiBindAllPorts = true;
+      loaded.midiPortNames.clear();
+    }
+
+    *this = loaded;
+
+    return true;
+  }
+  catch (const std::exception &e)
+  {
+    LOGINFO("[ERROR] Unable to read standalone settings: '{}'", e.what());
+    return false;
+  }
+  catch (...)
+  {
+    LOGINFO("[ERROR] Unable to read standalone settings");
+    return false;
+  }
+}
+
+bool StandaloneSettings::save(const fs::path &intoFile) const
+{
+  try
+  {
+    std::ofstream ofs(intoFile, std::ios::out | std::ios::binary | std::ios::trunc);
+    if (!ofs.is_open())
+    {
+      LOGINFO("[ERROR] Unable to open standalone settings for writing '{}'", intoFile.u8string());
+      return false;
+    }
+
+    ofs << "# clap-wrapper standalone settings.\n";
+    ofs << "# Audio devices and MIDI ports are matched by name when the standalone starts.\n";
+    ofs << "# An unmatched name falls back to the system default rather than failing.\n";
+    ofs << "version=" << currentVersion << "\n";
+
+    ofs << "audioApiName=" << escape(audioApiName) << "\n";
+    ofs << "outputDeviceName=" << escape(outputDeviceName) << "\n";
+    ofs << "inputDeviceName=" << escape(inputDeviceName) << "\n";
+    ofs << "audioOutputUsed=" << fromBool(audioOutputUsed) << "\n";
+    ofs << "audioInputUsed=" << fromBool(audioInputUsed) << "\n";
+    ofs << "sampleRate=" << sampleRate << "\n";
+    ofs << "bufferSize=" << bufferSize << "\n";
+
+    ofs << "midiBindAllPorts=" << fromBool(midiBindAllPorts) << "\n";
+    for (const auto &port : midiPortNames)
+    {
+      ofs << "midiPort=" << escape(port) << "\n";
+    }
+
+    if (hasWindowPosition)
+    {
+      ofs << "windowX=" << windowX << "\n";
+      ofs << "windowY=" << windowY << "\n";
+      ofs << "windowWidth=" << windowWidth << "\n";
+      ofs << "windowHeight=" << windowHeight << "\n";
+    }
+
+    for (const auto &[key, value] : unknownKeys)
+    {
+      ofs << escape(key) << "=" << escape(value) << "\n";
+    }
+
+    ofs.flush();
+
+    return static_cast<bool>(ofs);
+  }
+  catch (const std::exception &e)
+  {
+    LOGINFO("[ERROR] Unable to write standalone settings: '{}'", e.what());
+    return false;
+  }
+  catch (...)
+  {
+    LOGINFO("[ERROR] Unable to write standalone settings");
+    return false;
+  }
+}
+}  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/standalone_settings.h
+++ b/src/detail/standalone/standalone_settings.h
@@ -43,7 +43,7 @@ struct StandaloneSettings
   std::string outputDeviceName;  // empty means the system default device
   bool audioInputUsed{true};
   bool audioOutputUsed{true};
-  int32_t sampleRate{0};                      // 0 means the device's preferred rate
+  int32_t sampleRate{0};  // 0 means the device's preferred rate
   uint32_t bufferSize{defaultBufferSize};
 
   // An empty selection means "open every port", which is what the standalone did

--- a/src/detail/standalone/standalone_settings.h
+++ b/src/detail/standalone/standalone_settings.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "detail/clap/fsutil.h"
+
+namespace freeaudio::clap_wrapper::standalone
+{
+/*
+ * The standalone's audio and MIDI configuration, persisted alongside the plugin
+ * state blob. This is the "settings envelope" the state streaming code has always
+ * wanted: plugin state answers what the plugin sounds like, this answers what it
+ * is plugged into.
+ *
+ * Devices and MIDI ports are identified by *name*, never by RtAudio's numeric
+ * device id. Those ids are per-RtAudio-instance enumeration handles: they are not
+ * stable across a restart, and not even across an API switch within one session.
+ *
+ * The on-disk format is flat UTF-8 key=value text, one pair per line, '#' comments,
+ * so that a platform with no settings UI still has a supported way to configure the
+ * standalone. Keys we do not recognise survive a load/save round trip untouched, so
+ * settings written by a newer build are not silently destroyed by an older one.
+ *
+ * Leading and trailing whitespace is trimmed from both key and value, so a value
+ * cannot begin or end with a space. No device or port name in practice does.
+ */
+struct StandaloneSettings
+{
+  static constexpr int currentVersion{1};
+
+  // The frame count to ask for when nothing has been chosen yet. RtAudio cannot be
+  // asked what a device supports; you find out by trying to open it. 256 is the
+  // value that works essentially everywhere.
+  static constexpr uint32_t defaultBufferSize{256};
+
+  int version{currentVersion};
+
+  std::string audioApiName;      // RtAudio::getApiName(); empty means unspecified
+  std::string inputDeviceName;   // empty means the system default device
+  std::string outputDeviceName;  // empty means the system default device
+  bool audioInputUsed{true};
+  bool audioOutputUsed{true};
+  int32_t sampleRate{0};                      // 0 means the device's preferred rate
+  uint32_t bufferSize{defaultBufferSize};
+
+  // An empty selection means "open every port", which is what the standalone did
+  // before ports could be selected at all, and is the friendlier first run.
+  bool midiBindAllPorts{true};
+  std::vector<std::string> midiPortNames;
+
+  bool hasWindowPosition{false};
+  int32_t windowX{0}, windowY{0};
+  uint32_t windowWidth{0}, windowHeight{0};
+
+  // Keys from a future version, carried through verbatim on rewrite.
+  std::vector<std::pair<std::string, std::string>> unknownKeys;
+
+  // Neither of these throws; both report failure by returning false.
+  bool load(const fs::path &fromFile);
+  bool save(const fs::path &intoFile) const;
+};
+}  // namespace freeaudio::clap_wrapper::standalone

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -879,13 +879,13 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
         {
           if (LOWORD(msg.wparam) == Settings::Identifier::AudioApi)
           {
-            initializeAudio(sah->getCompiledApi()[settings.api.get()]);
+            selectAudioApi(sah->getCompiledApi()[settings.api.get()]);
 
             refreshOutputs();
             refreshInputs();
 
-            settings.output.set(sah->rtaDac->getDeviceInfo(sah->audioOutputDeviceID).name);
-            settings.input.set(sah->rtaDac->getDeviceInfo(sah->audioInputDeviceID).name);
+            settings.output.set(sah->deviceName(sah->audioOutputDeviceID));
+            settings.input.set(sah->deviceName(sah->audioInputDeviceID));
 
             refreshSampleRates();
             refreshBufferSizes();
@@ -901,7 +901,7 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
           {
             sah->audioOutputDeviceID = sah->getOutputAudioDevices()[settings.output.get()].ID;
 
-            sah->totalOutputChannels =
+            sah->deviceOutputChannels =
                 sah->getOutputAudioDevices()[settings.output.get()].outputChannels;
 
             refreshSampleRates();
@@ -915,7 +915,7 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
           {
             sah->audioInputDeviceID = sah->getInputAudioDevices()[settings.input.get()].ID;
 
-            sah->totalInputChannels = sah->getInputAudioDevices()[settings.input.get()].inputChannels;
+            sah->deviceInputChannels = sah->getInputAudioDevices()[settings.input.get()].inputChannels;
 
             refreshSampleRates();
             refreshBufferSizes();
@@ -1005,17 +1005,11 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
 
                  if (sah->restartRequested.exchange(false))
                  {
-                   // manually set running to false to make clapProcess a no-op
-                   // while the plugin is being reactivated. otherwise,
-                   // stopping and starting the entire audio engine is probably
-                   // overkill.
-                   {
-                     ClapWrapper::detail::shared::SpinLockGuard g(sah->processLock);
-                     sah->running = false;
-                   }
-                   // stay stopped if the plugin refused to reactivate
-                   sah->running =
-                       sah->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
+                   // Reactivate in place rather than bouncing the whole audio
+                   // engine. activatePlugin parks the callback, reactivates, and
+                   // only then lets processing resume - and leaves it stopped if
+                   // the plugin refuses to reactivate.
+                   sah->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
                  }
                }
 
@@ -1102,17 +1096,23 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
     log(getLastError());
   }
 
+  // Exactly one of these. The previous code called loadSettings() and then
+  // initializeAudio() unconditionally, and initializeAudio reset the device ids,
+  // mute state, sample rate and buffer size to hardware defaults - so everything
+  // that had just been restored was thrown away before it was ever used, and only
+  // the API name survived to the next launch.
   if (loadSettings())
   {
-    initializeAudio(sah->audioApi);
-    menu.item[1].fState = sah->audioInputUsed ? MFS_UNCHECKED : MFS_CHECKED;
-    SetMenuItemInfoW(getSystemMenu(hwnd.get()), 1, FALSE, &menu.item[1]);
+    applyLoadedAudio();
   }
   else
   {
-    initializeAudio();
+    applyDefaultAudio();
     saveSettings();
   }
+
+  menu.item[1].fState = sah->audioInputUsed ? MFS_UNCHECKED : MFS_CHECKED;
+  SetMenuItemInfoW(getSystemMenu(hwnd.get()), 1, FALSE, &menu.item[1]);
 
   if (plugin.gui)
   {
@@ -1182,8 +1182,12 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
   refreshBufferSizes();
 
   settings.api.set(sah->audioApiDisplayName);
-  settings.output.set(sah->rtaDac->getDeviceInfo(sah->audioOutputDeviceID).name);
-  settings.input.set(sah->rtaDac->getDeviceInfo(sah->audioInputDeviceID).name);
+  // deviceName() looks the id up through the device enumeration. Calling
+  // getDeviceInfo() with an id RtAudio doesn't recognise raises an error through
+  // the error callback, which by this point is wired to a modal message box -
+  // so a perfectly normal launch could greet the user with an error dialog.
+  settings.output.set(sah->deviceName(sah->audioOutputDeviceID));
+  settings.input.set(sah->deviceName(sah->audioInputDeviceID));
   settings.sampleRate.set(std::to_string(sah->currentSampleRate));
   settings.bufferSize.set(std::to_string(sah->currentBufferSize));
 
@@ -1332,75 +1336,33 @@ void Plugin::refreshMIDIInputs()
 
 bool Plugin::saveSettings()
 {
-  auto settingsPath{getStandaloneSettingsPath()};
+  if (!sah) return false;
 
-  if (settingsPath.has_value())
-  {
-    fs::create_directories(settingsPath.value() / plugin.plugin->desc->id);
+  sah->captureAudioSettings();
 
-    settings.set<std::string>("audioApiName", sah->audioApiName);
-    settings.set<double>("audioInputDeviceID", sah->audioInputDeviceID);
-    settings.set<double>("audioOutputDeviceID", sah->audioOutputDeviceID);
-    settings.set<bool>("audioInputUsed", sah->audioInputUsed);
-    settings.set<bool>("audioOutputUsed", sah->audioOutputUsed);
-    settings.set<double>("currentSampleRate", sah->currentSampleRate);
-    settings.set<double>("currentBufferSize", sah->currentBufferSize);
-    settings.set<Position>("position", position);
+  // Only offer a geometry back to the next launch once we have a real one.
+  sah->settings.hasWindowPosition = (position.width != 0 && position.height != 0);
+  sah->settings.windowX = position.x;
+  sah->settings.windowY = position.y;
+  sah->settings.windowWidth = position.width;
+  sah->settings.windowHeight = position.height;
 
-    auto settingsFilePath{settingsPath.value() / plugin.plugin->desc->id / "settings.json"};
-    std::wofstream file(settingsFilePath.c_str(), std::ios::binary | std::ios::out);
-
-    if (file.is_open())
-    {
-      auto serialized{settings.json.Stringify()};
-      file.write(serialized.c_str(), serialized.size());
-
-      return file ? true : false;
-    }
-  }
-
-  return false;
+  return sah->saveStandaloneSettings();
 }
 
 bool Plugin::loadSettings()
 {
-  auto settingsPath{getStandaloneSettingsPath()};
+  if (!sah || !sah->loadStandaloneSettings()) return false;
 
-  if (settingsPath.has_value())
+  if (sah->settings.hasWindowPosition)
   {
-    auto settingsFilePath{settingsPath.value() / plugin.plugin->desc->id / "settings.json"};
-    std::wifstream file(settingsFilePath.c_str(), std::ios::binary | std::ios::in);
-
-    if (file.is_open())
-    {
-      std::wstring buffer;
-      file.ignore(std::numeric_limits<std::streamsize>::max());
-      buffer.resize(file.gcount());
-      file.clear();
-      file.seekg(0, std::ios::beg);
-      file.read(buffer.data(), buffer.size());
-      if (auto parsed{settings.json.TryParse(buffer, settings.json)}; parsed)
-      {
-        sah->audioApiName = settings.get<std::string>("audioApiName");
-        // These are static on RtAudio - we run before any RtAudio instance exists,
-        // so they must not be reached through sah->rtaDac, which is still null here.
-        sah->audioApi = RtAudio::getCompiledApiByName(sah->audioApiName);
-        sah->audioApiDisplayName = RtAudio::getApiDisplayName(sah->audioApi);
-        sah->audioInputDeviceID = static_cast<unsigned int>(settings.get<double>("audioInputDeviceID"));
-        sah->audioOutputDeviceID =
-            static_cast<unsigned int>(settings.get<double>("audioOutputDeviceID"));
-        sah->audioInputUsed = settings.get<bool>("audioInputUsed");
-        sah->audioOutputUsed = settings.get<bool>("audioOutputUsed");
-        sah->currentSampleRate = static_cast<unsigned int>(settings.get<double>("currentSampleRate"));
-        sah->currentBufferSize = static_cast<unsigned int>(settings.get<double>("currentBufferSize"));
-        position = settings.get<Position>("position");
-
-        return parsed;
-      }
-    }
+    position.x = sah->settings.windowX;
+    position.y = sah->settings.windowY;
+    position.width = sah->settings.windowWidth;
+    position.height = sah->settings.windowHeight;
   }
 
-  return false;
+  return true;
 }
 
 void Plugin::initializeMIDI()
@@ -1420,28 +1382,63 @@ void Plugin::startMIDI()
   sah->startMIDIThread();
 }
 
-void Plugin::initializeAudio(RtAudio::Api api)
+void Plugin::refreshDeviceChannelCounts()
 {
-  sah->setAudioApi(api);
+  // How many channels to open the device with. Kept separate from the plugin's
+  // bus totals, which is what totalInput/OutputChannels means in the host.
+  for (const auto &device : sah->getOutputAudioDevices())
+  {
+    if (device.ID == sah->audioOutputDeviceID) sah->deviceOutputChannels = device.outputChannels;
+  }
 
+  for (const auto &device : sah->getInputAudioDevices())
+  {
+    if (device.ID == sah->audioInputDeviceID) sah->deviceInputChannels = device.inputChannels;
+  }
+}
+
+void Plugin::selectDefaultDevices()
+{
   auto [input, output, sampleRate]{sah->getDefaultAudioInOutSampleRate()};
 
+  // RtAudio hands back a default input device id even on a machine with no
+  // capture device at all, so take the id only if it names something real.
   sah->audioInputDeviceID = input;
-  sah->totalInputChannels = sah->rtaDac->getDeviceInfo(input).inputChannels;
-  sah->audioInputUsed = true;
+  sah->audioInputUsed = sah->isKnownDevice(input);
 
   sah->audioOutputDeviceID = output;
-  sah->totalOutputChannels = sah->rtaDac->getDeviceInfo(output).outputChannels;
-  sah->audioOutputUsed = true;
+  sah->audioOutputUsed = sah->isKnownDevice(output);
 
   sah->currentSampleRate = sampleRate;
-  sah->currentBufferSize = sah->getBufferSizes()[0];
+  sah->currentBufferSize = StandaloneSettings::defaultBufferSize;
+
+  refreshDeviceChannelCounts();
+}
+
+void Plugin::applyLoadedAudio()
+{
+  sah->applyAudioSettings();
+  refreshDeviceChannelCounts();
+}
+
+void Plugin::applyDefaultAudio()
+{
+  // WASAPI is the backend that is always present and always works on a stock
+  // Windows, so it is what a first run gets.
+  sah->setAudioApi(RtAudio::Api::WINDOWS_WASAPI);
+  selectDefaultDevices();
+}
+
+void Plugin::selectAudioApi(RtAudio::Api api)
+{
+  sah->setAudioApi(api);
+  selectDefaultDevices();
 }
 
 void Plugin::startAudio()
 {
-  sah->startAudioThreadOn(sah->audioInputDeviceID, sah->totalInputChannels, sah->audioInputUsed,
-                          sah->audioOutputDeviceID, sah->totalOutputChannels, sah->audioOutputUsed,
+  sah->startAudioThreadOn(sah->audioInputDeviceID, sah->deviceInputChannels, sah->audioInputUsed,
+                          sah->audioOutputDeviceID, sah->deviceOutputChannels, sah->audioOutputUsed,
                           sah->currentSampleRate);
 }
 }  // namespace freeaudio::clap_wrapper::standalone::windows_standalone

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -229,7 +229,27 @@ bool MessageHandler::contains(::UINT msg)
 
 ::LRESULT MessageHandler::invoke(Message message)
 {
-  return map.find(message.msg)->second({message.hwnd, message.msg, message.wparam, message.lparam});
+  // A C++ exception which escapes a window procedure does not unwind - the
+  // kernel terminates the process with STATUS_FATAL_USER_CALLBACK_EXCEPTION and
+  // no diagnostic at all. These handlers drive audio backends and third-party
+  // driver code, so contain what we can here; this is the one place every
+  // handler for both windows passes through. Note this catches C++ exceptions
+  // only: an access violation inside a driver is a structured exception and is
+  // still fatal, by design - there is nothing safe to continue to.
+  try
+  {
+    return map.find(message.msg)->second({message.hwnd, message.msg, message.wparam, message.lparam});
+  }
+  catch (const std::exception &e)
+  {
+    log("Unhandled exception in window message {}: {}", message.msg, e.what());
+  }
+  catch (...)
+  {
+    log("Unhandled exception in window message {}", message.msg);
+  }
+
+  return 0;
 }
 
 void MessageHandler::box(const std::string &message)
@@ -1267,8 +1287,40 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
   startMIDI();
   refreshMIDIInputs();
 
+  // Never put the message box up from here. RtAudio calls this from wherever the
+  // failure happened - including from inside the combo-box handler that asked for
+  // the device change, and from its own stream threads. A modal box runs a nested
+  // message loop, so showing one there re-enters the handler that is still on the
+  // stack. Queue the text and let the main loop show it once it is idle.
   sah->displayAudioError = [this](auto &errorText)
-  { message.error("Unable to configure audio: {}", errorText); };
+  {
+    {
+      std::lock_guard<std::mutex> guard(pendingErrorLock);
+
+      // Repeats are the norm: one failure typically reports through several
+      // layers, and nobody wants that dialog twice.
+      if (pendingError == errorText || errorText == lastShownError) return;
+      pendingError = errorText;
+    }
+
+    ::PostMessageW(hwnd.get(), WM_SHOW_AUDIO_ERROR, 0, 0);
+  };
+
+  message.on(WM_SHOW_AUDIO_ERROR,
+             [this](Message msg)
+             {
+               std::string text;
+               {
+                 std::lock_guard<std::mutex> guard(pendingErrorLock);
+                 text = pendingError;
+                 pendingError.clear();
+                 lastShownError = text;
+               }
+
+               if (!text.empty()) message.error("Unable to configure audio: {}", text);
+
+               return 0;
+             });
 
   refreshApis();
   refreshOutputs();

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -78,29 +78,45 @@ bool isRectOnAnyMonitor(const Position &position)
   return ::MonitorFromRect(&rect, MONITOR_DEFAULTTONULL) != nullptr;
 }
 
+/*
+ * The source length and the destination length are different quantities and both
+ * of these used to keep them in one variable: it started as the source length,
+ * was overwritten with the required destination length by the sizing call, and
+ * was then handed to the conversion call as the source length.
+ *
+ * For toUTF16 that silently truncated any multi-byte input, since the wide count
+ * is smaller than the byte count. For toUTF8 it read *past the end of the source*,
+ * because the UTF-8 form is longer than the UTF-16 form for anything non-ASCII.
+ *
+ * These run on the command line, every device name, every system error string,
+ * and the settings round trip, so on a non-English Windows they run constantly.
+ */
 std::wstring toUTF16(std::string_view input)
 {
-  std::wstring output;
+  if (input.empty()) return {};
 
-  if (input.length() > 0)
+  if (input.length() > static_cast<size_t>(std::numeric_limits<int>::max()))
   {
-    if (input.length() < std::numeric_limits<int>::max())
-    {
-      auto length{static_cast<int>(input.length())};
+    log("toUTF16(): String too long");
+    return {};
+  }
 
-      length = ::MultiByteToWideChar(CP_UTF8, 0, input.data(), length, nullptr, 0);
+  auto sourceLength{static_cast<int>(input.length())};
 
-      output.resize(length);
+  auto destinationLength{::MultiByteToWideChar(CP_UTF8, 0, input.data(), sourceLength, nullptr, 0)};
+  if (destinationLength <= 0)
+  {
+    log("toUTF16(): {}", getLastError());
+    return {};
+  }
 
-      if (::MultiByteToWideChar(CP_UTF8, 0, input.data(), length, output.data(), length) == 0)
-      {
-        log("toUTF16(): {}", getLastError());
-      }
-    }
-    else
-    {
-      log("toUTF16(): String too long");
-    }
+  std::wstring output(static_cast<size_t>(destinationLength), L'\0');
+
+  if (::MultiByteToWideChar(CP_UTF8, 0, input.data(), sourceLength, output.data(),
+                            destinationLength) == 0)
+  {
+    log("toUTF16(): {}", getLastError());
+    return {};
   }
 
   return output;
@@ -108,28 +124,31 @@ std::wstring toUTF16(std::string_view input)
 
 std::string toUTF8(std::wstring_view input)
 {
-  std::string output;
+  if (input.empty()) return {};
 
-  if (input.length() > 0)
+  if (input.length() > static_cast<size_t>(std::numeric_limits<int>::max()))
   {
-    if (input.length() < std::numeric_limits<int>::max())
-    {
-      auto length{static_cast<int>(input.length())};
+    log("toUTF8(): String too long");
+    return {};
+  }
 
-      length = ::WideCharToMultiByte(CP_UTF8, 0, input.data(), length, nullptr, 0, nullptr, nullptr);
+  auto sourceLength{static_cast<int>(input.length())};
 
-      output.resize(length);
+  auto destinationLength{
+      ::WideCharToMultiByte(CP_UTF8, 0, input.data(), sourceLength, nullptr, 0, nullptr, nullptr)};
+  if (destinationLength <= 0)
+  {
+    log("toUTF8(): {}", getLastError());
+    return {};
+  }
 
-      if (::WideCharToMultiByte(CP_UTF8, 0, input.data(), length, output.data(), length, nullptr,
-                                nullptr) == 0)
-      {
-        log("toUTF8(): {}", getLastError());
-      }
-    }
-    else
-    {
-      log("toUTF8(): String too long");
-    }
+  std::string output(static_cast<size_t>(destinationLength), '\0');
+
+  if (::WideCharToMultiByte(CP_UTF8, 0, input.data(), sourceLength, output.data(), destinationLength,
+                            nullptr, nullptr) == 0)
+  {
+    log("toUTF8(): {}", getLastError());
+    return {};
   }
 
   return output;

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -489,6 +489,16 @@ bool ComboBox::set(const std::string &searchString)
   return message.send(hwnd.get(), CB_GETCURSEL, 0, 0);
 }
 
+std::optional<size_t> ComboBox::selection(size_t containerSize)
+{
+  auto index{get()};
+
+  if (index == CB_ERR || index < 0) return std::nullopt;
+  if (static_cast<size_t>(index) >= containerSize) return std::nullopt;
+
+  return static_cast<size_t>(index);
+}
+
 ::LRESULT ComboBox::getItemHeight()
 {
   return message.send(hwnd.get(), CB_GETITEMHEIGHT, 0, 0);
@@ -877,75 +887,100 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
       {
         if (HIWORD(msg.wparam) == CBN_SELCHANGE)
         {
+          // Every one of these reads a combo selection and uses it as a vector
+          // index. CB_GETCURSEL returns -1 when nothing is selected, so each was
+          // an out-of-bounds read waiting for an empty or freshly-rebuilt combo.
+          // selection() yields nothing unless the index is real and in range.
           if (LOWORD(msg.wparam) == Settings::Identifier::AudioApi)
           {
-            selectAudioApi(sah->getCompiledApi()[settings.api.get()]);
+            auto apis{sah->getCompiledApi()};
 
-            refreshOutputs();
-            refreshInputs();
+            if (auto index{settings.api.selection(apis.size())}; index)
+            {
+              selectAudioApi(apis[*index]);
 
-            settings.output.set(sah->deviceName(sah->audioOutputDeviceID));
-            settings.input.set(sah->deviceName(sah->audioInputDeviceID));
+              refreshOutputs();
+              refreshInputs();
 
-            refreshSampleRates();
-            refreshBufferSizes();
+              settings.output.set(sah->deviceName(sah->audioOutputDeviceID));
+              settings.input.set(sah->deviceName(sah->audioInputDeviceID));
 
-            settings.sampleRate.set(std::to_string(sah->currentSampleRate));
-            settings.bufferSize.set(std::to_string(sah->currentBufferSize));
+              refreshSampleRates();
+              refreshBufferSizes();
 
-            saveSettings();
-            startAudio();
+              settings.sampleRate.set(std::to_string(sah->currentSampleRate));
+              settings.bufferSize.set(std::to_string(sah->currentBufferSize));
+
+              saveSettings();
+              startAudio();
+            }
           }
 
           if (LOWORD(msg.wparam) == Settings::Identifier::AudioOutput)
           {
-            sah->audioOutputDeviceID = sah->getOutputAudioDevices()[settings.output.get()].ID;
+            auto devices{sah->getOutputAudioDevices()};
 
-            sah->deviceOutputChannels =
-                sah->getOutputAudioDevices()[settings.output.get()].outputChannels;
+            if (auto index{settings.output.selection(devices.size())}; index)
+            {
+              sah->audioOutputDeviceID = devices[*index].ID;
+              sah->deviceOutputChannels = devices[*index].outputChannels;
+              sah->audioOutputUsed = true;
 
-            refreshSampleRates();
-            refreshBufferSizes();
+              refreshSampleRates();
+              refreshBufferSizes();
 
-            saveSettings();
-            startAudio();
+              saveSettings();
+              startAudio();
+            }
           }
 
           if (LOWORD(msg.wparam) == Settings::Identifier::AudioInput)
           {
-            sah->audioInputDeviceID = sah->getInputAudioDevices()[settings.input.get()].ID;
+            auto devices{sah->getInputAudioDevices()};
 
-            sah->deviceInputChannels = sah->getInputAudioDevices()[settings.input.get()].inputChannels;
+            if (auto index{settings.input.selection(devices.size())}; index)
+            {
+              sah->audioInputDeviceID = devices[*index].ID;
+              sah->deviceInputChannels = devices[*index].inputChannels;
+              sah->audioInputUsed = true;
 
-            refreshSampleRates();
-            refreshBufferSizes();
+              refreshSampleRates();
+              refreshBufferSizes();
 
-            saveSettings();
-            startAudio();
+              saveSettings();
+              startAudio();
+            }
           }
 
           if (LOWORD(msg.wparam) == Settings::Identifier::AudioSamplerate)
           {
-            auto sampleRates{sah->getInputAudioDevices()[settings.input.get()].sampleRates};
+            // This used to take the rate list from the *input* device vector,
+            // indexed by the input combo - so picking a sample rate read out of
+            // bounds whenever the current API had no input devices at all, which
+            // is routine for output-only ASIO drivers. The rates offered are the
+            // ones the stream can actually run at.
+            auto sampleRates{sah->getSampleRates()};
 
-            auto newRate{sampleRates[settings.sampleRate.get()]};
+            if (auto index{settings.sampleRate.selection(sampleRates.size())}; index)
+            {
+              sah->currentSampleRate = sampleRates[*index];
 
-            sah->currentSampleRate = newRate;
-
-            saveSettings();
-            startAudio();
+              saveSettings();
+              startAudio();
+            }
           }
 
           if (LOWORD(msg.wparam) == Settings::Identifier::AudioBuffersize)
           {
             auto bufferSizes{sah->getBufferSizes()};
 
-            auto bufferSize{bufferSizes[settings.bufferSize.get()]};
+            if (auto index{settings.bufferSize.selection(bufferSizes.size())}; index)
+            {
+              sah->currentBufferSize = bufferSizes[*index];
 
-            sah->currentBufferSize = bufferSize;
-
-            saveSettings();
-            startAudio();
+              saveSettings();
+              startAudio();
+            }
           }
         }
 

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -799,6 +799,8 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
   message.on(WM_SYSCOMMAND,
              [this](Message msg)
              {
+               if (!sah) return 0;
+
                switch (msg.wparam)
                {
                  case Menu::Identifier::AudioMidiSettings:
@@ -927,6 +929,8 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
       WM_COMMAND,
       [this](Message msg)
       {
+        if (!sah) return 0;
+
         if (HIWORD(msg.wparam) == CBN_SELCHANGE)
         {
           // Every one of these reads a combo selection and uses it as a vector
@@ -1062,6 +1066,8 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
   message.on(WM_TIMER,
              [this](Message msg)
              {
+               if (!sah) return 0;
+
                if (msg.wparam == timerId)
                {
                  if (sah->callbackRequested.exchange(false))
@@ -1097,13 +1103,35 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
 
                if (isTimerRunning)
                {
-                 if (stopTimer(timerId))
+                 // KillTimer returns nonzero on success, so this used to log the
+                 // last error precisely when nothing had gone wrong.
+                 if (!stopTimer(timerId))
                  {
                    log(getLastError());
                  }
+                 isTimerRunning = false;
                }
 
+               // The settings window can still be handed messages after the host
+               // is gone, and every one of its handlers reads sah. Take it down
+               // while it is still safe to do so.
+               settings.hwnd.reset();
+
+               // Release our reference to the CLAP *before* mainFinish, which
+               // runs entry->deinit(). Holding it here meant the plugin object
+               // was destroyed after the entry it came from had been deinited -
+               // a spec violation, and a use-after-free of the library in the
+               // dynamically loaded case.
+               plugin.gui = nullptr;
+               plugin.state = nullptr;
+               plugin.plugin = nullptr;
+               plugin.clap.reset();
+
                freeaudio::clap_wrapper::standalone::mainFinish();
+
+               // mainFinish destroys the StandaloneHost, so this pointer is dead
+               // from here on.
+               sah = nullptr;
 
                quit();
 
@@ -1122,6 +1150,8 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
       WM_PAINT,
       [this](Message msg)
       {
+        if (!sah) return 0;
+
         ::PAINTSTRUCT ps;
         ::HDC hdc{::BeginPaint(msg.hwnd, &ps)};
 
@@ -1281,6 +1311,8 @@ std::optional<clap_gui_resize_hints> Plugin::getResizeHints()
 
 void Plugin::refreshLayout()
 {
+  if (!sah) return;
+
   settings.repaint();
 
   settings.api.refreshFont(settings.scale);

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -563,15 +563,27 @@ void ListBox::add(const std::string &string)
   message.send(hwnd.get(), LB_ADDSTRING, 0, toUTF16(string).c_str());
 }
 
+// This is an LBS_MULTIPLESEL listbox, so the single-selection messages don't
+// apply to it: LB_SETCURSEL is documented as having no effect on a multi-select
+// listbox, and LB_GETCURSEL is not the way to read one. Using them meant a
+// restored multi-port MIDI selection could never be shown.
 bool ListBox::set(int index)
 {
-  return message.send(hwnd.get(), LB_SETCURSEL, index, 0) != CB_ERR ? true : false;
+  return message.send(hwnd.get(), LB_SETSEL, TRUE, index) != LB_ERR;
 }
 
 bool ListBox::set(const std::string &searchString)
 {
-  return message.send(hwnd.get(), LB_SELECTSTRING, -1, toUTF16(searchString).c_str()) != CB_ERR ? true
-                                                                                                : false;
+  auto index{message.send(hwnd.get(), LB_FINDSTRINGEXACT, -1, toUTF16(searchString).c_str())};
+
+  if (index == LB_ERR) return false;
+
+  return set(static_cast<int>(index));
+}
+
+void ListBox::clearSelection()
+{
+  message.send(hwnd.get(), LB_SETSEL, FALSE, -1);
 }
 
 ::LRESULT ListBox::get()
@@ -581,8 +593,19 @@ bool ListBox::set(const std::string &searchString)
 
 ::LRESULT ListBox::getItems(std::vector<int> &buffer)
 {
-  buffer.resize(getItemsCount());
-  return message.send(hwnd.get(), LB_GETSELITEMS, getItemsCount(), buffer.data());
+  auto count{getItemsCount()};
+
+  // LB_GETSELCOUNT answers LB_ERR (-1) on a single-selection listbox; resizing
+  // to that would be an enormous allocation rather than an empty list.
+  if (count == LB_ERR || count <= 0)
+  {
+    buffer.clear();
+    return 0;
+  }
+
+  buffer.resize(static_cast<size_t>(count));
+
+  return message.send(hwnd.get(), LB_GETSELITEMS, count, buffer.data());
 }
 
 ::LRESULT ListBox::getItemsCount()
@@ -1007,38 +1030,27 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
         {
           if (LOWORD(msg.wparam) == Settings::Identifier::MidiInputs)
           {
-            std::vector<int> ports;
-            settings.midiIn.getItems(ports);
+            std::vector<int> selected;
+            settings.midiIn.getItems(selected);
 
-            for (auto &midiIn : sah->midiIns)
-            {
-              midiIn.reset();
-            }
-            sah->midiIns.clear();
-            sah->currentMidiPorts.clear();
+            auto available{sah->getMidiPortNames()};
 
-            for (auto port : ports)
+            std::vector<std::string> chosen;
+            for (auto index : selected)
             {
-              if (ports.size() != 0)
+              if (index >= 0 && static_cast<size_t>(index) < available.size())
               {
-                try
-                {
-                  auto midiIn{std::make_unique<RtMidiIn>()};
-                  midiIn->openPort(port);
-                  midiIn->setCallback(sah->midiCallback, sah);
-                  sah->midiIns.push_back(std::move(midiIn));
-                  sah->currentMidiPorts.push_back(port);
-                }
-                catch (RtMidiError &error)
-                {
-                  log("{}", error.getMessage());
-                };
-              }
-              else
-              {
-                sah->stopMIDIThread();
+                chosen.push_back(available[index]);
               }
             }
+
+            sah->openMidiPorts(chosen, false);
+
+            // Record names, not indices: the index of a port changes as devices
+            // come and go. Once the user has touched the list we stop binding
+            // everything, so deselecting every port really does mean no MIDI in.
+            sah->settings.midiBindAllPorts = false;
+            sah->settings.midiPortNames = chosen;
 
             saveSettings();
           }
@@ -1380,11 +1392,31 @@ void Plugin::refreshMIDIInputs()
 {
   settings.midiIn.reset();
 
-  auto midiIn{std::make_unique<RtMidiIn>()};
+  auto available{sah->getMidiPortNames()};
 
-  for (uint32_t port{0}; port < sah->numMidiPorts; port++)
+  for (const auto &name : available)
   {
-    settings.midiIn.add(midiIn->getPortName(port));
+    settings.midiIn.add(name);
+  }
+
+  // Show what is actually open. The list used to be populated with nothing
+  // selected while every port was in fact bound, so the UI told the user the
+  // opposite of what was happening.
+  settings.midiIn.clearSelection();
+
+  if (sah->settings.midiBindAllPorts)
+  {
+    for (int index{0}; index < static_cast<int>(available.size()); ++index)
+    {
+      settings.midiIn.set(index);
+    }
+  }
+  else
+  {
+    for (const auto &name : sah->settings.midiPortNames)
+    {
+      settings.midiIn.set(name);
+    }
   }
 }
 
@@ -1417,18 +1449,6 @@ bool Plugin::loadSettings()
   }
 
   return true;
-}
-
-void Plugin::initializeMIDI()
-{
-  auto midiIn{std::make_unique<RtMidiIn>()};
-
-  sah->currentMidiPorts.clear();
-
-  for (uint32_t port{0}; port < sah->numMidiPorts; port++)
-  {
-    sah->currentMidiPorts.push_back(port);
-  }
 }
 
 void Plugin::startMIDI()

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -112,8 +112,8 @@ std::wstring toUTF16(std::string_view input)
 
   std::wstring output(static_cast<size_t>(destinationLength), L'\0');
 
-  if (::MultiByteToWideChar(CP_UTF8, 0, input.data(), sourceLength, output.data(),
-                            destinationLength) == 0)
+  if (::MultiByteToWideChar(CP_UTF8, 0, input.data(), sourceLength, output.data(), destinationLength) ==
+      0)
   {
     log("toUTF16(): {}", getLastError());
     return {};
@@ -925,143 +925,142 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
                return 0;
              });
 
-  settings.message.on(
-      WM_COMMAND,
-      [this](Message msg)
-      {
-        if (!sah) return 0;
+  settings.message.on(WM_COMMAND,
+                      [this](Message msg)
+                      {
+                        if (!sah) return 0;
 
-        if (HIWORD(msg.wparam) == CBN_SELCHANGE)
-        {
-          // Every one of these reads a combo selection and uses it as a vector
-          // index. CB_GETCURSEL returns -1 when nothing is selected, so each was
-          // an out-of-bounds read waiting for an empty or freshly-rebuilt combo.
-          // selection() yields nothing unless the index is real and in range.
-          if (LOWORD(msg.wparam) == Settings::Identifier::AudioApi)
-          {
-            auto apis{sah->getCompiledApi()};
+                        if (HIWORD(msg.wparam) == CBN_SELCHANGE)
+                        {
+                          // Every one of these reads a combo selection and uses it as a vector
+                          // index. CB_GETCURSEL returns -1 when nothing is selected, so each was
+                          // an out-of-bounds read waiting for an empty or freshly-rebuilt combo.
+                          // selection() yields nothing unless the index is real and in range.
+                          if (LOWORD(msg.wparam) == Settings::Identifier::AudioApi)
+                          {
+                            auto apis{sah->getCompiledApi()};
 
-            if (auto index{settings.api.selection(apis.size())}; index)
-            {
-              selectAudioApi(apis[*index]);
+                            if (auto index{settings.api.selection(apis.size())}; index)
+                            {
+                              selectAudioApi(apis[*index]);
 
-              refreshOutputs();
-              refreshInputs();
+                              refreshOutputs();
+                              refreshInputs();
 
-              settings.output.set(sah->deviceName(sah->audioOutputDeviceID));
-              settings.input.set(sah->deviceName(sah->audioInputDeviceID));
+                              settings.output.set(sah->deviceName(sah->audioOutputDeviceID));
+                              settings.input.set(sah->deviceName(sah->audioInputDeviceID));
 
-              refreshSampleRates();
-              refreshBufferSizes();
+                              refreshSampleRates();
+                              refreshBufferSizes();
 
-              settings.sampleRate.set(std::to_string(sah->currentSampleRate));
-              settings.bufferSize.set(std::to_string(sah->currentBufferSize));
+                              settings.sampleRate.set(std::to_string(sah->currentSampleRate));
+                              settings.bufferSize.set(std::to_string(sah->currentBufferSize));
 
-              saveSettings();
-              startAudio();
-            }
-          }
+                              saveSettings();
+                              startAudio();
+                            }
+                          }
 
-          if (LOWORD(msg.wparam) == Settings::Identifier::AudioOutput)
-          {
-            auto devices{sah->getOutputAudioDevices()};
+                          if (LOWORD(msg.wparam) == Settings::Identifier::AudioOutput)
+                          {
+                            auto devices{sah->getOutputAudioDevices()};
 
-            if (auto index{settings.output.selection(devices.size())}; index)
-            {
-              sah->audioOutputDeviceID = devices[*index].ID;
-              sah->deviceOutputChannels = devices[*index].outputChannels;
-              sah->audioOutputUsed = true;
+                            if (auto index{settings.output.selection(devices.size())}; index)
+                            {
+                              sah->audioOutputDeviceID = devices[*index].ID;
+                              sah->deviceOutputChannels = devices[*index].outputChannels;
+                              sah->audioOutputUsed = true;
 
-              refreshSampleRates();
-              refreshBufferSizes();
+                              refreshSampleRates();
+                              refreshBufferSizes();
 
-              saveSettings();
-              startAudio();
-            }
-          }
+                              saveSettings();
+                              startAudio();
+                            }
+                          }
 
-          if (LOWORD(msg.wparam) == Settings::Identifier::AudioInput)
-          {
-            auto devices{sah->getInputAudioDevices()};
+                          if (LOWORD(msg.wparam) == Settings::Identifier::AudioInput)
+                          {
+                            auto devices{sah->getInputAudioDevices()};
 
-            if (auto index{settings.input.selection(devices.size())}; index)
-            {
-              sah->audioInputDeviceID = devices[*index].ID;
-              sah->deviceInputChannels = devices[*index].inputChannels;
-              sah->audioInputUsed = true;
+                            if (auto index{settings.input.selection(devices.size())}; index)
+                            {
+                              sah->audioInputDeviceID = devices[*index].ID;
+                              sah->deviceInputChannels = devices[*index].inputChannels;
+                              sah->audioInputUsed = true;
 
-              refreshSampleRates();
-              refreshBufferSizes();
+                              refreshSampleRates();
+                              refreshBufferSizes();
 
-              saveSettings();
-              startAudio();
-            }
-          }
+                              saveSettings();
+                              startAudio();
+                            }
+                          }
 
-          if (LOWORD(msg.wparam) == Settings::Identifier::AudioSamplerate)
-          {
-            // This used to take the rate list from the *input* device vector,
-            // indexed by the input combo - so picking a sample rate read out of
-            // bounds whenever the current API had no input devices at all, which
-            // is routine for output-only ASIO drivers. The rates offered are the
-            // ones the stream can actually run at.
-            auto sampleRates{sah->getSampleRates()};
+                          if (LOWORD(msg.wparam) == Settings::Identifier::AudioSamplerate)
+                          {
+                            // This used to take the rate list from the *input* device vector,
+                            // indexed by the input combo - so picking a sample rate read out of
+                            // bounds whenever the current API had no input devices at all, which
+                            // is routine for output-only ASIO drivers. The rates offered are the
+                            // ones the stream can actually run at.
+                            auto sampleRates{sah->getSampleRates()};
 
-            if (auto index{settings.sampleRate.selection(sampleRates.size())}; index)
-            {
-              sah->currentSampleRate = sampleRates[*index];
+                            if (auto index{settings.sampleRate.selection(sampleRates.size())}; index)
+                            {
+                              sah->currentSampleRate = sampleRates[*index];
 
-              saveSettings();
-              startAudio();
-            }
-          }
+                              saveSettings();
+                              startAudio();
+                            }
+                          }
 
-          if (LOWORD(msg.wparam) == Settings::Identifier::AudioBuffersize)
-          {
-            auto bufferSizes{sah->getBufferSizes()};
+                          if (LOWORD(msg.wparam) == Settings::Identifier::AudioBuffersize)
+                          {
+                            auto bufferSizes{sah->getBufferSizes()};
 
-            if (auto index{settings.bufferSize.selection(bufferSizes.size())}; index)
-            {
-              sah->currentBufferSize = bufferSizes[*index];
+                            if (auto index{settings.bufferSize.selection(bufferSizes.size())}; index)
+                            {
+                              sah->currentBufferSize = bufferSizes[*index];
 
-              saveSettings();
-              startAudio();
-            }
-          }
-        }
+                              saveSettings();
+                              startAudio();
+                            }
+                          }
+                        }
 
-        if (HIWORD(msg.wparam) == LBN_SELCHANGE)
-        {
-          if (LOWORD(msg.wparam) == Settings::Identifier::MidiInputs)
-          {
-            std::vector<int> selected;
-            settings.midiIn.getItems(selected);
+                        if (HIWORD(msg.wparam) == LBN_SELCHANGE)
+                        {
+                          if (LOWORD(msg.wparam) == Settings::Identifier::MidiInputs)
+                          {
+                            std::vector<int> selected;
+                            settings.midiIn.getItems(selected);
 
-            auto available{sah->getMidiPortNames()};
+                            auto available{sah->getMidiPortNames()};
 
-            std::vector<std::string> chosen;
-            for (auto index : selected)
-            {
-              if (index >= 0 && static_cast<size_t>(index) < available.size())
-              {
-                chosen.push_back(available[index]);
-              }
-            }
+                            std::vector<std::string> chosen;
+                            for (auto index : selected)
+                            {
+                              if (index >= 0 && static_cast<size_t>(index) < available.size())
+                              {
+                                chosen.push_back(available[index]);
+                              }
+                            }
 
-            sah->openMidiPorts(chosen, false);
+                            sah->openMidiPorts(chosen, false);
 
-            // Record names, not indices: the index of a port changes as devices
-            // come and go. Once the user has touched the list we stop binding
-            // everything, so deselecting every port really does mean no MIDI in.
-            sah->settings.midiBindAllPorts = false;
-            sah->settings.midiPortNames = chosen;
+                            // Record names, not indices: the index of a port changes as devices
+                            // come and go. Once the user has touched the list we stop binding
+                            // everything, so deselecting every port really does mean no MIDI in.
+                            sah->settings.midiBindAllPorts = false;
+                            sah->settings.midiPortNames = chosen;
 
-            saveSettings();
-          }
-        }
+                            saveSettings();
+                          }
+                        }
 
-        return 0;
-      });
+                        return 0;
+                      });
 
   message.on(WM_TIMER,
              [this](Message msg)

--- a/src/detail/standalone/windows/windows_standalone.h
+++ b/src/detail/standalone/windows/windows_standalone.h
@@ -209,6 +209,7 @@ struct ListBox final : public Control
 
   bool set(int index);
   bool set(const std::string &searchString);
+  void clearSelection();
   ::LRESULT get();
   ::LRESULT getItems(std::vector<int> &buffer);
   ::LRESULT getItemsCount();
@@ -290,7 +291,6 @@ struct Plugin final : public Window
   bool saveSettings();
   bool loadSettings();
 
-  void initializeMIDI();
   void startMIDI();
 
   // Startup takes exactly one of these: the persisted configuration if we have

--- a/src/detail/standalone/windows/windows_standalone.h
+++ b/src/detail/standalone/windows/windows_standalone.h
@@ -13,20 +13,12 @@
 #include <wil/com.h>
 #include <wil/resource.h>
 
-#include <winrt/windows.foundation.h>
-#include <winrt/windows.data.json.h>
-
 #define FMT_HEADER_ONLY 1
 #include <fmt/format.h>
 #include <fmt/xchar.h>
 
 #include "detail/standalone/entry.h"
 #include "detail/standalone/standalone_host.h"
-
-namespace winrt
-{
-using namespace winrt::Windows::Data::Json;
-};  // namespace winrt
 
 namespace freeaudio::clap_wrapper::standalone::windows_standalone
 {
@@ -134,16 +126,6 @@ struct Position
   uint32_t width{0};
   uint32_t height{0};
 };
-
-// Clamp a JSON-sourced double into int32 range before narrowing. Avoids UB when a
-// corrupt/out-of-range coordinate (e.g. a minimized window's -32000 sentinel that an
-// older build persisted as a huge unsigned value) is read back.
-inline int32_t jsonNumberToInt32(double value)
-{
-  if (value >= 2147483647.0) return 2147483647;
-  if (value <= -2147483648.0) return -2147483648;
-  return static_cast<int32_t>(value);
-}
 
 // True when the rectangle intersects a connected display.
 bool isRectOnAnyMonitor(const Position &position);
@@ -272,105 +254,12 @@ struct Plugin final : public Window
       MidiInputs
     };
 
-    template <typename T, typename U>
-    auto set(std::string_view key, U value) -> void
-    {
-      if constexpr (std::is_same_v<T, std::string>)
-      {
-        json.SetNamedValue(toUTF16(key), winrt::JsonValue::CreateStringValue(toUTF16(value)));
-      }
-
-      if constexpr (std::is_same_v<T, bool>)
-      {
-        json.SetNamedValue(toUTF16(key), winrt::JsonValue::CreateBooleanValue(value));
-      }
-
-      if constexpr (std::is_same_v<T, double>)
-      {
-        json.SetNamedValue(toUTF16(key), winrt::JsonValue::CreateNumberValue(value));
-      }
-
-      if constexpr (std::is_same_v<T, Position>)
-      {
-        auto pos{winrt::JsonObject()};
-        pos.SetNamedValue(L"x", winrt::JsonValue::CreateNumberValue(value.x));
-        pos.SetNamedValue(L"y", winrt::JsonValue::CreateNumberValue(value.y));
-        pos.SetNamedValue(L"width", winrt::JsonValue::CreateNumberValue(value.width));
-        pos.SetNamedValue(L"height", winrt::JsonValue::CreateNumberValue(value.height));
-        json.SetNamedValue(toUTF16(key), pos);
-      }
-    }
-
-    template <typename T>
-    auto get(std::string_view key) -> T
-    {
-      auto value{json.GetNamedValue(toUTF16(key), nullptr)};
-
-      if constexpr (std::is_same_v<T, std::string>)
-      {
-        if (value && value.ValueType() == winrt::JsonValueType::String)
-        {
-          return toUTF8(value.GetString());
-        }
-        else
-        {
-          return {};
-        }
-      }
-
-      if constexpr (std::is_same_v<T, bool>)
-      {
-        if (value && value.ValueType() == winrt::JsonValueType::Boolean)
-        {
-          return value.GetBoolean();
-        }
-        else
-        {
-          return false;
-        }
-      }
-
-      if constexpr (std::is_same_v<T, double>)
-      {
-        if (value && value.ValueType() == winrt::JsonValueType::Number)
-        {
-          return value.GetNumber();
-        }
-        else
-        {
-          return 0.0;
-        }
-      }
-
-      if constexpr (std::is_same_v<T, Position>)
-      {
-        if (value && value.ValueType() == winrt::JsonValueType::Object)
-        {
-          auto parsedPos{value.GetObject()};
-
-          Position buffer;
-          buffer.x = jsonNumberToInt32(parsedPos.GetNamedNumber(L"x"));
-          buffer.y = jsonNumberToInt32(parsedPos.GetNamedNumber(L"y"));
-          buffer.width = static_cast<uint32_t>(parsedPos.GetNamedNumber(L"width"));
-          buffer.height = static_cast<uint32_t>(parsedPos.GetNamedNumber(L"height"));
-
-          return buffer;
-        }
-        else
-        {
-          return {};
-        }
-      }
-    }
-
     ComboBox api;
     ComboBox output;
     ComboBox input;
     ComboBox sampleRate;
     ComboBox bufferSize;
     ListBox midiIn;
-
-    winrt::JsonObject json;
   };
 
   struct ClapPlugin
@@ -398,7 +287,20 @@ struct Plugin final : public Window
   void initializeMIDI();
   void startMIDI();
 
-  void initializeAudio(RtAudio::Api api = RtAudio::Api::WINDOWS_WASAPI);
+  // Startup takes exactly one of these: the persisted configuration if we have
+  // one, otherwise the machine's defaults. The old single initializeAudio() ran
+  // on both paths and overwrote everything loadSettings() had just restored.
+  void applyLoadedAudio();
+  void applyDefaultAudio();
+
+  // The user picked a different API in the settings panel: rebuild the RtAudio
+  // instance and take that API's default devices, since device ids from the
+  // previous API mean nothing under the new one.
+  void selectAudioApi(RtAudio::Api api);
+
+  void selectDefaultDevices();
+  void refreshDeviceChannelCounts();
+
   void startAudio();
 
   freeaudio::clap_wrapper::standalone::StandaloneHost *sah{

--- a/src/detail/standalone/windows/windows_standalone.h
+++ b/src/detail/standalone/windows/windows_standalone.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -229,6 +230,10 @@ struct SystemMenu
   std::vector<::MENUITEMINFOW> item;
 };
 
+// Posted to the plugin window to show a queued audio error from the main loop
+// rather than from inside whatever handler or backend thread produced it.
+constexpr ::UINT WM_SHOW_AUDIO_ERROR{WM_APP + 1};
+
 struct Plugin final : public Window
 {
   struct Menu final : public SystemMenu
@@ -316,6 +321,11 @@ struct Plugin final : public Window
 
   bool isTimerRunning{false};
   const ::UINT_PTR timerId{0};
+
+  // Written from RtAudio's error callback, which can be any thread.
+  std::mutex pendingErrorLock;
+  std::string pendingError;
+  std::string lastShownError;
 
   ClapPlugin plugin;
   Position position;

--- a/src/detail/standalone/windows/windows_standalone.h
+++ b/src/detail/standalone/windows/windows_standalone.h
@@ -189,6 +189,12 @@ struct ComboBox final : public Control
   bool set(int index);
   bool set(const std::string &searchString);
   ::LRESULT get();
+
+  // get() returns CB_ERR (-1) when nothing is selected, which as a vector index is
+  // an out-of-bounds read. Callers index containers with this instead, and it is
+  // empty unless the selection is both present and in range.
+  std::optional<size_t> selection(size_t containerSize);
+
   ::LRESULT getItemHeight();
 
   static ::LRESULT CALLBACK procedure(::HWND hwnd, ::UINT msg, ::WPARAM wparam, ::LPARAM lparam,

--- a/src/wrapasstandalone_windows.cpp
+++ b/src/wrapasstandalone_windows.cpp
@@ -46,7 +46,23 @@ int WINAPI wWinMain(HINSTANCE /* hInstance */, HINSTANCE /* hPrevInstance */, PW
   auto clapPlugin{freeaudio::clap_wrapper::standalone::mainCreatePlugin(
       entry, PLUGIN_ID, PLUGIN_INDEX, static_cast<int>(argv.size()), argv.data())};
 
-  freeaudio::clap_wrapper::standalone::windows_standalone::Plugin plugin{clapPlugin, nCmdShow};
+  if (!clapPlugin)
+  {
+    // The Plugin constructor dereferences this immediately, so a failed create
+    // used to be a null dereference rather than a message.
+    freeaudio::clap_wrapper::standalone::windows_standalone::MessageHandler{}.error(
+        "Unable to create the plugin. The CLAP was found but did not provide '" PLUGIN_ID "'.");
 
-  return freeaudio::clap_wrapper::standalone::windows_standalone::run();
+    return 4;
+  }
+
+  {
+    freeaudio::clap_wrapper::standalone::windows_standalone::Plugin plugin{clapPlugin, nCmdShow};
+
+    // Drop our own reference before the scope ends. The wrapper's shutdown runs
+    // from WM_DESTROY inside run(), and the CLAP must not outlive it.
+    clapPlugin.reset();
+
+    return freeaudio::clap_wrapper::standalone::windows_standalone::run();
+  }
 }


### PR DESCRIPTION
Windows half of #516, plus the shared-layer items the Windows criticals sit on.

Scope agreed up front: `WIN-1`..`WIN-7`, plus `CC-1`, `CC-4`/`CC-5`, `CC-10`. Three more
came along because a critical was unfixable without them — `CC-6`, `CC-8` (selection half),
`CC-9`. Everything else in #516 is untouched: no macOS, no Linux, no `BP-*`, no Windows
cleanup or modernize.

None of the three headline Windows complaints turned out to be a Windows bug. Two are
missing shared infrastructure and one is a shared lifecycle bug that Windows is merely the
only frontend able to trigger, being the only one with an API picker. So this is
shared-layer first, thin Windows layer on top — which also leaves macOS and Linux able to
adopt the same code rather than solve it again.

## "Audio settings don't seem to save and restore at all"

They were saved. Startup called `loadSettings()` and then `initializeAudio()`
unconditionally, and `initializeAudio` reset device ids, mute state, sample rate and buffer
size to hardware defaults — so everything just restored was overwritten before it was used.
Only the API name survived, which is exactly the one field commit `5f9c936` had fixed.

Rather than reorder those two calls in the Windows frontend, the store moves to the shared
layer, where the comment in `saveStandaloneAndPluginSettings` has been asking for it since
the beginning. `StandaloneSettings` is a flat UTF-8 `key=value` file written next to the
state blob as `standalone-settings.conf`. No new dependency — the repo carries only `fmt`
and `psl`, and a hand-editable config file is what `LIN-11` wants anyway. Unrecognised keys
survive a load/save round trip, so a newer build's settings are not destroyed by an older
one.

Devices and MIDI ports are stored **by name**. RtAudio 6 device ids are per-instance
enumeration handles; the old code persisted the number, so after a restart it asked for
whichever device happened to land on that id.

Windows splits `initializeAudio` into `applyLoadedAudio` / `applyDefaultAudio` /
`selectAudioApi` and takes exactly one of the first two at startup. (`WIN-1`, `WIN-2`, `CC-1`)

First-run buffer size was `getBufferSizes()[0]` — **16 frames**. It now comes from the
shared default of 256, and 16 is gone from the offered list, since no backend runs there
reliably. `openStream` writes back the size it actually granted, so that is what gets
persisted. (`WIN-4`, `CC-10`)

## "WASAPI to ASIO can crash"

`setAudioApi` was one line: construct the new `RtAudio` over the old one. That constructs
the new backend — probing drivers, and ASIO's probe touches process-global SDK state —
while the outgoing backend's realtime thread is still calling us, then destroys the old
instance by assignment, with no stop, no `running=false` handshake and no lock. The
`isStreamRunning()` guard in `startAudioThreadOnImpl` could not help: by the time it runs,
`rtaDac` already points at the new instance. It now stops, deactivates and destroys the old
instance before building the new one. (`CC-4`)

`activatePlugin`/`deactivatePlugin` never took `processLock`, so an API switch, a device
change or OK in the settings panel could deactivate while `process()` was in flight. The
stop-and-wait handshake now lives inside `deactivatePlugin`, so a frontend cannot forget it;
the hand-rolled copy in the Windows `WM_TIMER` handler is gone. (`CC-5`)

The five combo reads in the settings `WM_COMMAND` handler used `CB_GETCURSEL` directly as a
`std::vector` index. That returns `CB_ERR` (-1) when nothing is selected — an out-of-bounds
read, reachable any time a combo is empty or has just been rebuilt, which is precisely what
switching API does. The sample-rate case was worse: it built its rate list from the *input*
device vector indexed by the *input* combo, so picking a rate on an API with no input
devices — routine for output-only ASIO drivers — indexed an empty vector. (`WIN-3`)

## Under-maintained code

**MIDI selection was theatre.** The listbox handler called `saveSettings()`, but
`saveSettings` wrote no MIDI keys, so nothing was stored. Meanwhile `startMIDIThread` opened
every port on launch while the panel showed nothing selected — the UI stated the opposite of
what was happening. Port selection moves into the shared layer, matched by name; a port that
is unplugged right now is logged and *kept* in the settings so it returns when the device
does. "Bind everything" is tracked separately from "an empty selection", so deselecting
every port is now expressible. The listbox is `LBS_MULTIPLESEL` but was driven with
`LB_SETCURSEL` (documented as having no effect on a multi-select listbox) and `LB_GETCURSEL`
compared against `CB_ERR`, so a restored multi-port selection could not have been displayed
even once it was stored. (`WIN-7`, `CC-8` selection half)

**The UTF converters.** Both kept the source length and the destination length in one
variable: it started as the source length, the sizing call overwrote it with the required
destination length, and the conversion call then received it as the source length.
`toUTF16` silently truncates multi-byte input — `Distörtion äöü` comes back as
`Distörtion ä`, one character lost per non-ASCII character. `toUTF8` is worse: it **reads
past the end of the source buffer**, because the UTF-8 form is longer than the UTF-16 form
for anything non-ASCII. These run on the command line, every device name, every
`FormatMessageW` string, and the settings round trip — so on a non-English Windows they run
constantly. (`WIN-6`)

**Lifetimes.** A null return from `mainCreatePlugin` went straight into the `Plugin`
constructor, which dereferences it on its first line. The `Plugin` struct's own
`shared_ptr<Clap::Plugin>` outlived `mainFinish()`, which runs `entry->deinit()` — so the
plugin object was destroyed after the entry it came from had been deinited, a spec violation
and a use-after-free of the library in the dynamically loaded case. The raw `sah` pointer
dangled from the moment `mainFinish` reset the host, while the settings window could still
be handed messages, and every one of its handlers reads `sah`. (`WIN-5`)

Also `getSampleRates` asked the input device for its rates even when input was unused, and
asked twice (`CC-9`); `startMIDIThread` called `exit(EXIT_FAILURE)` when the first
`RtMidiIn` threw, which on Linux is the routine "ALSA sequencer unavailable" case and made
the GUI app vanish without a word (`CC-6`); `stopMIDIThread` reset the pointers but left the
vector holding them; `stopTimer`'s success test was inverted, logging `GetLastError()`
exactly when `KillTimer` had succeeded.

## Two things not in #516

**The Windows standalone did not build.** C++/WinRT falls back to
`<experimental/coroutine>` under C++17 (`base.h:73-75`), and current MSVC STL hard-errors on
that header. The repo builds the standalone at C++17 by default, so it did not compile with
a current toolchain at all. The only thing pulling winrt in was the settings JSON parser, so
replacing it fixed the build as a side effect. `RuntimeObject.Lib` is no longer linked.

**A shutdown hang.** RtAudio reports device *enumeration* failures through the same error
callback as stream failures, and the frontend puts that in a modal dialog. On a machine with
no audio devices that is one dialog per probe, stacked on the message loop — the app looks
hung and cannot be closed. Confirmed against `next` that this predates the branch.
Enumeration is now silenced for display purposes (never for logging), device ids are checked
before `getDeviceInfo` is asked about them, and a missing input device drops input instead
of failing the whole stream.

## Verified

Built and run on Windows 11, MSVC 14.51 (VS 18), clean configure, Release at the repo's
default C++ standard. The settings panel was driven through real Win32 messages — the same
`CBN_SELCHANGE` notifications the combo boxes send when a user picks an item — rather than
by calling into the code directly.

**Audio API switching (`CC-4`).** Built with `RTAUDIO_API_ASIO=ON` and `RTAUDIO_API_DS=ON`
so the combo offered ASIO, WASAPI and DirectSound, and switched repeatedly with a stream
running and the plugin activated. The lifecycle ordering this PR fixes is sound. **But see
the ASIO section below: this PR does not make WASAPI↔ASIO switching safe, because the
remaining crash is not in clap-wrapper.**

**Device, rate and buffer persistence (`WIN-1`, `WIN-2`).** Through the panel: picked the
non-default output device (SPDIF rather than the default speakers), 192000 Hz, and 512
frames; quit; relaunched. All three came back selected, resolved by name. Sample rates are
re-derived per device and the offered list matched the hardware (4000…192000).

**Graceful degradation.** This box has no capture device. The standalone starts output-only,
logs it, and shows no dialog — where before it asked RtAudio about a device id that names
nothing, which raises an error through the error callback and became a modal box.

Also: unknown settings keys preserved across a round trip; malformed lines and an empty key
dropped without crashing; a device name that no longer exists falls back to the default with
a log line and no dialog; MIDI default binds all, a one-port selection opens exactly that
port, and a selected-but-absent port warns and is *retained*; missing plugin id exits 4 with
a dialog instead of dereferencing null; closing the main window **while the settings window
is open** exits cleanly with code 0, which is the `WIN-5` use-after-free scenario.

The `toUTF16` truncation was checked against the real Win32 API, old algorithm versus new,
rather than reasoned about: `Distörtion äöü` → `Distörtion ä` before, exact after.

## The ASIO crash is upstream in RtAudio, and this PR does not fix it

Retested with two ASIO drivers installed (Steinberg Generic Low Latency, Steinberg
built-in). Selecting ASIO **crashes the process** — `0xC000041D`
(STATUS_FATAL_USER_CALLBACK_EXCEPTION), from an access violation at address `0x0`, i.e. a
call through a null function pointer. Tracked down with a vectored exception handler: the
return address on the stack at the fault is inside `asioglld.dll` +0x8AF2 — the driver
itself is calling a host callback that is null.

The null one is RtAudio's. `RtApiAsio::probeDeviceOpen` sets:

```
asioCallbacks.bufferSwitch         = &bufferSwitch;
asioCallbacks.sampleRateDidChange  = &sampleRateChanged;
asioCallbacks.asioMessage          = &asioMessages;
asioCallbacks.bufferSwitchTimeInfo = NULL;      // <- RtAudio.cpp:3804
```

RtAudio answers `kAsioSupportsTimeInfo` with 0, which by the letter of the ASIO SDK should
mean the driver uses `bufferSwitch`. This driver calls `bufferSwitchTimeInfo` regardless —
a common assumption, since the SDK's own host examples always provide it. Jump to 0, process
gone.

Confirmed by patching the vendored RtAudio to implement `bufferSwitchTimeInfo` as a forward
to `bufferSwitch`:

```c
static ASIOTime *bufferSwitchTimeInfo( ASIOTime *, long index, ASIOBool processNow )
{
  bufferSwitch( index, processNow );
  return 0L;
}
```

With that one change, **15 consecutive switches across ASIO / WASAPI / DirectSound, five of
them selecting ASIO, with a live stream — no crash.** Without it, it dies on the first or
third ASIO selection.

That patch is *not* in this PR: it belongs upstream in RtAudio (6.0.1 is what
`guarantee_rtaudio` pins), or in a deliberate decision to carry a patch or a fork here.
Worth its own issue, and it means "wasapi to asio can crash" in #516 is at least partly not
a clap-wrapper bug at all.

What this PR *does* contribute on that path: the `CC-4` teardown ordering is genuinely
wrong and is fixed; and enumeration is no longer run repeatedly, which matters because every
ASIO `probeDevices()` loads, `ASIOInit()`s and unloads every installed driver — that churn
is what produced `RtApiAsio::probeDeviceOpen: ... (Not enough memory to complete the
request.) creating buffers` on this machine before the caching commit.

Note that on plain `next` this crash does not reproduce, but not because it is fixed there:
`next` never gets far enough to open an ASIO stream at all, because it stalls behind
`getDeviceInfo: deviceId argument not found` dialogs first.

## Not tested, and why

`WM_DEVICECHANGE` — the tail of `WIN-3` — is **not** implemented. Device hot-plug is not
something I can trigger here, and shipping untested audio-restart-on-device-change seemed
worse than shipping nothing.

ASIO is **off by default** in a stock clap-wrapper build — `RTAUDIO_API_ASIO` has to be set
on RtAudio directly, which is `BP-12`'s point about these knobs being undocumented
reach-through. So the crash above needs a deliberate build to reach today.

## Notes for the macOS/Linux side

Nothing here changes macOS or Linux behaviour: neither writes a settings file yet, and an
absent file leaves the previous default path exactly as it was. The shared pieces they can
adopt when convenient are `StandaloneSettings` (`CC-1`, and `LIN-2` only needs
`getStandaloneSettingsPath` implemented for it to work on Linux), the
`openMidiPorts`/`getMidiPortNames` model that `MAC-1` needs, and the activate/deactivate
handshake.

One leftover: `AppDelegate.mm:45-52` still has macOS's copy of the restart lock-dance that
`CC-5` makes redundant. It is correct as written, just no longer necessary — left alone
deliberately to avoid colliding with the macOS work.
