### PR TITLE
AUv2: honour request_restart

### DIFF
--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -27,6 +27,7 @@
 #include "process.h"
 #include "parameter.h"
 #include "detail/shared/fixedqueue.h"
+#include "detail/shared/spinlock.h"
 #include "detail/shared/midi_translation.h"
 #include "detail/os/osutil.h"
 #include "detail/clap/automation.h"
@@ -583,6 +584,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
   }
   void restartPlugin() override
   {
+    _requestRestart = true;
   }
   void request_callback() override
   {
@@ -740,6 +742,8 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   void activateCLAP();
   void deactivateCLAP();
+  // the AU-level half of the teardown, which an internal restart must not do
+  void releaseHostMIDIOutput();
   bool IsBypassEffect()
   {
     return _isBypassed;
@@ -819,6 +823,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
 #endif
 
   std::atomic_bool _requestUICallback = false;
+  std::atomic_bool _requestRestart = false;
+
+  // Held by Render() for its whole body, and taken by onIdle() to fence against
+  // an in-flight render before it rebuilds the plugin. See onIdle().
+  ClapWrapper::detail::shared::SpinLock _processLock;
 
   // the queue from audiothread to UI thread
   ClapWrapper::detail::shared::fixedqueue<queueEvent, 8192> _queueToUI;

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -683,6 +683,7 @@ void WrapAsAUV2::Cleanup()
     }
   }
   deactivateCLAP();
+  releaseHostMIDIOutput();
   Base::Cleanup();
 }
 
@@ -1145,6 +1146,14 @@ void WrapAsAUV2::deactivateCLAP()
     _plugin->stop_processing();
     _plugin->deactivate();
   }
+}
+
+// Only when the AU itself is going away. A restart the plugin asked for cycles
+// the CLAP underneath a still-initialized AU, and the host does not reinstall
+// what it handed us through SetProperty -- so dropping these there would lose
+// MIDI output for the rest of the session.
+void WrapAsAUV2::releaseHostMIDIOutput()
+{
   _midioutput_hostcallback = {nullptr, nullptr};
 #if AUSDK_MIDI2_AVAILABLE
   // No render can run once the AU is uninitialized: drop the event-list block
@@ -1160,6 +1169,7 @@ OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags &inFlags, const AudioTime
                             UInt32 inFrames)
 {
   assert(inFlags == 0);
+  ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
   if (_initialized && (inFlags == 0))
   {
     // do the render dance
@@ -1368,6 +1378,32 @@ void WrapAsAUV2::onIdle()
     {
       auto guarantee_mainthread = _plugin->AlwaysMainThread();
       _plugin->_plugin->on_main_thread(_plugin->_plugin);
+    }
+  }
+
+  if (_requestRestart.exchange(false) && _plugin)
+  {
+    // AU has no host-facing "reinitialize me", but it needs none: the wrapper
+    // owns the CLAP's activate/deactivate itself, so it can cycle it underneath
+    // a still-initialized AU. The standalone does the same thing.
+    auto guarantee_mainthread = _plugin->AlwaysMainThread();
+
+    // The lock is held only long enough to close the door, not across the
+    // rebuild. Render holds it for its whole body, so once it is acquired no
+    // render is inside the process adapter; clearing _initialized under it
+    // keeps the ones that follow out while the plugin is torn down and stood
+    // back up. Those renders return without touching the buffers, exactly as
+    // they do before the AU is initialized.
+    bool wasInitialized;
+    {
+      ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
+      wasInitialized = _initialized.exchange(false);
+    }
+
+    if (wasInitialized)
+    {
+      deactivateCLAP();
+      activateCLAP();
     }
   }
 }


### PR DESCRIPTION
A plugin that defers reallocation until its next activate cycle -- a changed FFT size, latency or oversampling factor -- never applied it under AUv2, because restartPlugin() was an empty body. Reported against SpectrumWorx, where the FFT size control moved in the UI while the audio engine went on running the old size in Logic. See #521.

The AU host need not be involved. The wrapper owns the CLAP's activate/deactivate itself, so onIdle can cycle the plugin underneath a still initialized AU, which is what the standalone already does. Render takes the process lock for its whole body so the rebuild can fence against a render already in flight, and holds it only long enough to close the door rather than across the rebuild.

Releasing the host's MIDI output callbacks moves out of deactivateCLAP and into Cleanup. The host hands those over through SetProperty and does not reinstall them across a restart it did not perform, so a plugin with MIDI output would have lost it for the rest of the session.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>