### PR TITLE
Issue523

### DIFF
--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -580,6 +580,20 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // ---------------- Clap::IHost
   void mark_dirty() override
   {
+    // AU has no setDirty(); the idiom is to tell the host that its cached
+    // kAudioUnitProperty_ClassInfo is stale (what param_rescan() already does).
+    // Deferred to onIdle(): PropertyChanged() runs the host's listeners
+    // synchronously and they are free to come back in through the property
+    // getters — a host reading ClassInfo from inside the notification would
+    // re-enter the plugin's state->save() while the plugin is still inside the
+    // call that reported dirty. The flag also collapses bursts into one
+    // notification per idle tick.
+    //
+    // Deliberately not accompanied by kAudioUnitProperty_PresentPreset: the
+    // wrapper exposes no presets, so AUBase's mCurrentPreset stays {-1,
+    // "Untitled"} and notifying it would only make hosts re-read an unchanged
+    // value. That belongs with CLAP preset-load support, when it arrives.
+    _requestMarkDirty = true;
   }
   void restartPlugin() override
   {
@@ -819,6 +833,8 @@ class WrapAsAUV2 : public ausdk::AUBase,
 #endif
 
   std::atomic_bool _requestUICallback = false;
+  // set by mark_dirty(), serviced in onIdle()
+  std::atomic_bool _requestMarkDirty = false;
 
   // the queue from audiothread to UI thread
   ClapWrapper::detail::shared::fixedqueue<queueEvent, 8192> _queueToUI;

--- a/src/detail/auv3/auv3_audiounit.mm
+++ b/src/detail/auv3/auv3_audiounit.mm
@@ -138,6 +138,8 @@ class AUv3ImplDetail : public Clap::IHost, public Clap::IAutomation, public os::
   std::string _hostname = "CLAP-as-AUv3";
   std::atomic<bool> _initialized{false};
   std::atomic_bool _requestUICallback{false};
+  // set by mark_dirty(), serviced by the idle timer
+  std::atomic_bool _requestMarkDirty{false};
   dispatch_source_t _idleTimer = nullptr;
 
   // Back-reference to the ObjC audio unit (weak to avoid retain cycle)
@@ -184,6 +186,13 @@ class AUv3ImplDetail : public Clap::IHost, public Clap::IAutomation, public os::
   void mark_dirty() override
   {
     AUV3LOG("IHost::mark_dirty() called");
+    // AUAudioUnit has no dirty flag. The nearest equivalent is a KVO
+    // notification on fullState, which AUAudioUnit.h documents as bridged to
+    // the v2 property kAudioUnitProperty_ClassInfo. Deferred to the idle timer
+    // so that a host reacting to it by reading the state cannot re-enter the
+    // plugin from inside the call that reported dirty, and so bursts collapse
+    // into one notification per tick.
+    _requestMarkDirty = true;
   }
   void restartPlugin() override
   {
@@ -218,6 +227,25 @@ class AUv3ImplDetail : public Clap::IHost, public Clap::IAutomation, public os::
       // Fire CLAP timers — safe while processing since timer callbacks
       // run on the main thread, not the audio thread.
       self->fireTimers();
+
+      // Tell the host that the state it last read is stale. Serviced even
+      // while processing: no CLAP plugin call is made here.
+      if (self->_requestMarkDirty.exchange(false))
+      {
+        ClapAUv3AudioUnit *au = self->_audioUnit;
+        if (au)
+        {
+          // Both keys cross the appex XPC boundary: a v3 host sees the KVO,
+          // and a v2-API host receives the bridged kAudioUnitProperty_ClassInfo
+          // / kAudioUnitProperty_ClassInfoFromDocument notification. Note that
+          // AudioToolbox also emits allParameterValues alongside these keys, so
+          // a host may re-read parameter values as a side effect.
+          [au willChangeValueForKey:@"fullState"];
+          [au didChangeValueForKey:@"fullState"];
+          [au willChangeValueForKey:@"fullStateForDocument"];
+          [au didChangeValueForKey:@"fullStateForDocument"];
+        }
+      }
 
       // Do NOT call on_main_thread() while the plugin is processing.
       // JUCE's on_main_thread() acquires locks that process() also needs —

--- a/src/detail/os/linux.cpp
+++ b/src/detail/os/linux.cpp
@@ -11,6 +11,7 @@
 #include "osutil.h"
 #include <filesystem>
 #include <stdio.h>
+#include <chrono>
 
 #include <dlfcn.h>
 
@@ -192,6 +193,12 @@ void detach(IPlugObject *plugobject)
 
 uint64_t getTickInMS()
 {
-  return clock();
+  // Wall-clock milliseconds since some fixed point — the CLAP timer extension
+  // schedules in real time. Deliberately not clock(): that is process CPU time
+  // summed over all threads, so it crawls while the process is idle (timers
+  // never fire) and can outrun real time while the audio threads are busy.
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                   std::chrono::steady_clock::now().time_since_epoch())
+                                   .count());
 }
 }  // namespace os

--- a/src/detail/os/macos.mm
+++ b/src/detail/os/macos.mm
@@ -17,6 +17,7 @@
 #include "osutil.h"
 #include <vector>
 #include <iostream>
+#include <chrono>
 #include <dlfcn.h>
 
 #include "detail/os/fs.h"
@@ -117,7 +118,13 @@ void detach(IPlugObject *plugobject)
 
 uint64_t getTickInMS()
 {
-  return (::clock() * 1000) / CLOCKS_PER_SEC;
+  // Wall-clock milliseconds since some fixed point — the CLAP timer extension
+  // schedules in real time. Deliberately not clock(): that is process CPU time
+  // summed over all threads, so it crawls while the process is idle (timers
+  // never fire) and can outrun real time while the audio threads are busy.
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                   std::chrono::steady_clock::now().time_since_epoch())
+                                   .count());
 }
 
 fs::path getPluginPath()

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1361,6 +1361,14 @@ void WrapAsAUV2::onIdle()
     }
   }
 
+  if (_requestMarkDirty.exchange(false))
+  {
+    // The plugin's state no longer matches what the host last read. Apple's
+    // v2->v3 bridge turns this into a KVO notification on the AUAudioUnit's
+    // fullState, so v3 hosts hear it too.
+    PropertyChanged(kAudioUnitProperty_ClassInfo, kAudioUnitScope_Global, 0);
+  }
+
   if (_requestUICallback)
   {
     _requestUICallback = false;


### PR DESCRIPTION
Both Audio Unit wrappers dropped the plugin's clap_host_state::mark_dirty call. AU has
no setDirty(), so use the idiom the wrapper already relies on in
param_rescan(): tell the host that its cached kAudioUnitProperty_ClassInfo is
stale. On AUv3 that is a KVO notification on fullState, which AUAudioUnit.h
documents as bridged to that same v2 property.

Measured in both directions, so one signal serves both host generations:
PropertyChanged(ClassInfo) from AUv2 arrives at a v2-API host's listener and,
via AUAudioUnitV2Bridge, as fullState KVO in a v3 host; the fullState KVO
from an appex crosses the XPC boundary to a v3 host and arrives at a v2-API
host as ClassInfo. No host in these tests refetched the state.

Both are deferred to the existing idle pump rather than fired inline.
PropertyChanged() runs the host's listeners synchronously and they may come
back in through the property getters — a host reading ClassInfo from inside
the notification would re-enter the plugin's state->save() while the plugin
is still inside the call that reported dirty. The flag also collapses bursts
into one notification per tick, and it delivers notifications a plugin emits
from init(), before the host has installed its listeners.

Not accompanied by kAudioUnitProperty_PresentPreset: the wrapper exposes no
presets, so AUBase's mCurrentPreset stays {-1, "Untitled"} and notifying it
would only make hosts re-read an unchanged value. That belongs with CLAP
preset-load support.