### PR TITLE
VST3: clear the missed-latency flag, and null check the handler in tail_changed

### DIFF
--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -213,6 +213,10 @@ tresult PLUGIN_API ClapAsVst3::setActive(TBool state)
 
     if (_missedLatencyRequest)
     {
+      // cleared here, not just in getLatencySamples(): a host that does not answer
+      // the restart by re-querying the latency would otherwise leave the flag set
+      // and get a fresh kLatencyChanged out of every later setActive(true).
+      _missedLatencyRequest = false;
       latency_changed();
     }
 

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -1340,7 +1340,10 @@ void ClapAsVst3::latency_changed()
 void ClapAsVst3::tail_changed()
 {
   // TODO: this could also be kIoChanged, we have to check this
-  this->componentHandler->restartComponent(Vst::RestartFlags::kLatencyChanged);
+  // a plugin can report a tail change from within state load(), which a host may
+  // call before it hands us the component handler - as param_rescan guards for
+  if (this->componentHandler)
+    this->componentHandler->restartComponent(Vst::RestartFlags::kLatencyChanged);
 }
 
 void ClapAsVst3::mark_dirty()


### PR DESCRIPTION
Two small VST3 correctness fixes, found while tracing why a CLAP plugin's `request_restart` never lands in Ardour on Linux.

**`_missedLatencyRequest` is never cleared once it fires.** `getLatencySamples()` sets it when the host asks while the plugin is inactive and returns 0; `setActive(true)` answers it with `latency_changed()` so the host comes back for the real number. But the flag is only ever cleared inside `getLatencySamples()`, so a host that does not re-query the latency in response leaves it set — and gets a fresh `restartComponent(kLatencyChanged)` out of every subsequent activation for the life of the instance. Ardour is such a host: its `kLatencyChanged` branch only invalidates a cached value and re-reads it later, at a time of its choosing.

**`tail_changed()` dereferences `componentHandler` unguarded.** `latency_changed()` one line above and `param_rescan()` both test it first, with a comment explaining that a plugin can ask from within its state `load()`, before the host has handed the wrapper the handler. `tail_changed()` has the same exposure and no check.

Both are one-liners. Compiled and exercised against SpectrumWorx's VST3 build; no behaviour change for a host that already re-queries latency.

Split into two commits so each stands alone.
