### PR TITLE
VST3: give the Linux wrapper a main thread when no editor is open

### DIFF
--- a/src/detail/os/linux.cpp
+++ b/src/detail/os/linux.cpp
@@ -12,11 +12,33 @@
 #include <filesystem>
 #include <stdio.h>
 #include <chrono>
+#include <algorithm>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <vector>
 
 #include <dlfcn.h>
 
 namespace os
 {
+// A Linux VST3 plug-in has no main thread of its own to hang a timer on. The
+// only main-thread callback a VST3 host offers here is Steinberg::Linux::
+// IRunLoop, and that arrives through IPlugFrame -- which means it exists only
+// while an editor is open. Everything onIdle() drives (clap_host::
+// request_callback, clap timers, a deferred parameter flush, the queue of
+// parameter edits bound for the host) was therefore dead whenever the plug-in
+// window was shut.
+//
+// A thread of our own stands in for the main thread the host does not give us
+// -- hence the _standIn members below. It covers that gap and only that gap: a
+// plug object that has been handed a run loop reports hasOwnIdleSource() and is
+// skipped, and when every attached object has one the thread parks on the
+// condition variable rather than spinning. It is the same arrangement JUCE's
+// Linux plug-in client uses, which runs a MessageThread of its own and stops it
+// when the host's message thread appears.
+constexpr auto idleInterval = std::chrono::milliseconds(10);
+
 class LinuxHelper
 {
  public:
@@ -24,10 +46,23 @@ class LinuxHelper
   void terminate();
   void attach(IPlugObject *plugobject);
   void detach(IPlugObject *plugobject);
+  void idleSourceChanged();
 
  private:
+  // both want _standInLock held
+  bool anyoneWantsTicking() const;
   void executeDefered();
+
+  void run();
+
+  // Recursive, and paired with condition_variable_any, because it is held
+  // across onIdle() and a plug object may come back through attach(), detach()
+  // or idleSourceChanged() from inside its own idle.
+  std::recursive_mutex _standInLock;
+  std::condition_variable_any _standInWakeup;
+  std::thread _standInThread;
   std::vector<IPlugObject *> _plugs;
+  bool _standInRunning{false};
 } gLinuxHelper;
 
 #if 0
@@ -152,27 +187,90 @@ std::string getBinaryName()
 #endif
 void LinuxHelper::init()
 {
+  // The thread starts with the first attach() rather than here: a host scanning
+  // plug-ins dlopens and dlcloses this module without ever activating anything.
 }
 
 void LinuxHelper::terminate()
 {
+  {
+    std::lock_guard<std::recursive_mutex> guard(_standInLock);
+    _standInRunning = false;
+  }
+  _standInWakeup.notify_all();
+  if (_standInThread.joinable()) _standInThread.join();
+}
+
+bool LinuxHelper::anyoneWantsTicking() const
+{
+  for (auto const *p : _plugs)
+  {
+    if (p && !p->hasOwnIdleSource()) return true;
+  }
+  return false;
 }
 
 void LinuxHelper::executeDefered()
 {
-  for (auto p : _plugs)
+  for (auto *p : _plugs)
   {
-    if (p) p->onIdle();
+    // An object with a run loop is already being idled on the host's own main
+    // thread; ticking it here too would give it two main threads.
+    if (p && !p->hasOwnIdleSource()) p->onIdle();
   }
 }
+
+void LinuxHelper::run()
+{
+  LOGDETAIL("clap-wrapper: Linux idle thread started");
+
+  std::unique_lock<std::recursive_mutex> guard(_standInLock);
+  while (_standInRunning)
+  {
+    if (!anyoneWantsTicking())
+    {
+      LOGDETAIL("clap-wrapper: every attached object has a run loop, pausing the idle thread");
+      _standInWakeup.wait(guard, [this] { return !_standInRunning || anyoneWantsTicking(); });
+      continue;
+    }
+
+    _standInWakeup.wait_for(guard, idleInterval, [this] { return !_standInRunning; });
+    if (!_standInRunning) break;
+
+    // The lock is held across the idle deliberately: detach() runs on the
+    // host's thread and is followed by the object's destruction, so it has to
+    // be able to wait out an idle that is already in flight. Lock order is
+    // helper-then-plug-object; nothing may call attach(), detach() or
+    // idleSourceChanged() while holding a plug object's own lock.
+    executeDefered();
+  }
+
+  LOGDETAIL("clap-wrapper: Linux idle thread exiting");
+}
+
 void LinuxHelper::attach(IPlugObject *plugobject)
 {
+  std::lock_guard<std::recursive_mutex> guard(_standInLock);
   _plugs.push_back(plugobject);
+
+  if (!_standInRunning)
+  {
+    _standInRunning = true;
+    _standInThread = std::thread([this] { run(); });
+  }
+  _standInWakeup.notify_all();
 }
 
 void LinuxHelper::detach(IPlugObject *plugobject)
 {
+  std::lock_guard<std::recursive_mutex> guard(_standInLock);
   _plugs.erase(std::remove(_plugs.begin(), _plugs.end(), plugobject), _plugs.end());
+  _standInWakeup.notify_all();
+}
+
+void LinuxHelper::idleSourceChanged()
+{
+  _standInWakeup.notify_all();
 }
 
 }  // namespace os
@@ -189,6 +287,11 @@ void attach(IPlugObject *plugobject)
 void detach(IPlugObject *plugobject)
 {
   gLinuxHelper.detach(plugobject);
+}
+
+void idleSourceChanged()
+{
+  gLinuxHelper.idleSourceChanged();
 }
 
 uint64_t getTickInMS()

--- a/src/detail/os/osutil.h
+++ b/src/detail/os/osutil.h
@@ -5,8 +5,8 @@
 */
 
 #include <atomic>
-#include <string>
 #include <functional>
+#include <string>
 
 #include "log.h"
 #include "fs.h"
@@ -57,12 +57,27 @@ class IPlugObject
 {
  public:
   virtual void onIdle() = 0;
+
+  // Windows drives onIdle() from a WM_TIMER on a message window and macOS from
+  // a CFRunLoopTimer on the main run loop, both of which already belong to the
+  // host's main thread. Linux has no such thread to hang a timer on, so its
+  // helper runs one of its own and asks here whether an object would rather be
+  // left alone -- which it would, while a host run loop is driving it instead.
+  virtual bool hasOwnIdleSource() const
+  {
+    return false;
+  }
+
   virtual ~IPlugObject()
   {
   }
 };
 void attach(IPlugObject *plugobject);
 void detach(IPlugObject *plugobject);
+// Tells the Linux helper that some object's answer to hasOwnIdleSource() has
+// changed, so that it can pause its thread or wake it up again. Implemented on
+// Linux only, and called only from LIN paths.
+void idleSourceChanged();
 uint64_t getTickInMS();
 
 // Used for clap_plugin_entry.init(). Path to DSO (Linux, Windows), or the bundle (macOS).

--- a/src/detail/vst3/plugview.cpp
+++ b/src/detail/vst3/plugview.cpp
@@ -5,13 +5,13 @@
 
 WrappedView::WrappedView(const clap_plugin_t *plugin, const clap_plugin_gui_t *gui,
                          std::function<void()> onReleaseAdditionalReferences,
-                         std::function<void(bool)> onDestroy, std::function<void()> onRunLoopAvailable)
+                         std::function<void(bool)> onDestroy, std::function<void()> onRunLoopChanged)
   : IPlugView()
   , FObject()
   , _plugin(plugin)
   , _extgui(gui)
   , _onReleaseAdditionalReferences(onReleaseAdditionalReferences)
-  , _onRunLoopAvailable(onRunLoopAvailable)
+  , _onRunLoopChanged(onRunLoopChanged)
   , _onDestroy(onDestroy)
 {
 }
@@ -224,14 +224,24 @@ tresult PLUGIN_API WrappedView::setFrame(IPlugFrame *frame)
   _plugFrame = frame;
 
 #if LIN
+  // The run loop going away matters as much as it arriving: it is the wrapper's
+  // only main thread, and something has to take over when the host takes it
+  // back. A host may hand back a null frame and keep the view alive across an
+  // editor being closed and reopened.
+  auto *const previousRunLoop = _runLoop;
+  Steinberg::Linux::IRunLoop *runLoop{nullptr};
   if (_plugFrame)
   {
-    if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void **)&_runLoop) ==
-            Steinberg::kResultOk &&
-        _onRunLoopAvailable)
+    if (_plugFrame->queryInterface(Steinberg::Linux::IRunLoop::iid, (void **)&runLoop) !=
+        Steinberg::kResultOk)
     {
-      _onRunLoopAvailable();
+      runLoop = nullptr;
     }
+  }
+  _runLoop = runLoop;
+  if (_runLoop != previousRunLoop && _onRunLoopChanged)
+  {
+    _onRunLoopChanged();
   }
 #endif
   return kResultOk;

--- a/src/detail/vst3/plugview.h
+++ b/src/detail/vst3/plugview.h
@@ -23,7 +23,7 @@ class WrappedView : public Steinberg::IPlugView,
  public:
   WrappedView(const clap_plugin_t *plugin, const clap_plugin_gui_t *gui,
               std::function<void()> onReleaseAdditionalReferences, std::function<void(bool)> onDestroy,
-              std::function<void()> onRunLoopAvailable);
+              std::function<void()> onRunLoopChanged);
   ~WrappedView();
 
   // IPlugView interface
@@ -100,7 +100,7 @@ class WrappedView : public Steinberg::IPlugView,
   void releaseAdditionalReferences();
   const clap_plugin_t *_plugin = nullptr;
   const clap_plugin_gui_t *_extgui = nullptr;
-  std::function<void()> _onReleaseAdditionalReferences = nullptr, _onRunLoopAvailable = nullptr;
+  std::function<void()> _onReleaseAdditionalReferences = nullptr, _onRunLoopChanged = nullptr;
   std::function<void(bool)> _onDestroy = nullptr;
   clap_window_t _window = {nullptr, {nullptr}};
   IPlugFrame *_plugFrame = nullptr;

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -274,6 +274,9 @@ tresult PLUGIN_API ClapAsVst3::canProcessSampleSize(int32 symbolicSampleSize)
 
 tresult PLUGIN_API ClapAsVst3::setState(IBStream *state)
 {
+  // [main-thread] -- must not run while the Linux helper thread is inside this
+  // plug-in's idle. \see _mainThreadLock
+  std::lock_guard<std::recursive_mutex> mainThreadGuard(_mainThreadLock);
   auto raise = _plugin->AlwaysMainThread();
   // a plugin may request a value rescan from within load(), which syncs the values for us
   _paramValuesSyncedDuringLoad = false;
@@ -312,6 +315,9 @@ void ClapAsVst3::syncParameterValuesFromClap()
 
 tresult PLUGIN_API ClapAsVst3::getState(IBStream *state)
 {
+  // [main-thread] -- must not run while the Linux helper thread is inside this
+  // plug-in's idle. \see _mainThreadLock
+  std::lock_guard<std::recursive_mutex> mainThreadGuard(_mainThreadLock);
   return (_plugin->save(CLAPVST3StreamAdapter(state)) ? Steinberg::kResultOk : Steinberg::kResultFalse);
 }
 
@@ -350,6 +356,9 @@ uint32 PLUGIN_API ClapAsVst3::getTailSamples()
 
 tresult PLUGIN_API ClapAsVst3::setupProcessing(Vst::ProcessSetup &newSetup)
 {
+  // [main-thread] -- must not run while the Linux helper thread is inside this
+  // plug-in's idle. \see _mainThreadLock
+  std::lock_guard<std::recursive_mutex> mainThreadGuard(_mainThreadLock);
   if (newSetup.symbolicSampleSize != Vst::kSample32)
   {
     return kResultFalse;
@@ -411,6 +420,9 @@ tresult PLUGIN_API ClapAsVst3::setProcessing(TBool state)
 tresult PLUGIN_API ClapAsVst3::setBusArrangements(Vst::SpeakerArrangement *inputs, int32 numIns,
                                                   Vst::SpeakerArrangement *outputs, int32 numOuts)
 {
+  // [main-thread] -- must not run while the Linux helper thread is inside this
+  // plug-in's idle. \see _mainThreadLock
+  std::lock_guard<std::recursive_mutex> mainThreadGuard(_mainThreadLock);
   if (!_plugin->_ext._audioports)
   {
     return kResultFalse;
@@ -501,6 +513,9 @@ tresult PLUGIN_API ClapAsVst3::setComponentState(IBStream * /*state*/)
 
 IPlugView *PLUGIN_API ClapAsVst3::createView(FIDString /*name*/)
 {
+  // [main-thread] -- must not run while the Linux helper thread is inside this
+  // plug-in's idle. \see _mainThreadLock
+  std::lock_guard<std::recursive_mutex> mainThreadGuard(_mainThreadLock);
   if (_plugin->_ext._gui)
   {
     clearContextMenu();
@@ -517,6 +532,10 @@ IPlugView *PLUGIN_API ClapAsVst3::createView(FIDString /*name*/)
               detachTimers(_wrappedview->getRunLoop());
               detachPosixFD(_wrappedview->getRunLoop());
               _iRunLoop = nullptr;
+
+              // the editor is going away, and with it the only main thread the
+              // host was ever going to hand us -- wake the helper back up
+              os::idleSourceChanged();
 #endif
 
               clearContextMenu();
@@ -527,8 +546,21 @@ IPlugView *PLUGIN_API ClapAsVst3::createView(FIDString /*name*/)
           {
 
 #if LIN
-            attachTimers(_wrappedview->getRunLoop());
-            attachPosixFD(_wrappedview->getRunLoop());
+            if (auto *const runLoop = _wrappedview->getRunLoop())
+            {
+              attachTimers(runLoop);
+              attachPosixFD(runLoop);
+            }
+            else if (_iRunLoop)
+            {
+              // the host took the frame back but kept the view: unregister
+              // while the old run loop is still alive, then hand the idle back
+              // to the helper thread
+              detachTimers(_iRunLoop);
+              detachPosixFD(_iRunLoop);
+              _iRunLoop = nullptr;
+              os::idleSourceChanged();
+            }
 #else
             (void)this;  // silence warning on non-linux
 #endif
@@ -542,6 +574,9 @@ IPlugView *PLUGIN_API ClapAsVst3::createView(FIDString /*name*/)
 tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::ParamValue valueNormalized,
                                                      Vst::String128 string)
 {
+  // [main-thread] -- must not run while the Linux helper thread is inside this
+  // plug-in's idle. \see _mainThreadLock
+  std::lock_guard<std::recursive_mutex> mainThreadGuard(_mainThreadLock);
   auto param = (Vst3Parameter *)this->getParameterObject(id);
   auto val = param->asClapValue(valueNormalized);
 
@@ -583,6 +618,9 @@ tresult PLUGIN_API ClapAsVst3::getParamStringByValue(Vst::ParamID id, Vst::Param
 tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar *string,
                                                      Vst::ParamValue &valueNormalized)
 {
+  // [main-thread] -- must not run while the Linux helper thread is inside this
+  // plug-in's idle. \see _mainThreadLock
+  std::lock_guard<std::recursive_mutex> mainThreadGuard(_mainThreadLock);
   auto param = (Vst3Parameter *)this->getParameterObject(id);
   Steinberg::String m(string);
   char inbuf[128];
@@ -604,6 +642,9 @@ tresult PLUGIN_API ClapAsVst3::getParamValueByString(Vst::ParamID id, Vst::TChar
 tresult PLUGIN_API ClapAsVst3::activateBus(Vst::MediaType type, Vst::BusDirection dir, int32 index,
                                            TBool state)
 {
+  // [main-thread] -- must not run while the Linux helper thread is inside this
+  // plug-in's idle. \see _mainThreadLock
+  std::lock_guard<std::recursive_mutex> mainThreadGuard(_mainThreadLock);
   return super::activateBus(type, dir, index, state);
 }
 
@@ -644,6 +685,9 @@ tresult PLUGIN_API ClapAsVst3::setIoMode(Vst::IoMode mode)
 
 tresult PLUGIN_API ClapAsVst3::setComponentHandler(Vst::IComponentHandler *handler)
 {
+  // [main-thread] -- must not run while the Linux helper thread is inside this
+  // plug-in's idle. \see _mainThreadLock
+  std::lock_guard<std::recursive_mutex> mainThreadGuard(_mainThreadLock);
   componentHandler3.reset();
 
   // the base class extracts IComponentHandler and IComponentHandler2
@@ -1465,6 +1509,22 @@ const char *ClapAsVst3::host_get_name()
 
 void ClapAsVst3::onIdle()
 {
+  if (!_plugin || !_plugin->_plugin) return;
+
+  // On the run loop path this is the host's own main thread and the lock is
+  // uncontended. On the Linux helper thread it is not, so take it with
+  // try_lock: the helper holds a module-wide lock while it idles, and blocking
+  // here would stall every other instance behind whichever one the host is
+  // currently inside. Anything skipped is picked up on the next tick.
+  std::unique_lock<std::recursive_mutex> mainThreadGuard(_mainThreadLock, std::try_to_lock);
+  if (!mainThreadGuard.owns_lock()) return;
+
+  // Makes clap_host_thread_check::is_main_thread() answer true for the
+  // duration. The lock above is what earns that answer rather than merely
+  // asserting it: while it is held, the thread the host calls the main thread
+  // cannot be in here as well.
+  auto mainThreadOverride = _plugin->AlwaysMainThread();
+
   // handling queued events
   queueEvent n;
   while (_queueToUI.pop(n))
@@ -1532,10 +1592,10 @@ void ClapAsVst3::onIdle()
   }
 
 #if LIN
-  if (!_iRunLoop)  // don't process timers if we have a runloop.
-                   // (but if we don't have a runloop on linux onIdle isn't called
-                   // anyway so consider just not having this at all once we decide
-                   // to do with the no UI case)
+  // With a run loop the timers are registered on it directly and fire as
+  // ITimerHandlers. Without one this idle belongs to the helper thread, and
+  // driving them here is what makes clap timers work with no editor open.
+  if (!_iRunLoop)
 #endif
   {
     // handling timerobjects
@@ -1609,6 +1669,9 @@ void ClapAsVst3::attachTimers(Steinberg::Linux::IRunLoop *r)
         _iRunLoop->registerTimer(t.handler.get(), t.period);
       }
     }
+
+    // the host's own main thread drives the idle from here on
+    os::idleSourceChanged();
   }
 }
 

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -364,6 +364,14 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
  public:
   //----from IPlugObject
   void onIdle() override;
+#if LIN
+  // While an editor is open the host's run loop drives onIdle() on the real
+  // main thread and the Linux helper thread stands down. \see attachTimers()
+  bool hasOwnIdleSource() const override
+  {
+    return _iRunLoop != nullptr;
+  }
+#endif
 
  private:
   std::vector<clap_id> _gesturedparameters;
@@ -412,6 +420,17 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   std::atomic_bool _requestUICallback = false;
   std::atomic_bool _requestRestart = false;
+
+  // Held by whichever thread is currently acting as this plug-in's main thread:
+  // the host's, or the Linux helper standing in for it while no editor is open.
+  // The VST3 entry points a host is expected to call on the main thread take it
+  // too, so that the two cannot be inside the plug-in at the same time.
+  // Recursive because a plug-in reaches back into the wrapper from within
+  // on_main_thread().
+  //
+  // Lock order is helper-then-plug-object: never call os::attach(), os::detach()
+  // or os::idleSourceChanged() while holding this.
+  std::recursive_mutex _mainThreadLock;
   bool _missedLatencyRequest = false;
 
   std::thread::id _main_thread_id{};


### PR DESCRIPTION
On Windows onIdle() is driven by a WM_TIMER on a message window and on macOS by a CFRunLoopTimer on the main run loop. Both already belong to the host's main thread, so they run whether or not an editor is open.

Linux has no equivalent. The only main-thread callback a VST3 host offers is Steinberg::Linux::IRunLoop, and it is reached through IPlugFrame, which means it exists only while an editor is open. LinuxHelper had the shape of the other two -- attach(), detach(), executeDefered() -- but nothing ever called executeDefered(), so with the plug-in window shut onIdle() did not run at all. Everything it drives was dead:

  - clap_host::request_callback never reached clap_plugin::on_main_thread
  - the queue of parameter edits bound for the host was never drained, so beginEdit/performEdit/endEdit never reached the host
  - a requested parameter flush never happened
  - restartComponent(kIoChanged | kLatencyChanged) was never sent, so latency changes went unannounced
  - clap timers never fired

Measured against Reaper with the editor closed, 14 of 14 request_callback calls went unanswered; under Steinberg's own validator, 372 of 372.

This adds the missing timer as a thread of the helper's own, at 100Hz. It stands in for the main thread the host does not provide, and covers that gap only: a plug object that has been handed a run loop answers hasOwnIdleSource() and is skipped, and when every attached object has one the thread parks on a condition variable rather than spinning. os::idleSourceChanged() wakes it when an editor closes. That is the same arrangement JUCE's Linux plug-in client uses, which runs a MessageThread of its own and stops it when the host's message thread appears.

Because that thread is not the host's main thread, two things follow.

Clap::Plugin::AlwaysMainThread() is raised around the idle so that clap_host_thread_check answers truthfully for its duration, and a recursive _mainThreadLock is taken there and in the VST3 entry points a host calls on the main thread, so that the two cannot be inside the plug-in at once. onIdle() takes it with try_lock and skips the tick if the host is already inside: the helper holds a module-wide lock while it idles, and blocking would stall every other instance behind it.

One fix this depends on: WrappedView::setFrame() now reports the run loop going away as well as arriving. It only ever set _runLoop, so a host that hands back a null frame while keeping the view -- across an editor being closed and reopened -- left the wrapper believing it still had a main thread, and the stand-in thread parked forever. _onRunLoopAvailable is renamed _onRunLoopChanged to match.

Tested on aarch64 Linux: Steinberg's validator passes 47/47; a purpose- built host that never creates a view serves every request_callback where it previously served none; opening and closing an editor mid-run hands the idle over in both directions without dropping one.

Assisted-by: Claude Opus 5 (1M context) <noreply@anthropic.com>