### PR TITLE
AUv2: implement host request_process()

### DIFF
--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -587,8 +587,8 @@ void Plugin::clapRequestRestart(const clap_host *host)
 // [thread-safe]
 void Plugin::clapRequestProcess(const clap_host *host)
 {
-  // right now, I don't know how to communicate this to the host
-  // in VST3 you can't force processing...
+  auto self = static_cast<Plugin *>(host->host_data);
+  self->_parentHost->request_process();
 }
 
 // Registers a periodic timer.

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -40,6 +40,7 @@ class IHost
 
   virtual void mark_dirty() = 0;
   virtual void restartPlugin() = 0;
+  virtual void request_process() = 0;
   virtual void request_callback() = 0;
 
   virtual void setupWrapperSpecifics(

--- a/src/detail/aax/wrapper.cpp
+++ b/src/detail/aax/wrapper.cpp
@@ -1108,6 +1108,12 @@ void ClapAsAAX::restartPlugin()
 {
 }
 
+void ClapAsAAX::request_process()
+{
+  // AAX has no host-facing way to ask for processing to start, the same as
+  // restartPlugin() above.
+}
+
 bool ClapAsAAX::register_timer(uint32_t period_ms, clap_id *timer_id)
 {
   // AAX TimerWakeup fires at roughly 30ms; clamp period to that minimum.

--- a/src/detail/aax/wrapper.h
+++ b/src/detail/aax/wrapper.h
@@ -236,6 +236,8 @@ class ClapAsAAX : public AAX_CEffectParameters,
 
   void restartPlugin() override;
 
+  void request_process() override;
+
   void request_callback() override;
 
   // clap_timer support

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -604,8 +604,9 @@ class WrapAsAUV2 : public ausdk::AUBase,
   {
     // AU gives a plugin no way to make the host pull Render(), so this cannot
     // mean what it means in a real host. What the wrapper does own is the CLAP's
-    // own activate/start_processing pair, and the parameter flush -- see
-    // onIdle(), which decides which of the two this tick can deliver.
+    // own activate/start_processing pair -- see onIdle(), which stands the plugin
+    // back up if the AU is initialized and the CLAP underneath it is not, and
+    // then asks for the flush that carries whatever the request was really about.
     _requestProcess = true;
   }
   void request_callback() override
@@ -631,9 +632,10 @@ class WrapAsAUV2 : public ausdk::AUBase,
   }
   void param_request_flush() override
   {
-    // Deferred to onIdle(): flush() is only ours to call while the CLAP is
-    // deactivated -- once it is active the render thread owns that call, and
-    // then a flush is not needed anyway because process() carries the events.
+    // May arrive at any moment and in any state, active or not: it says the
+    // plugin has parameter events, not that it has stopped processing. Deferred
+    // to onIdle(), which is the only place that can tell whether a render is
+    // going to carry them already.
     _requestedFlush = true;
   }
 
@@ -730,6 +732,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   // --------------- IPlugObject
   void onIdle() override;
+
+  // drains _queueToUI into the host's parameter listeners; called at the top of
+  // onIdle() and again after an idle flush, so a value the flush pulled out of
+  // the plugin does not wait a further tick to be announced.
+  void pushQueuedEventsToHost();
 
   // context menu extension
   bool supportsContextMenu() const override
@@ -896,8 +903,15 @@ class WrapAsAUV2 : public ausdk::AUBase,
   std::atomic_bool _requestRestart = false;
   // set by request_process(), serviced in onIdle()
   std::atomic_bool _requestProcess = false;
-  // set by param_request_flush(), serviced in onIdle()
+  // "there are parameter events to move": set by param_request_flush() for the
+  // plugin's direction and by SetParameter for the host's, serviced in onIdle()
   std::atomic_bool _requestedFlush = false;
+  // set by Render(), cleared by onIdle(): tells the idle tick whether a render
+  // has carried the plugin's events since it last looked. See onIdle().
+  std::atomic_bool _renderedSinceIdle = false;
+  // consecutive idle ticks that saw no render, saturating at the point where the
+  // idle tick takes over the flushing. Only onIdle() touches it.
+  uint32_t _idleTicksSinceRender = 0;
 
   // Held by Render() for its whole body, and taken by onIdle() to fence against
   // an in-flight render before it rebuilds the plugin. See onIdle().

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -764,10 +764,15 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // CLAP port layout (ValidFormat admits every probed layout), push the
   // matching configuration into the plugin via configurable-audio-ports and
   // refresh the port caches. Called from activateCLAP: main thread, plugin
-  // deactivated — the state the extension requires.
-  void applyConfigurationFromBusFormats();
+  // deactivated — the state the extension requires. Returns false when the
+  // plugin rejects the configuration, in which case activation must not
+  // proceed (the AU formats and the plugin's ports would disagree about
+  // buffer sizes).
+  bool applyConfigurationFromBusFormats();
 
-  void activateCLAP();
+  // Returns false when the plugin rejects the host-chosen bus formats; the
+  // caller must treat that as a failed initialization.
+  bool activateCLAP();
   void deactivateCLAP();
   // the AU-level half of the teardown, which an internal restart must not do
   void releaseHostMIDIOutput();
@@ -816,7 +821,12 @@ class WrapAsAUV2 : public ausdk::AUBase,
   };
   std::vector<ChannelCapsCache> _channelCapsCache;
 
-  // Upper bound of the per-scope channel counts probed for the cache.
+  // Upper bound of the per-scope main-bus *channel counts* probed for the
+  // cache (not a bus count). The active layout is seeded into the cache
+  // unconditionally, so a plugin whose main bus is wider than this still
+  // advertises its own configuration; the bound only limits how many
+  // alternate layouts are asked about (and so how many
+  // can_apply_configuration calls a single instantiation makes).
   static constexpr uint32_t kMaxProbedChannels = 8;
 
   uint32_t _midi_preferred_dialect = 0;

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -425,6 +425,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
     const UInt32 strippedStatus = inStatus & 0xf0U;  // NOLINT
     const UInt32 channel = inStatus & 0x0fU;         // NOLINT
 
+    // Every path that queues onto the adapter takes the process lock. A host
+    // may call the MusicDevice entry points from its MIDI thread at any time,
+    // including while the idle tick is flushing (see onIdle()) -- and the
+    // adapter's event queue takes one writer at a time.
+    ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
     if (_processAdapter)
     {
       _processAdapter->addMIDIEvent(inStatus, inData1, inData2, inOffsetSampleFrame);
@@ -443,6 +448,9 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // note-expression handling of the MIDI1 path.
   OSStatus MIDIEventList(UInt32 inOffsetSampleFrame, const struct MIDIEventList *evtlist) override
   {
+    // Held across the whole list rather than per event; handleUMPSysEx7() is
+    // called from inside it and must not take it again. See MIDIEvent().
+    ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
     if (!_processAdapter || !evtlist) return noErr;
 
     const bool midi2 = (evtlist->protocol == kMIDIProtocol_2_0);
@@ -502,6 +510,8 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   // Reassemble a UMP SysEx7 packet stream into a single CLAP SysEx event using the
   // shared reassembler; on a complete message it is already framed with 0xF0/0xF7.
+  // Called only from MIDIEventList(), which holds the process lock for the
+  // whole list -- do not take it here, it is not recursive.
   void handleUMPSysEx7(uint32_t w0, uint32_t w1, UInt32 offset)
   {
     if (!_processAdapter) return;
@@ -515,6 +525,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   OSStatus SysEx(const UInt8 *inData, UInt32 inLength) override
   {
+    ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
     if (_processAdapter)
     {
       // the AU SysEx entry point carries no sample offset; deliver at frame 0
@@ -528,6 +539,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
                      NoteInstanceID *outNoteInstanceID, UInt32 inOffsetSampleFrame,
                      const MusicDeviceNoteParams &inParams) override
   {
+    ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
     if (!_processAdapter) return kAudioUnitErr_Uninitialized;
 
     const int16_t channel = static_cast<int16_t>(inGroupID & 0x0F);
@@ -545,6 +557,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
   OSStatus StopNote(MusicDeviceGroupID inGroupID, NoteInstanceID inNoteInstanceID,
                     UInt32 inOffsetSampleFrame) override
   {
+    ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
     if (!_processAdapter) return kAudioUnitErr_Uninitialized;
     const int16_t channel = static_cast<int16_t>(inGroupID & 0x0F);
     _processAdapter->stopNote(static_cast<int32_t>(inNoteInstanceID), channel, inOffsetSampleFrame);
@@ -816,6 +829,9 @@ class WrapAsAUV2 : public ausdk::AUBase,
   std::shared_ptr<Clap::Plugin> _plugin = nullptr;
 
   std::unique_ptr<Clap::AUv2::ProcessAdapter> _processAdapter;
+  // Only for the deactivated-plugin flush, where _processAdapter does not
+  // exist. Lives across flushes so gestures pair up; see flushParameters().
+  std::unique_ptr<Clap::AUv2::ProcessAdapter> _flushAdapter;
   std::atomic<bool> _initialized = false;
 
   // some info about the wrapped clap
@@ -912,6 +928,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // consecutive idle ticks that saw no render, saturating at the point where the
   // idle tick takes over the flushing. Only onIdle() touches it.
   uint32_t _idleTicksSinceRender = 0;
+  // how many of those ticks make a stopped host, sized from the block period in
+  // activateCLAP(). See onIdle().
+  static constexpr double kIdleTickMs = 10.0;
+  static constexpr uint32_t kMinIdleTicksBeforeFlush = 5;
+  uint32_t _idleTicksBeforeFlush = kMinIdleTicksBeforeFlush;
 
   // Held by Render() for its whole body, and taken by onIdle() to fence against
   // an in-flight render before it rebuilds the plugin. See onIdle().

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -754,6 +754,19 @@ class WrapAsAUV2 : public ausdk::AUBase,
   void addInputBus(int bus, const clap_audio_port_info_t *info);
   void addOutputBus(int bus, const clap_audio_port_info_t *info);
 
+  // Configuration requests for the main busses: main ports get the given
+  // channel counts, non-main ports keep their current ones. Shared by the
+  // PostConstructor probe and applyConfigurationFromBusFormats.
+  std::vector<clap_audio_port_configuration_request_t> mainBusConfigurationRequests(
+      uint32_t mainInChannels, uint32_t mainOutChannels) const;
+
+  // If the host chose main-bus stream formats that differ from the current
+  // CLAP port layout (ValidFormat admits every probed layout), push the
+  // matching configuration into the plugin via configurable-audio-ports and
+  // refresh the port caches. Called from activateCLAP: main thread, plugin
+  // deactivated — the state the extension requires.
+  void applyConfigurationFromBusFormats();
+
   void activateCLAP();
   void deactivateCLAP();
   // the AU-level half of the teardown, which an internal restart must not do
@@ -789,6 +802,22 @@ class WrapAsAUV2 : public ausdk::AUBase,
   };
   std::vector<AudioPortCache> _inputPortCache;
   std::vector<AudioPortCache> _outputPortCache;
+
+  // Main-bus channel-count pairs the plugin accepts, probed at
+  // PostConstructor through clap.configurable-audio-ports (the wrapper's
+  // only source of alternate layouts, mirroring the VST3 wrapper) under the
+  // same deactivated-only constraint as the port caches. Advertised through
+  // SupportedNumChannels, accepted in ValidFormat, applied in activateCLAP
+  // once the host has settled on formats (applyConfigurationFromBusFormats).
+  struct ChannelCapsCache
+  {
+    uint32_t inputChannels;   // main input channel count, 0 = no main input
+    uint32_t outputChannels;  // main output channel count, 0 = no main output
+  };
+  std::vector<ChannelCapsCache> _channelCapsCache;
+
+  // Upper bound of the per-scope channel counts probed for the cache.
+  static constexpr uint32_t kMaxProbedChannels = 8;
 
   uint32_t _midi_preferred_dialect = 0;
   uint32_t _midi_supported_dialects = 0;

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -600,6 +600,14 @@ class WrapAsAUV2 : public ausdk::AUBase,
   {
     _requestRestart = true;
   }
+  void request_process() override
+  {
+    // AU gives a plugin no way to make the host pull Render(), so this cannot
+    // mean what it means in a real host. What the wrapper does own is the CLAP's
+    // own activate/start_processing pair, and the parameter flush -- see
+    // onIdle(), which decides which of the two this tick can deliver.
+    _requestProcess = true;
+  }
   void request_callback() override
   {
     _requestUICallback = true;
@@ -623,6 +631,10 @@ class WrapAsAUV2 : public ausdk::AUBase,
   }
   void param_request_flush() override
   {
+    // Deferred to onIdle(): flush() is only ours to call while the CLAP is
+    // deactivated -- once it is active the render thread owns that call, and
+    // then a flush is not needed anyway because process() carries the events.
+    _requestedFlush = true;
   }
 
   void latency_changed() override;
@@ -774,6 +786,9 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // caller must treat that as a failed initialization.
   bool activateCLAP();
   void deactivateCLAP();
+  // parameter-only round trip on a throwaway process adapter, for when no render
+  // is running to carry the events. Only legal while the CLAP is deactivated.
+  void flushParameters();
   // the AU-level half of the teardown, which an internal restart must not do
   void releaseHostMIDIOutput();
   bool IsBypassEffect()
@@ -879,6 +894,10 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // set by mark_dirty(), serviced in onIdle()
   std::atomic_bool _requestMarkDirty = false;
   std::atomic_bool _requestRestart = false;
+  // set by request_process(), serviced in onIdle()
+  std::atomic_bool _requestProcess = false;
+  // set by param_request_flush(), serviced in onIdle()
+  std::atomic_bool _requestedFlush = false;
 
   // Held by Render() for its whole body, and taken by onIdle() to fence against
   // an in-flight render before it rebuilds the plugin. See onIdle().

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -187,6 +187,25 @@ void ProcessAdapter::sortEventIndices()
             });
 }
 
+// Parameter-only round trip, for when there is no render to carry the events.
+// clap_plugin_params.flush() is [main-thread] while the plugin is deactivated and
+// [audio-thread] while it is active; the wrapper only ever calls this on a
+// throwaway adapter for a deactivated plugin, which is why the event vectors are
+// cleared rather than preserved for a following process() cycle.
+void ProcessAdapter::flush()
+{
+  if (!_ext_params) return;
+
+  _events.clear();
+  _eventindices.clear();
+
+  // no sortEventIndices(): there is no input event to order
+  _ext_params->flush(_plugin, _processData.in_events, _processData.out_events);
+
+  _events.clear();
+  _eventindices.clear();
+}
+
 void ProcessAdapter::process(ProcessData &data)
 {
   // CLAP requires event times within [0, frames_count); a host stamping

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -19,6 +19,12 @@ inline clap_sectime doubleToSecTime(double t)
   return round(t * CLAP_SECTIME_FACTOR);
 }
 
+// the only event types a parameter flush may carry, per clap/ext/params.h
+inline bool isParameterEvent(uint16_t type)
+{
+  return type == CLAP_EVENT_PARAM_VALUE || type == CLAP_EVENT_PARAM_MOD;
+}
+
 ProcessAdapter::~ProcessAdapter()
 {
   if (_input_ports)
@@ -187,23 +193,43 @@ void ProcessAdapter::sortEventIndices()
             });
 }
 
-// Parameter-only round trip, for when there is no render to carry the events.
+// Parameter-only round trip, for when no render is running to carry the events.
+// Two things are due when process() is not coming: the parameter events queued
+// since the last cycle -- host automation, arriving through SetParameter -- have
+// to reach the plugin, and the plugin has to be given somewhere to push its own
+// output events, which in CLAP it can only do from inside process() or flush().
+//
 // clap_plugin_params.flush() is [main-thread] while the plugin is deactivated and
-// [audio-thread] while it is active; the wrapper only ever calls this on a
-// throwaway adapter for a deactivated plugin, which is why the event vectors are
-// cleared rather than preserved for a following process() cycle.
+// [audio-thread] while it is active; the caller decides which of the two it is
+// and serializes this against Render() accordingly.
+//
+// Only parameter events are legal in a flush, so the index list is narrowed to
+// those. Anything else queued -- MIDI the host handed us outside a render --
+// keeps its place in _events and waits for the next process() cycle.
 void ProcessAdapter::flush()
 {
   if (!_ext_params) return;
 
-  _events.clear();
   _eventindices.clear();
+  for (size_t i = 0; i < _events.size(); ++i)
+  {
+    if (isParameterEvent(_events[i].header.type)) _eventindices.emplace_back(i);
+  }
+  sortEventIndices();
 
-  // no sortEventIndices(): there is no input event to order
   _ext_params->flush(_plugin, _processData.in_events, _processData.out_events);
 
-  _events.clear();
+  // What was just delivered is gone; whatever is left keeps waiting, so both the
+  // queue and the index list are rebuilt over the events that remain.
+  size_t kept = 0;
+  for (size_t i = 0; i < _events.size(); ++i)
+  {
+    if (!isParameterEvent(_events[i].header.type)) _events[kept++] = _events[i];
+  }
+  _events.resize(kept);
+
   _eventindices.clear();
+  for (size_t i = 0; i < kept; ++i) _eventindices.emplace_back(i);
 }
 
 void ProcessAdapter::process(ProcessData &data)
@@ -338,9 +364,11 @@ void ProcessAdapter::process(ProcessData &data)
 uint32_t ProcessAdapter::input_events_size(const struct clap_input_events *list)
 {
   auto self = static_cast<ProcessAdapter *>(list->ctx);
-  auto k = (uint32_t)self->_events.size();
+  // the index list, not the event list: the two match one to one for a process()
+  // cycle, but a flush narrows the indices to the parameter events and leaves the
+  // rest of the queue in place.
+  auto k = (uint32_t)self->_eventindices.size();
   return k;
-  // return self->_vstdata->inputEvents->getEventCount();
 }
 
 // returns the pointer to an event in the list. The index accessed is not the position in the event list itself
@@ -349,7 +377,7 @@ const clap_event_header_t *ProcessAdapter::input_events_get(const struct clap_in
                                                             uint32_t index)
 {
   auto self = static_cast<ProcessAdapter *>(list->ctx);
-  if (self->_events.size() > index)
+  if (self->_eventindices.size() > index)
   {
     // we can safely return the note.header also for other event types
     // since they are at the same memory address

--- a/src/detail/auv3/auv3_audiounit.mm
+++ b/src/detail/auv3/auv3_audiounit.mm
@@ -207,6 +207,14 @@ class AUv3ImplDetail : public Clap::IHost, public Clap::IAutomation, public os::
     AUV3LOG("IHost::restartPlugin() called");
   }
 
+  void request_process() override
+  {
+    // The AUv3 host owns the render resources: start_processing() happens in
+    // allocateRenderResourcesAndReturnError:, which only the host calls. There
+    // is nothing to wake from this side.
+    AUV3LOG("IHost::request_process() called");
+  }
+
   void request_callback() override
   {
     // Just set the flag. The main-queue idle timer will service it between

--- a/src/detail/standalone/macos/AppDelegate.mm
+++ b/src/detail/standalone/macos/AppDelegate.mm
@@ -50,6 +50,17 @@
     standaloneHost->running = standaloneHost->activatePlugin(standaloneHost->currentSampleRate, 1,
                                                              standaloneHost->currentBufferSize * 2);
   }
+
+  // Unlike a plugin wrapper, the standalone owns its audio engine, so a wake
+  // request means something here: if the plugin is not active, stand it up. If
+  // it already is, the callback is pulling it and there is nothing to do. The
+  // sample rate check keeps this from firing before the engine has ever run.
+  if (standaloneHost->processRequested.exchange(false) && !standaloneHost->isActive &&
+      standaloneHost->currentSampleRate > 0)
+  {
+    standaloneHost->running = standaloneHost->activatePlugin(standaloneHost->currentSampleRate, 1,
+                                                             standaloneHost->currentBufferSize * 2);
+  }
 }
 
 - (void)doSetup

--- a/src/detail/standalone/standalone_host.h
+++ b/src/detail/standalone/standalone_host.h
@@ -116,6 +116,11 @@ struct StandaloneHost : Clap::IHost
   {
     restartRequested = true;
   }
+  std::atomic<bool> processRequested{false};
+  void request_process() override
+  {
+    processRequested = true;
+  }
   std::atomic<bool> callbackRequested{false};
   void request_callback() override
   {

--- a/src/detail/standalone/windows/windows_standalone.cpp
+++ b/src/detail/standalone/windows/windows_standalone.cpp
@@ -1102,6 +1102,20 @@ Plugin::Plugin(std::shared_ptr<Clap::Plugin> clapPlugin, int nCmdShow)
                    // the plugin refuses to reactivate.
                    sah->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
                  }
+
+                 if (sah->processRequested.exchange(false))
+                 {
+                   // Unlike a plugin wrapper, the standalone owns its audio
+                   // engine, so a wake request means something here: if the
+                   // plugin is not active, stand it up. If it already is, the
+                   // callback is pulling it and there is nothing to do. The
+                   // sample rate check keeps this from firing before the
+                   // engine has ever run.
+                   if (!sah->isActive && sah->currentSampleRate > 0)
+                   {
+                     sah->activatePlugin(sah->currentSampleRate, 1, sah->currentBufferSize * 2);
+                   }
+                 }
                }
 
                return 0;

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -3,6 +3,8 @@
 #include <set>
 #include <limits>
 #include <cassert>
+#include <algorithm>
+#include <cmath>
 #include <Block.h>
 
 extern bool fillAudioUnitCocoaView(AudioUnitCocoaViewInfo *viewInfo, std::shared_ptr<Clap::Plugin>);
@@ -1234,8 +1236,6 @@ bool WrapAsAUV2::activateCLAP()
   if (_plugin)
   {
     assert(!_initialized);
-    if (!_processAdapter) _processAdapter = std::make_unique<Clap::AUv2::ProcessAdapter>();
-
     // Reconcile the host-chosen bus formats with the plugin's port layout
     // before anything reads the ports: main thread, plugin deactivated. A
     // failure here must fail the activation: ValidFormat can only vet each
@@ -1254,6 +1254,17 @@ bool WrapAsAUV2::activateCLAP()
     _plugin->setBlockSizes(minSampleFrames, maxSampleFrames);
     _plugin->setSampleRate(Output(0).GetStreamFormat().mSampleRate);
 
+    // How long onIdle() waits before it decides the host has stopped rendering.
+    // A fixed number of ticks cannot work: at 4096 frames and 44.1kHz a block is
+    // 93ms, so a host that is rendering perfectly normally leaves gaps longer
+    // than any small constant, and the idle tick would flush inside every one of
+    // them -- stealing the scheduled automation SetParameter queues, offsets and
+    // all. Three blocks is a gap no rendering host produces.
+    const double sampleRate = std::max(Output(0).GetStreamFormat().mSampleRate, 1.0);
+    const double blockMs = 1000.0 * static_cast<double>(maxSampleFrames) / sampleRate;
+    const auto ticks = static_cast<uint32_t>(std::ceil(3.0 * blockMs / kIdleTickMs));
+    _idleTicksBeforeFlush = std::max(kMinIdleTicksBeforeFlush, ticks);
+
     // the plugin's actually-declared audio port counts (0 when it has no
     // audio-ports extension); these may be fewer than the AU element counts
     uint32_t clapAudioInputs = 0, clapAudioOutputs = 0;
@@ -1263,9 +1274,20 @@ bool WrapAsAUV2::activateCLAP()
       clapAudioOutputs = _plugin->_ext._audioports->count(_plugin->_plugin, false);
     }
 
-    _processAdapter->setupProcessing(Inputs(), Outputs(), _plugin->_plugin, _plugin->_ext._params, this,
-                                     &_parametertree, this, maxSampleFrames, _midi_preferred_dialect,
-                                     _midi_supported_dialects, clapAudioInputs, clapAudioOutputs);
+    {
+      // Built and configured under the lock: every other path that queues onto
+      // the adapter checks the pointer under it, and must not find one that is
+      // half set up (setupProcessing clears the event queue as it goes).
+      ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
+      if (!_processAdapter) _processAdapter = std::make_unique<Clap::AUv2::ProcessAdapter>();
+      _processAdapter->setupProcessing(Inputs(), Outputs(), _plugin->_plugin, _plugin->_ext._params,
+                                       this, &_parametertree, this, maxSampleFrames,
+                                       _midi_preferred_dialect, _midi_supported_dialects,
+                                       clapAudioInputs, clapAudioOutputs);
+      // The deactivated-state flush adapter has no further use, and the gestures
+      // it was tracking belong to the real one now.
+      _flushAdapter.reset();
+    }
 
     _plugin->activate();
     _plugin->start_processing();
@@ -1278,8 +1300,13 @@ void WrapAsAUV2::deactivateCLAP()
 {
   if (_plugin)
   {
-    _initialized = false;
-    _processAdapter.reset();
+    {
+      // Under the lock: SetParameter and the MIDI entry points test this
+      // pointer and then use it, and the idle tick may be inside a flush on it.
+      ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
+      _initialized = false;
+      _processAdapter.reset();
+    }
     _plugin->stop_processing();
     _plugin->deactivate();
   }
@@ -1614,25 +1641,24 @@ void WrapAsAUV2::onIdle()
   // here is only whether a render is going to do the job first.
   //
   // One empty tick is not proof the host has stopped, and guessing wrong costs
-  // something: at a large block size renders are simply rarer than the 10ms idle
-  // (2048 samples is 43ms), and the host schedules automation through
-  // SetParameter with a buffer offset, so a flush that beat the next render to
-  // the queue would deliver those values stripped of their offsets. A few
-  // consecutive empty ticks settle the question at no cost; once the host really
-  // has stopped, the counter stays saturated and a request is served on the very
-  // next tick.
-  static constexpr uint32_t idleTicksBeforeFlush = 5;
-
+  // something: the host schedules automation through SetParameter with a buffer
+  // offset, so a flush that beat the next render to the queue would deliver
+  // those values stripped of their offsets. How long to wait cannot be a
+  // constant either - at 4096 frames and 44.1kHz a block is 93ms, so a host
+  // rendering perfectly normally leaves gaps longer than any small number of
+  // 10ms ticks. activateCLAP() sizes the wait at three blocks, which no
+  // rendering host produces; once one really has stopped, the counter stays
+  // saturated and a request is served on the very next tick.
   if (_renderedSinceIdle.exchange(false))
   {
     _idleTicksSinceRender = 0;
   }
-  else if (_idleTicksSinceRender < idleTicksBeforeFlush)
+  else if (_idleTicksSinceRender < _idleTicksBeforeFlush)
   {
     ++_idleTicksSinceRender;
   }
 
-  if (_requestedFlush && _idleTicksSinceRender >= idleTicksBeforeFlush)
+  if (_requestedFlush && _idleTicksSinceRender >= _idleTicksBeforeFlush)
   {
     // Fences against Render() and against SetParameter, the queue's other
     // writer. While the plugin is active clap_plugin_params.flush() is
@@ -1672,13 +1698,21 @@ void WrapAsAUV2::flushParameters()
 {
   if (!_plugin || !_plugin->_ext._params) return;
 
-  // The VST3 wrapper builds the same throwaway for its own flush. No audio is
-  // involved -- a zero numMaxSamples skips the silent-stream buffers, and the
-  // plugin is handed no audio ports.
-  Clap::AUv2::ProcessAdapter pa;
-  pa.setupProcessing(Inputs(), Outputs(), _plugin->_plugin, _plugin->_ext._params, this, &_parametertree,
-                     this, 0, _midi_preferred_dialect, _midi_supported_dialects, 0, 0);
-  pa.flush();
+  // Kept between flushes rather than built per call, the way the VST3 wrapper
+  // builds its throwaway: a gesture the plugin opens in one deactivated flush
+  // and closes in the next has to find the same adapter, because that is where
+  // the open was recorded -- a close arriving at a fresh one is dropped, and
+  // the host stays armed on the parameter. activateCLAP() releases it.
+  // No audio is involved: a zero numMaxSamples skips the silent-stream buffers,
+  // and the plugin is handed no audio ports.
+  if (!_flushAdapter)
+  {
+    _flushAdapter = std::make_unique<Clap::AUv2::ProcessAdapter>();
+    _flushAdapter->setupProcessing(Inputs(), Outputs(), _plugin->_plugin, _plugin->_ext._params, this,
+                                   &_parametertree, this, 0, _midi_preferred_dialect,
+                                   _midi_supported_dialects, 0, 0);
+  }
+  _flushAdapter->flush();
 }
 
 OSStatus WrapAsAUV2::SaveState(CFPropertyListRef *ptPList)

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1742,6 +1742,23 @@ bool WrapAsAUV2::ValidFormat(AudioUnitScope inScope, AudioUnitElement inElement,
   // (applyConfigurationFromBusFormats), before it activates.
   if (cache[inElement].isMain)
   {
+    // An alternate layout is accepted here on the promise that activateCLAP()
+    // pushes it into the plugin before anything renders, and CLAP only allows
+    // ports to be reconfigured while the plugin is deactivated. So once the AU
+    // is initialized that promise cannot be kept: the only channel count still
+    // valid is the one the ports actually have, which the equality above
+    // already let through. A host wanting another layout has to uninitialize
+    // first, which is the AU convention regardless.
+    //
+    // Accepting one anyway would be worse than refusing it. The AU element
+    // would report a channel count the active plugin's port does not have, and
+    // the process adapter - whose per-port pointer arrays were sized at
+    // setupProcessing - would write past them on the next render. It is also
+    // what auval tests: from an initialized 2/2 it sets the output to 1 and the
+    // input to 3, and expects both to be turned away rather than to leave the
+    // unit in a pair the plugin never advertised.
+    if (IsInitialized()) return false;
+
     const bool isInput = (inScope == kAudioUnitScope_Input);
     for (const auto &caps : _channelCapsCache)
     {

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1107,12 +1107,118 @@ void WrapAsAUV2::addOutputBus(int bus, const clap_audio_port_info_t *info)
   busref.SetStreamFormat(sf);
 }
 
+std::vector<clap_audio_port_configuration_request_t> WrapAsAUV2::mainBusConfigurationRequests(
+    uint32_t mainInChannels, uint32_t mainOutChannels) const
+{
+  // One request per port, mirroring the VST3 wrapper's setBusArrangements
+  // (wrapasvst3.cpp): main ports get the given counts, non-main ports keep
+  // their current ones.
+  std::vector<clap_audio_port_configuration_request_t> requests;
+  auto addRequest = [&requests](bool isInput, uint32_t port, uint32_t channels)
+  {
+    clap_audio_port_configuration_request_t request{};
+    request.is_input = isInput;
+    request.port_index = port;
+    request.channel_count = channels;
+    request.port_type =
+        (channels == 1) ? CLAP_PORT_MONO : ((channels == 2) ? CLAP_PORT_STEREO : nullptr);
+    request.port_details = nullptr;
+    requests.push_back(request);
+  };
+
+  for (size_t i = 0; i < _inputPortCache.size(); ++i)
+    addRequest(true, static_cast<uint32_t>(i),
+               _inputPortCache[i].isMain ? mainInChannels : _inputPortCache[i].channelCount);
+  for (size_t i = 0; i < _outputPortCache.size(); ++i)
+    addRequest(false, static_cast<uint32_t>(i),
+               _outputPortCache[i].isMain ? mainOutChannels : _outputPortCache[i].channelCount);
+
+  return requests;
+}
+
+void WrapAsAUV2::applyConfigurationFromBusFormats()
+{
+  // Nothing to reconcile unless the PostConstructor probe found alternate
+  // layouts: without them ValidFormat pinned every bus to its port's count.
+  if (_channelCapsCache.empty() || !_plugin->_ext._audioports ||
+      !_plugin->_ext._configurable_audio_ports)
+    return;
+
+  // The channel counts the host settled on for the main busses. AU elements
+  // map 1:1 to the CLAP ports scanned at PostConstructor.
+  bool mismatch = false;
+  uint32_t mainInChannels = 0, mainOutChannels = 0;
+
+  for (size_t i = 0; i < _inputPortCache.size(); ++i)
+  {
+    if (!_inputPortCache[i].isMain) continue;
+    mainInChannels = Input(static_cast<AudioUnitElement>(i)).GetStreamFormat().mChannelsPerFrame;
+    mismatch |= (mainInChannels != _inputPortCache[i].channelCount);
+    break;
+  }
+  for (size_t i = 0; i < _outputPortCache.size(); ++i)
+  {
+    if (!_outputPortCache[i].isMain) continue;
+    mainOutChannels = Output(static_cast<AudioUnitElement>(i)).GetStreamFormat().mChannelsPerFrame;
+    mismatch |= (mainOutChannels != _outputPortCache[i].channelCount);
+    break;
+  }
+
+  if (!mismatch) return;
+
+  auto requests = mainBusConfigurationRequests(mainInChannels, mainOutChannels);
+  const bool applied = _plugin->_ext._configurable_audio_ports->apply_configuration(
+      _plugin->_plugin, requests.data(), static_cast<uint32_t>(requests.size()));
+
+  if (!applied)
+  {
+    LOGINFO("[clap-wrapper] could not apply an audio port configuration for {}/{} channels",
+            mainInChannels, mainOutChannels);
+    return;
+  }
+
+  // The port layout changed: refresh the snapshots and the bus names/formats
+  // from the rescanned ports (element counts are unchanged — the configs
+  // describe main-port layouts). The plugin is still deactivated here, so the
+  // scan is legal.
+  auto ap = _plugin->_ext._audioports;
+  auto pl = _plugin->_plugin;
+
+  _inputPortCache.clear();
+  const auto numAudioInputs = ap->count(pl, true);
+  for (uint32_t i = 0; i < numAudioInputs; ++i)
+  {
+    clap_audio_port_info inf;
+    ap->get(pl, i, true, &inf);
+    _inputPortCache.push_back({inf.channel_count, (inf.flags & CLAP_AUDIO_PORT_IS_MAIN) != 0});
+    addInputBus(static_cast<int>(i), &inf);
+  }
+
+  _outputPortCache.clear();
+  const auto numAudioOutputs = ap->count(pl, false);
+  for (uint32_t i = 0; i < numAudioOutputs; ++i)
+  {
+    clap_audio_port_info inf;
+    ap->get(pl, i, false, &inf);
+    _outputPortCache.push_back({inf.channel_count, (inf.flags & CLAP_AUDIO_PORT_IS_MAIN) != 0});
+    addOutputBus(static_cast<int>(i), &inf);
+  }
+
+  LOGINFO("[clap-wrapper] applied audio port configuration for {}/{} channels", mainInChannels,
+          mainOutChannels);
+}
+
 void WrapAsAUV2::activateCLAP()
 {
   if (_plugin)
   {
     assert(!_initialized);
     if (!_processAdapter) _processAdapter = std::make_unique<Clap::AUv2::ProcessAdapter>();
+
+    // Reconcile the host-chosen bus formats with the plugin's port layout
+    // before anything reads the ports: main thread, plugin deactivated.
+    applyConfigurationFromBusFormats();
+
     auto maxSampleFrames = Base::GetMaxFramesPerSlice();
     auto minSampleFrames = (maxSampleFrames >= 16) ? 16 : 1;
     _plugin->setBlockSizes(minSampleFrames, maxSampleFrames);
@@ -1595,7 +1701,24 @@ bool WrapAsAUV2::ValidFormat(AudioUnitScope inScope, AudioUnitElement inElement,
     }
     return true;
   }
-  return inNewFormat.mChannelsPerFrame == cache[inElement].channelCount;
+
+  if (inNewFormat.mChannelsPerFrame == cache[inElement].channelCount) return true;
+
+  // A main bus additionally accepts any channel count that one of the probed
+  // configurable-audio-ports layouts offers on this scope — still validated
+  // against the PostConstructor snapshots, never a live port scan. The
+  // matching configuration is pushed into the plugin in activateCLAP
+  // (applyConfigurationFromBusFormats), before it activates.
+  if (cache[inElement].isMain)
+  {
+    const bool isInput = (inScope == kAudioUnitScope_Input);
+    for (const auto &caps : _channelCapsCache)
+    {
+      const uint32_t channels = isInput ? caps.inputChannels : caps.outputChannels;
+      if (channels != 0 && channels == inNewFormat.mChannelsPerFrame) return true;
+    }
+  }
+  return false;
 }
 
 OSStatus WrapAsAUV2::ChangeStreamFormat(AudioUnitScope inScope, AudioUnitElement inElement,
@@ -1612,7 +1735,19 @@ UInt32 WrapAsAUV2::SupportedNumChannels(const AUChannelInfo **outInfo)
 {
   // Built from the PostConstructor snapshot rather than a live port scan (see
   // ValidFormat) so this is safe to call while the plugin is active.
-  if (cinfo.empty() && isEffectFacade())
+  if (cinfo.empty() && !_channelCapsCache.empty())
+  {
+    // The PostConstructor probe found the plugin's accepted main-bus layouts
+    // through clap.configurable-audio-ports: advertise exactly those (the
+    // matching one is applied in activateCLAP once the host settles on it).
+    for (const auto &caps : _channelCapsCache)
+    {
+      cinfo.emplace_back();
+      cinfo.back().inChannels = static_cast<SInt16>(caps.inputChannels);
+      cinfo.back().outChannels = static_cast<SInt16>(caps.outputChannels);
+    }
+  }
+  else if (cinfo.empty() && isEffectFacade())
   {
     // No CLAP audio ports at all: advertise the fixed stereo in/out layout of the
     // placeholder busses so auval / hosts treat this as a plain stereo unit.
@@ -1709,6 +1844,52 @@ void WrapAsAUV2::PostConstructor()
       */
     }
     LOGINFO("[clap-wrapper] PostConstructor: Ins={} Outs={}", numAudioInputs, numAudioOutputs);
+  }
+
+  // Probe the plugin's alternate main-bus layouts through
+  // clap.configurable-audio-ports — the wrapper's only source of alternate
+  // layouts, mirroring the VST3 wrapper's setBusArrangements. The plugin is
+  // deactivated here, which is the state can_apply_configuration requires;
+  // like the port scan above, the result is snapshotted and never queried
+  // live afterwards. Every accepted pair is advertised through
+  // SupportedNumChannels, accepted by ValidFormat, and applied in
+  // activateCLAP once the host has settled on formats.
+  if (_plugin->_ext._configurable_audio_ports && (!_inputPortCache.empty() || !_outputPortCache.empty()))
+  {
+    uint32_t currentIn = 0, currentOut = 0;
+    for (const auto &port : _inputPortCache)
+      if (port.isMain)
+      {
+        currentIn = port.channelCount;
+        break;
+      }
+    for (const auto &port : _outputPortCache)
+      if (port.isMain)
+      {
+        currentOut = port.channelCount;
+        break;
+      }
+
+    // A scope without a main port contributes the fixed count 0.
+    const uint32_t minIn = currentIn ? 1 : 0, maxIn = currentIn ? kMaxProbedChannels : 0;
+    const uint32_t minOut = currentOut ? 1 : 0, maxOut = currentOut ? kMaxProbedChannels : 0;
+
+    for (uint32_t in = minIn; in <= maxIn; ++in)
+    {
+      for (uint32_t out = minOut; out <= maxOut; ++out)
+      {
+        bool accepted = (in == currentIn && out == currentOut);  // current layout is a given
+        if (!accepted)
+        {
+          auto requests = mainBusConfigurationRequests(in, out);
+          accepted = _plugin->_ext._configurable_audio_ports->can_apply_configuration(
+              _plugin->_plugin, requests.data(), static_cast<uint32_t>(requests.size()));
+        }
+        if (accepted) _channelCapsCache.push_back({in, out});
+      }
+    }
+    LOGINFO("[clap-wrapper] PostConstructor: {} probed main-bus channel layouts",
+            _channelCapsCache.size());
   }
 
   // A plugin can legitimately declare no audio output ports (a note effect such

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -586,17 +586,24 @@ OSStatus WrapAsAUV2::SetParameter(AudioUnitParameterID inID, AudioUnitScope inSc
 {
   if (inScope == kAudioUnitScope_Global)
   {
-    if (_processAdapter)
+    auto p = _parametertree.find(inID);
+    if (p != _parametertree.end())
     {
-      // a parameter has been set.
-      // _processAdapter->addParameterEvent(inID,inValue,inBufferOffsetInFrames);
-      auto p = _parametertree.find(inID);
-      if (p != _parametertree.end())
+      // Fenced against onIdle(), the other consumer of the adapter's event
+      // queue. Render() holding the lock is not enough on its own: AUBase calls
+      // this from ScheduleParameter(), i.e. on the render thread but outside the
+      // render, so without this the queue would have two writers.
+      ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
+      if (_processAdapter)
       {
         auto &param = p->second.get()->info();
         _processAdapter->addParameterEvent(param, inValue, inBufferOffsetInFrames);
       }
     }
+
+    // Nothing may ever render this: on an idle track process() is not coming,
+    // and then onIdle() is the only thing that will hand it to the plugin.
+    _requestedFlush = true;
   }
   return AUBase::SetParameter(inID, inScope, inElement, inValue, inBufferOffsetInFrames);
 }
@@ -1339,6 +1346,10 @@ OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags &inFlags, const AudioTime
 
     _processAdapter->process(data);
 
+    // This render carried whatever was queued in either direction, so the next
+    // idle tick has nothing to make up for. See onIdle().
+    _renderedSinceIdle = true;
+
     {
       for (auto &i : _midi_outports)
       {
@@ -1434,10 +1445,8 @@ void WrapAsAUV2::onEndEdit(clap_id id)
 #endif
 }
 
-void WrapAsAUV2::onIdle()
+void WrapAsAUV2::pushQueuedEventsToHost()
 {
-  if (!_plugin) return;
-  // run queue stuff
   queueEvent e;
   while (this->_queueToUI.pop(e))
   {
@@ -1500,6 +1509,13 @@ void WrapAsAUV2::onIdle()
       break;
     }
   }
+}
+
+void WrapAsAUV2::onIdle()
+{
+  if (!_plugin) return;
+
+  pushQueuedEventsToHost();
 
   if (_requestMarkDirty.exchange(false))
   {
@@ -1571,45 +1587,94 @@ void WrapAsAUV2::onIdle()
     {
       activateCLAP();
     }
-    else if (!_initialized)
-    {
-      // Nothing to wake, and nothing is going to render. clap/ext/params.h
-      // names request_flush() and request_process() as the two ways to get a
-      // GUI-side parameter change into the processor, so deliver the one of
-      // the two the AU can actually deliver -- otherwise a plugin that picked
-      // request_process() (as it may) gets no path in at all.
-      ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
-      if (!_initialized) flushParameters();
-    }
-    // else: active and processing, the host is already pulling us.
+
+    // Whatever parameter traffic the request was really about is the flush
+    // below's problem, in either direction: ask for one.
+    _requestedFlush = true;
   }
 
-  if (_requestedFlush.exchange(false) && _plugin)
+  // The parameter flush.
+  //
+  // In CLAP a plugin can only push an output event -- a value its own editor
+  // changed, the gesture around it -- from inside process() or flush(), and the
+  // host's own parameter sets only reach the plugin the same way (SetParameter
+  // queues them on the process adapter). Both directions therefore stop dead
+  // whenever the host stops rendering, and AU hosts do stop: Logic will not run
+  // a track it knows carries no signal, and an initialized unit can sit there
+  // for minutes without a single Render() call. The VST3 SDK's AU wrapper and
+  // JUCE's never meet this because neither routes automation through the audio
+  // cycle at all -- they call AUParameterSet/AUEventListenerNotify straight from
+  // the editor callback. A CLAP has no equivalent to call, so the wrapper has to
+  // do the pulling.
+  //
+  // _requestedFlush says there is something to pull. The plugin sets it through
+  // param_request_flush(), which it may call at any moment and in any state --
+  // it is not a statement about processing, just "I have parameter events" --
+  // and SetParameter sets it for the other direction. What is left to decide
+  // here is only whether a render is going to do the job first.
+  //
+  // One empty tick is not proof the host has stopped, and guessing wrong costs
+  // something: at a large block size renders are simply rarer than the 10ms idle
+  // (2048 samples is 43ms), and the host schedules automation through
+  // SetParameter with a buffer offset, so a flush that beat the next render to
+  // the queue would deliver those values stripped of their offsets. A few
+  // consecutive empty ticks settle the question at no cost; once the host really
+  // has stopped, the counter stays saturated and a request is served on the very
+  // next tick.
+  static constexpr uint32_t idleTicksBeforeFlush = 5;
+
+  if (_renderedSinceIdle.exchange(false))
   {
-    auto guarantee_mainthread = _plugin->AlwaysMainThread();
-
-    // The lock is what makes this safe to do from the idle thread: a render
-    // that started before _initialized went false may still be inside the
-    // process adapter pushing output events into _queueToUI, and that queue
-    // has one producer.
-    ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
-    if (!_initialized) flushParameters();
+    _idleTicksSinceRender = 0;
   }
+  else if (_idleTicksSinceRender < idleTicksBeforeFlush)
+  {
+    ++_idleTicksSinceRender;
+  }
+
+  if (_requestedFlush && _idleTicksSinceRender >= idleTicksBeforeFlush)
+  {
+    // Fences against Render() and against SetParameter, the queue's other
+    // writer. While the plugin is active clap_plugin_params.flush() is
+    // [audio-thread]; the lock is what makes the idle thread stand in for it.
+    // It also keeps the single producer _queueToUI expects, since the output
+    // events this flush pulls out go down the same path a render's would.
+    ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
+
+    // Cleared before the work, not after: a request that arrives while the
+    // plugin is inside flush() is about events this flush cannot have seen, and
+    // has to survive into the next tick.
+    _requestedFlush = false;
+
+    if (_initialized && _processAdapter)
+    {
+      auto guarantee_audiothread = _plugin->AlwaysAudioThread();
+      _processAdapter->flush();
+    }
+    else
+    {
+      // Deactivated: the real adapter does not exist, and flush() is
+      // [main-thread] here.
+      auto guarantee_mainthread = _plugin->AlwaysMainThread();
+      flushParameters();
+    }
+  }
+
+  // Announce anything the flush just produced in this tick rather than the next.
+  pushQueuedEventsToHost();
 }
 
-// Only legal while the CLAP is deactivated: clap_plugin_params.flush() is
-// [main-thread] when the plugin is inactive and [audio-thread] when it is
-// active, and while it is active process() carries the events anyway. Callers
-// check _initialized under _processLock.
+// Builds a throwaway process adapter to flush against, for the deactivated case
+// only: the real one lives between activateCLAP() and deactivateCLAP(), and
+// clap_plugin_params.flush() is [main-thread] exactly while the plugin is
+// inactive. Callers check _initialized under _processLock.
 void WrapAsAUV2::flushParameters()
 {
   if (!_plugin || !_plugin->_ext._params) return;
 
-  // A throwaway adapter, like the VST3 wrapper builds for its own flush: the
-  // real one only exists between activateCLAP() and deactivateCLAP(), and this
-  // path runs precisely when it does not. No audio is involved -- a zero
-  // numMaxSamples skips the silent-stream buffers, and the plugin is handed no
-  // audio ports.
+  // The VST3 wrapper builds the same throwaway for its own flush. No audio is
+  // involved -- a zero numMaxSamples skips the silent-stream buffers, and the
+  // plugin is handed no audio ports.
   Clap::AUv2::ProcessAdapter pa;
   pa.setupProcessing(Inputs(), Outputs(), _plugin->_plugin, _plugin->_ext._params, this, &_parametertree,
                      this, 0, _midi_preferred_dialect, _midi_supported_dialects, 0, 0);

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1551,6 +1551,69 @@ void WrapAsAUV2::onIdle()
       }
     }
   }
+
+  // After the restart branch on purpose: a restart asked for in the same tick
+  // ends with the plugin activated and processing, which is what a wake would
+  // have been asking for anyway.
+  if (_requestProcess.exchange(false) && _plugin)
+  {
+    auto guarantee_mainthread = _plugin->AlwaysMainThread();
+
+    // AU offers a plugin nothing like this: there is no way to make the host
+    // start pulling Render(). What the wrapper does own is the CLAP's own
+    // activate/start_processing pair, which it drives from AU Initialize() --
+    // so if the AU is initialized and the CLAP is not running underneath it,
+    // stand it back up. No lock is needed to decide that: activateCLAP()
+    // publishes _initialized last, and a render that reads it false returns
+    // without touching the plugin, exactly as it does before the AU is
+    // initialized at all.
+    if (IsInitialized() && !_initialized)
+    {
+      activateCLAP();
+    }
+    else if (!_initialized)
+    {
+      // Nothing to wake, and nothing is going to render. clap/ext/params.h
+      // names request_flush() and request_process() as the two ways to get a
+      // GUI-side parameter change into the processor, so deliver the one of
+      // the two the AU can actually deliver -- otherwise a plugin that picked
+      // request_process() (as it may) gets no path in at all.
+      ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
+      if (!_initialized) flushParameters();
+    }
+    // else: active and processing, the host is already pulling us.
+  }
+
+  if (_requestedFlush.exchange(false) && _plugin)
+  {
+    auto guarantee_mainthread = _plugin->AlwaysMainThread();
+
+    // The lock is what makes this safe to do from the idle thread: a render
+    // that started before _initialized went false may still be inside the
+    // process adapter pushing output events into _queueToUI, and that queue
+    // has one producer.
+    ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
+    if (!_initialized) flushParameters();
+  }
+}
+
+// Only legal while the CLAP is deactivated: clap_plugin_params.flush() is
+// [main-thread] when the plugin is inactive and [audio-thread] when it is
+// active, and while it is active process() carries the events anyway. Callers
+// check _initialized under _processLock.
+void WrapAsAUV2::flushParameters()
+{
+  if (!_plugin || !_plugin->_ext._params) return;
+
+  // A throwaway adapter, like the VST3 wrapper builds for its own flush: the
+  // real one only exists between activateCLAP() and deactivateCLAP(), and this
+  // path runs precisely when it does not. No audio is involved -- a zero
+  // numMaxSamples skips the silent-stream buffers, and the plugin is handed no
+  // audio ports.
+  Clap::AUv2::ProcessAdapter pa;
+  pa.setupProcessing(Inputs(), Outputs(), _plugin->_plugin, _plugin->_ext._params, this, &_parametertree,
+                     this, 0, _midi_preferred_dialect, _midi_supported_dialects, 0, 0);
+  pa.flush();
 }
 
 OSStatus WrapAsAUV2::SaveState(CFPropertyListRef *ptPList)

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -204,7 +204,13 @@ OSStatus WrapAsAUV2::Initialize()
   // CLAP does not want it, therefore the wrapper insists on being in the
   // main thread
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
-  activateCLAP();
+  if (!activateCLAP())
+  {
+    // The host settled on a main-bus format pair the plugin does not accept
+    // (see activateCLAP). Refuse the initialization rather than render with
+    // buffers sized differently from the plugin's ports.
+    return kAudioUnitErr_FormatNotSupported;
+  }
 
 #if 0
   // get our current numChannels for input and output
@@ -1136,27 +1142,33 @@ std::vector<clap_audio_port_configuration_request_t> WrapAsAUV2::mainBusConfigur
   return requests;
 }
 
-void WrapAsAUV2::applyConfigurationFromBusFormats()
+bool WrapAsAUV2::applyConfigurationFromBusFormats()
 {
   // Nothing to reconcile unless the PostConstructor probe found alternate
   // layouts: without them ValidFormat pinned every bus to its port's count.
   if (_channelCapsCache.empty() || !_plugin->_ext._audioports ||
       !_plugin->_ext._configurable_audio_ports)
-    return;
+    return true;
 
   // The channel counts the host settled on for the main busses. AU elements
-  // map 1:1 to the CLAP ports scanned at PostConstructor.
+  // map 1:1 to the CLAP ports scanned at PostConstructor, but a plugin that
+  // changes its port *count* in apply_configuration can leave the caches
+  // longer than the element scopes, and ausdk's Input()/Output() throw on an
+  // element that does not exist - so never look past the element counts.
   bool mismatch = false;
   uint32_t mainInChannels = 0, mainOutChannels = 0;
 
-  for (size_t i = 0; i < _inputPortCache.size(); ++i)
+  const size_t numInputElements = Inputs().GetNumberOfElements();
+  const size_t numOutputElements = Outputs().GetNumberOfElements();
+
+  for (size_t i = 0; i < _inputPortCache.size() && i < numInputElements; ++i)
   {
     if (!_inputPortCache[i].isMain) continue;
     mainInChannels = Input(static_cast<AudioUnitElement>(i)).GetStreamFormat().mChannelsPerFrame;
     mismatch |= (mainInChannels != _inputPortCache[i].channelCount);
     break;
   }
-  for (size_t i = 0; i < _outputPortCache.size(); ++i)
+  for (size_t i = 0; i < _outputPortCache.size() && i < numOutputElements; ++i)
   {
     if (!_outputPortCache[i].isMain) continue;
     mainOutChannels = Output(static_cast<AudioUnitElement>(i)).GetStreamFormat().mChannelsPerFrame;
@@ -1164,7 +1176,7 @@ void WrapAsAUV2::applyConfigurationFromBusFormats()
     break;
   }
 
-  if (!mismatch) return;
+  if (!mismatch) return true;
 
   auto requests = mainBusConfigurationRequests(mainInChannels, mainOutChannels);
   const bool applied = _plugin->_ext._configurable_audio_ports->apply_configuration(
@@ -1174,13 +1186,14 @@ void WrapAsAUV2::applyConfigurationFromBusFormats()
   {
     LOGINFO("[clap-wrapper] could not apply an audio port configuration for {}/{} channels",
             mainInChannels, mainOutChannels);
-    return;
+    return false;
   }
 
   // The port layout changed: refresh the snapshots and the bus names/formats
-  // from the rescanned ports (element counts are unchanged — the configs
-  // describe main-port layouts). The plugin is still deactivated here, so the
-  // scan is legal.
+  // from the rescanned ports. The plugin is still deactivated here, so the
+  // scan is legal. Ports past the AU element counts (frozen at
+  // PostConstructor) are cached but get no bus; the process adapter clamps
+  // to the element counts the same way.
   auto ap = _plugin->_ext._audioports;
   auto pl = _plugin->_plugin;
 
@@ -1191,7 +1204,7 @@ void WrapAsAUV2::applyConfigurationFromBusFormats()
     clap_audio_port_info inf;
     ap->get(pl, i, true, &inf);
     _inputPortCache.push_back({inf.channel_count, (inf.flags & CLAP_AUDIO_PORT_IS_MAIN) != 0});
-    addInputBus(static_cast<int>(i), &inf);
+    if (i < numInputElements) addInputBus(static_cast<int>(i), &inf);
   }
 
   _outputPortCache.clear();
@@ -1201,14 +1214,15 @@ void WrapAsAUV2::applyConfigurationFromBusFormats()
     clap_audio_port_info inf;
     ap->get(pl, i, false, &inf);
     _outputPortCache.push_back({inf.channel_count, (inf.flags & CLAP_AUDIO_PORT_IS_MAIN) != 0});
-    addOutputBus(static_cast<int>(i), &inf);
+    if (i < numOutputElements) addOutputBus(static_cast<int>(i), &inf);
   }
 
   LOGINFO("[clap-wrapper] applied audio port configuration for {}/{} channels", mainInChannels,
           mainOutChannels);
+  return true;
 }
 
-void WrapAsAUV2::activateCLAP()
+bool WrapAsAUV2::activateCLAP()
 {
   if (_plugin)
   {
@@ -1216,8 +1230,17 @@ void WrapAsAUV2::activateCLAP()
     if (!_processAdapter) _processAdapter = std::make_unique<Clap::AUv2::ProcessAdapter>();
 
     // Reconcile the host-chosen bus formats with the plugin's port layout
-    // before anything reads the ports: main thread, plugin deactivated.
-    applyConfigurationFromBusFormats();
+    // before anything reads the ports: main thread, plugin deactivated. A
+    // failure here must fail the activation: ValidFormat can only vet each
+    // scope on its own (AU hosts set formats one SetProperty at a time), so
+    // the host can legally land on an input/output *pair* the plugin
+    // rejects - and activating anyway would size the AU render buffers
+    // differently from the plugin's ports, which is a heap overrun in the
+    // render path.
+    if (!applyConfigurationFromBusFormats())
+    {
+      return false;
+    }
 
     auto maxSampleFrames = Base::GetMaxFramesPerSlice();
     auto minSampleFrames = (maxSampleFrames >= 16) ? 16 : 1;
@@ -1241,6 +1264,7 @@ void WrapAsAUV2::activateCLAP()
     _plugin->start_processing();
     _initialized = true;
   }
+  return true;
 }
 
 void WrapAsAUV2::deactivateCLAP()
@@ -1517,7 +1541,14 @@ void WrapAsAUV2::onIdle()
     if (wasInitialized)
     {
       deactivateCLAP();
-      activateCLAP();
+      // Cannot fail for the format-pair reason Initialize guards against:
+      // the formats have not changed since the last successful activation.
+      // If it fails anyway, _initialized stays false and renders return
+      // silence, the same state as before Initialize.
+      if (!activateCLAP())
+      {
+        LOGINFO("[clap-wrapper] restart: could not reactivate the plugin");
+      }
     }
   }
 }
@@ -1854,42 +1885,71 @@ void WrapAsAUV2::PostConstructor()
   // live afterwards. Every accepted pair is advertised through
   // SupportedNumChannels, accepted by ValidFormat, and applied in
   // activateCLAP once the host has settled on formats.
-  if (_plugin->_ext._configurable_audio_ports && (!_inputPortCache.empty() || !_outputPortCache.empty()))
+  // Gated on having output ports like the port-derived cross-product in
+  // SupportedNumChannels: an input-only plugin renders through the
+  // placeholder output element, and a probed pair would contradict that by
+  // advertising 0 output channels.
+  if (_plugin->_ext._configurable_audio_ports && !_outputPortCache.empty())
   {
+    bool hasMainIn = false, hasMainOut = false;
     uint32_t currentIn = 0, currentOut = 0;
     for (const auto &port : _inputPortCache)
       if (port.isMain)
       {
+        hasMainIn = true;
         currentIn = port.channelCount;
         break;
       }
     for (const auto &port : _outputPortCache)
       if (port.isMain)
       {
+        hasMainOut = true;
         currentOut = port.channelCount;
         break;
       }
 
-    // A scope without a main port contributes the fixed count 0.
-    const uint32_t minIn = currentIn ? 1 : 0, maxIn = currentIn ? kMaxProbedChannels : 0;
-    const uint32_t minOut = currentOut ? 1 : 0, maxOut = currentOut ? kMaxProbedChannels : 0;
-
-    for (uint32_t in = minIn; in <= maxIn; ++in)
+    // The probe varies only the main ports, and an AUChannelInfo pair can
+    // only describe the main busses. A scope that has ports but none marked
+    // main - a sidechain-only input, or a plugin that never sets
+    // CLAP_AUDIO_PORT_IS_MAIN at all - can be neither varied nor described:
+    // a probed pair would advertise 0 channels for a scope that does take
+    // audio. Leave the cache empty in that case, which keeps the pre-probe
+    // behaviour: SupportedNumChannels falls back to the port-derived
+    // cross-product and ValidFormat pins every bus to its port's count.
+    if ((_inputPortCache.empty() || hasMainIn) && (_outputPortCache.empty() || hasMainOut))
     {
-      for (uint32_t out = minOut; out <= maxOut; ++out)
+      // The active layout is advertised unconditionally, whatever its
+      // width: the grid below only *adds* alternates, so kMaxProbedChannels
+      // never hides the plugin's own configuration (a 16-channel main
+      // output stays advertised even though the grid stops at 8).
+      _channelCapsCache.push_back({currentIn, currentOut});
+
+      // A scope without any ports contributes the fixed count 0.
+      const uint32_t minIn = currentIn ? 1 : 0, maxIn = currentIn ? kMaxProbedChannels : 0;
+      const uint32_t minOut = currentOut ? 1 : 0, maxOut = currentOut ? kMaxProbedChannels : 0;
+
+      for (uint32_t in = minIn; in <= maxIn; ++in)
       {
-        bool accepted = (in == currentIn && out == currentOut);  // current layout is a given
-        if (!accepted)
+        for (uint32_t out = minOut; out <= maxOut; ++out)
         {
+          if (in == currentIn && out == currentOut) continue;  // seeded above
           auto requests = mainBusConfigurationRequests(in, out);
-          accepted = _plugin->_ext._configurable_audio_ports->can_apply_configuration(
-              _plugin->_plugin, requests.data(), static_cast<uint32_t>(requests.size()));
+          if (_plugin->_ext._configurable_audio_ports->can_apply_configuration(
+                  _plugin->_plugin, requests.data(), static_cast<uint32_t>(requests.size())))
+          {
+            _channelCapsCache.push_back({in, out});
+          }
         }
-        if (accepted) _channelCapsCache.push_back({in, out});
       }
+      LOGINFO("[clap-wrapper] PostConstructor: {} probed main-bus channel layouts",
+              _channelCapsCache.size());
     }
-    LOGINFO("[clap-wrapper] PostConstructor: {} probed main-bus channel layouts",
-            _channelCapsCache.size());
+    else
+    {
+      LOGINFO(
+          "[clap-wrapper] PostConstructor: not probing channel layouts, a scope has ports but no "
+          "main port");
+    }
   }
 
   // A plugin can legitimately declare no audio output ports (a note effect such

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -1351,6 +1351,15 @@ void ClapAsVst3::mark_dirty()
   if (componentHandler2) componentHandler2->setDirty(true);
 }
 
+void ClapAsVst3::request_process()
+{
+  // Nothing VST3 can do with this. IComponentHandler has no "start pulling me"
+  // and the host alone decides when process() runs, so there is no honest
+  // wake here -- and no flush fallback either: onIdle() only runs while the
+  // component is active (os::attach lives in setActive), and while it is
+  // active the parameter flush belongs to the audio thread.
+}
+
 void ClapAsVst3::request_callback()
 {
   _requestUICallback = true;

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -336,6 +336,8 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   void restartPlugin() override;
 
+  void request_process() override;
+
   void request_callback() override;
 
   bool track_info_get(clap_track_info_t *info) override;

--- a/tests/clap-first-example/distortion_clap.cpp
+++ b/tests/clap-first-example/distortion_clap.cpp
@@ -343,6 +343,11 @@ bool clap1stDist_state_load(const clap_plugin_t *plugin, const clap_istream_t *s
     p->rescan(clapHost, CLAP_PARAM_RESCAN_TEXT);
     p->request_flush(clapHost);
   }
+  // clap/ext/params.h names request_flush() and clap_host.request_process() as
+  // the two ways to get the values just loaded into the processor. Ask for both,
+  // so a wrapper that only implements one of them still gets them - and so the
+  // request_process() path is exercised by the wrappers' own test runs.
+  clapHost->request_process(clapHost);
   return true;
 }
 static const clap_plugin_state_t s_clap1stDist_state = {clap1stDist_state_save, clap1stDist_state_load};


### PR DESCRIPTION
> **Stacked on #530** — rebased onto that branch so the two do not conflict in `activateCLAP()`. The first three commits here are #530's; review from `AUv2: implement host request_process()` onward. Once #530 lands this diff collapses to its own three commits.

Two related holes in the AUv2 wrapper: `clap_host.request_process()` never reached the backends at all, and — the one that actually bites — nothing but `process()` ever drained the plugin's event queue, in either direction.

## `request_process()`

`Plugin::clapRequestProcess` was an empty stub that never reached `IHost`, and `IHost` had no such method to reach. Its two siblings have been wired to the backends all along. It is now a pure virtual, implemented by all five.

AU gives a plugin nothing that means "start pulling `Render()`", which is what the old comment was about. But the wrapper is the one that calls `activate()`/`start_processing()` on the CLAP in the first place, from AU `Initialize()`, so `onIdle()` stands the plugin back up if the AU is initialized and the CLAP underneath it is not — and then asks for the flush below, which is what the request was usually really about.

## The flush — why this is not only about `request_process()`

In CLAP a plugin can only push an output event (a value its own editor changed, the gesture around it) from inside `process()` or `params.flush()`. The host's own parameter sets travel the same road the other way: `SetParameter` queues them on the process adapter for the next cycle to pick up.

So both directions stop dead the moment the host stops calling `Render()` — and AU hosts do stop. Logic will not run a track it knows carries no signal, and an initialized unit can then sit for minutes without a single render. Neither the VST3 SDK's AU wrapper nor JUCE's ever meets this, because neither routes automation through the audio cycle at all: both call `AUParameterSet`/`AUEventListenerNotify` straight out of the editor callback. A CLAP has no equivalent to call, so the wrapper has to do the pulling.

`param_request_flush()` — an empty override until now — is the trigger. It means "I have parameter events", may arrive at any moment in any state, and says nothing about whether the plugin is processing; `SetParameter` arms the same flag for the other direction. No polling: an idle plugin nobody is asking anything of is left alone.

What `onIdle()` decides is only whether a render will do the job first. `Render()` sets an atomic saying it ran, and a request is served once enough consecutive ticks have gone by without one. Not on the first empty tick, and not after a fixed count either — at 4096 frames and 44.1kHz a block is 93ms, so a host rendering perfectly normally leaves gaps longer than any small number of 10ms ticks, and a flush that beat the next render to the queue would hand the plugin the host's scheduled automation stripped of the buffer offsets it came with. `activateCLAP()` sizes the wait at three block periods, which no rendering host produces.

`ProcessAdapter::flush()` was declared but never defined. It is implemented here, and it delivers what is queued rather than discarding it: only parameter events are legal in a flush, so the index list is narrowed to those and the rest of the queue — MIDI the host handed us outside a render — keeps its place for the next `process()`. That makes the index list and the event list different lengths for the first time, which is what `input_events_size()`/`input_events_get()` now read.

## Locking

Letting the idle thread flush puts a third writer on the adapter's event queue, so the paths that queue onto it all take `_processLock` now: `SetParameter` (called from `AUBase::ScheduleParameter`, on the render thread but outside the render) and the MusicDevice entry points (`MIDIEvent`, `MIDIEventList`, `SysEx`, `StartNote`, `StopNote`), which a host may call from its MIDI thread at any time — for an instrument, exactly when the flush is armed. `MIDIEventList` holds it across the whole list, which is why `handleUMPSysEx7` must not take it again.

`activateCLAP()`/`deactivateCLAP()` also build and destroy the adapter under the lock; a locked `SetParameter` could otherwise use a pointer being reset underneath it.

The deactivated-plugin case still flushes through a separate adapter, since the real one does not exist then, but it is kept between calls rather than built per flush: gesture pairing is per adapter, so a begin emitted in one flush and closed in the next would otherwise lose its close and leave the host armed on the parameter.

## The other backends

They get what they can give. The standalone owns its audio engine, so a wake means something there and it activates the plugin if it is not active, alongside the restart flag the frontends already service. VST3, AUv3 and AAX have no way to ask their host for processing, and say so.
