### PR TITLE
AUv2 stability and thread safety

### DIFF
--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -815,7 +815,7 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // buffer sizes).
   bool applyConfigurationFromBusFormats();
 
-  // Returns false when the plugin rejects the host-chosen bus formats; the
+  // Returns false when the plugin rejects the bus formats or fails to start;
   // caller must treat that as a failed initialization.
   bool activateCLAP();
   void deactivateCLAP();
@@ -846,6 +846,10 @@ class WrapAsAUV2 : public ausdk::AUBase,
   // exist. Lives across flushes so gestures pair up; see flushParameters().
   std::unique_ptr<Clap::AUv2::ProcessAdapter> _flushAdapter;
   std::atomic<bool> _initialized = false;
+  /// Whether CLAP activation succeeded and requires a matching deactivation.
+  bool _clapActivated = false;
+  /// Whether CLAP processing started and requires a matching stop notification.
+  bool _clapProcessing = false;
 
   // some info about the wrapped clap
   // audio-port layout captured at PostConstructor. Scanning the CLAP

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -832,6 +832,9 @@ class WrapAsAUV2 : public ausdk::AUBase,
 
   // --------------- internals
 
+  /// Shares the SDK's non-realtime entry lock with idle callbacks and the Cocoa editor.
+  std::shared_ptr<ausdk::AUMutex> _mainThreadMutex = std::make_shared<ausdk::AUMutex>();
+
   // the wrapped CLAP:
   std::string _clapname;
   std::string _clapid;

--- a/src/detail/auv2/auv2_shared.h
+++ b/src/detail/auv2/auv2_shared.h
@@ -29,7 +29,7 @@ namespace free_audio::auv2_wrapper
 typedef struct ui_connection
 {
   uint32_t identifier = kAudioUnitProperty_ClapWrapper_UIConnection_id;
-  Clap::Plugin *_plugin = nullptr;   // points to the plugin instance
+  Clap::Plugin *_plugin = nullptr;  // points to the plugin instance
   /// Serializes host lifecycle calls with editor calls and outlives either connection endpoint.
   std::shared_ptr<ausdk::AUMutex> _mainThreadMutex;
   clap_window_t *_window = nullptr;  // points to a window handle, actually ptr to wrapping NSView class

--- a/src/detail/auv2/auv2_shared.h
+++ b/src/detail/auv2/auv2_shared.h
@@ -14,6 +14,8 @@
 
 #include <iostream>
 #include <functional>
+#include <memory>
+#include <AudioUnitSDK/AUUtility.h>
 #include "clap_proxy.h"
 #include <AudioToolbox/AudioUnitProperties.h>
 
@@ -28,6 +30,8 @@ typedef struct ui_connection
 {
   uint32_t identifier = kAudioUnitProperty_ClapWrapper_UIConnection_id;
   Clap::Plugin *_plugin = nullptr;   // points to the plugin instance
+  /// Serializes host lifecycle calls with editor calls and outlives either connection endpoint.
+  std::shared_ptr<ausdk::AUMutex> _mainThreadMutex;
   clap_window_t *_window = nullptr;  // points to a window handle, actually ptr to wrapping NSView class
   uint32_t *_canary = nullptr;       // a canary in the Windows class
   std::function<void(clap_window_t *, uint32_t *)> _registerWindow = nullptr;

--- a/src/detail/auv2/process.cpp
+++ b/src/detail/auv2/process.cpp
@@ -292,7 +292,9 @@ void ProcessAdapter::process(ProcessData &data)
     for (uint32_t i = 0; i < _numInputs; ++i)
     {
       auto &m = static_cast<ausdk::AUInputElement &>(*_audioInputScope->SafeGetElement(i));
-      if (m.PullInput(data.flags, data.timestamp, i, data.numSamples) == noErr)
+      // Silence reported by one input must not describe another input or the plugin output.
+      auto inputFlags = data.flags & ~kAudioUnitRenderAction_OutputIsSilence;
+      if (m.PullInput(inputFlags, data.timestamp, i, data.numSamples) == noErr)
       {
         AudioBufferList &myInBuffers = m.GetBufferList();
         auto num = myInBuffers.mNumberBuffers;
@@ -352,6 +354,9 @@ void ProcessAdapter::process(ProcessData &data)
 #endif
 
   _plugin->process(_plugin, &_processData);
+
+  // A CLAP plugin may generate audible output even when its inputs are silent.
+  data.flags &= ~kAudioUnitRenderAction_OutputIsSilence;
 
   processOutputEvents();
 

--- a/src/detail/auv2/wrappedview.asinclude.mm
+++ b/src/detail/auv2/wrappedview.asinclude.mm
@@ -46,7 +46,7 @@
 
 - (NSView *)uiViewForAudioUnit:(AudioUnit)inAudioUnit withSize:(NSSize)inPreferredSize
 {
-  static free_audio::auv2_wrapper::ui_connection uiconn;
+  free_audio::auv2_wrapper::ui_connection uiconn;
 
   // free_audio::auv2_wrapper::ui_connection connection;
   // Remember we end up being called here because that's what AUCocoaUIView does in the initiation
@@ -89,6 +89,9 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
   LOGINFO("[clap-wrapper] creating NSView");
 
   ui = *cont;
+  // The property lookup has returned, so editor calls need their own SDK entry guard.
+  const auto mainThreadMutex = ui._mainThreadMutex;
+  const ausdk::AUEntryGuard mainThreadGuard(mainThreadMutex.get());
   canary = 0xbeebbeeb;
 
   if (ui._registerWindow)
@@ -151,6 +154,8 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 }
 - (void)viewDidMoveToWindow
 {
+  const auto mainThreadMutex = ui._mainThreadMutex;
+  const ausdk::AUEntryGuard mainThreadGuard(mainThreadMutex.get());
   if ([self window] == nil)
   {
     LOGINFO("[clap-wrapper] - view removed from a window");
@@ -171,6 +176,9 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 
 - (void)dealloc
 {
+  // Super deallocation releases the C++ ivars before this scope unlocks the mutex.
+  const auto mainThreadMutex = ui._mainThreadMutex;
+  const ausdk::AUEntryGuard mainThreadGuard(mainThreadMutex.get());
   LOGINFO("[clap-wrapper] NS View dealloc");
   if (idleTimer)
   {
@@ -186,6 +194,8 @@ void CLAP_WRAPPER_TIMER_CALLBACK(CFRunLoopTimerRef timer, void *info)
 - (void)setFrame:(NSRect)newSize
 {
   [super setFrame:newSize];
+  const auto mainThreadMutex = ui._mainThreadMutex;
+  const ausdk::AUEntryGuard mainThreadGuard(mainThreadMutex.get());
   if (canary)
   {
     auto gui = ui._plugin->_ext._gui;

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -1382,9 +1382,8 @@ void WrapAsAUV2::releaseHostMIDIOutput()
 OSStatus WrapAsAUV2::Render(AudioUnitRenderActionFlags &inFlags, const AudioTimeStamp &inTimeStamp,
                             UInt32 inFrames)
 {
-  assert(inFlags == 0);
   ClapWrapper::detail::shared::SpinLockGuard processGuard(_processLock);
-  if (_initialized && (inFlags == 0))
+  if (_initialized)
   {
     // do the render dance
     Clap::AUv2::ProcessData data{inFlags, inTimeStamp, inFrames, this};

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -724,7 +724,6 @@ void WrapAsAUV2::Cleanup()
       if (_plugin->_plugin && _plugin->_ext._gui)
       {
         this->_uiconn._destroyWindow();
-        this->_plugin->_ext._gui->destroy(_plugin->_plugin);
       }
     }
   }

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <algorithm>
 #include <cmath>
+#include <mutex>
 #include <Block.h>
 
 extern bool fillAudioUnitCocoaView(AudioUnitCocoaViewInfo *viewInfo, std::shared_ptr<Clap::Plugin>);
@@ -157,6 +158,10 @@ WrapAsAUV2::WrapAsAUV2(const std::string &clapname, const std::string &clapid, i
   , _idx{idx}
   , _os_attached([this] { os::attach(this); }, [this] { os::detach(this); })
 {
+  // Logic may initialize an AU on a worker while its editor and idle timer run.
+  // The SDK holds this lock across its complete non-realtime dispatch, including
+  // changes to AUBase::IsInitialized() before and after the virtual callbacks.
+  SetMutex(_mainThreadMutex.get());
   _uiIsOpened = false;
   if (!_desc)
   {
@@ -173,7 +178,6 @@ WrapAsAUV2::WrapAsAUV2(const std::string &clapname, const std::string &clapid, i
       if (_plugin)
       {
         _plugin->initialize();
-        _os_attached.on();
       }
       else
       {
@@ -189,6 +193,7 @@ WrapAsAUV2::WrapAsAUV2(const std::string &clapname, const std::string &clapid, i
 
 WrapAsAUV2::~WrapAsAUV2()
 {
+  const std::lock_guard<ausdk::AUMutex> mainThreadGuard(*_mainThreadMutex);
 #if AUSDK_MIDI2_AVAILABLE
   if (auto blk = _midioutput_hosteventlistblock.exchange(nullptr)) Block_release(blk);
   for (auto blk : _retiredEventListBlocks) Block_release(blk);
@@ -214,6 +219,8 @@ WrapAsAUV2::~WrapAsAUV2()
   {
     CFRelease(_current_program_name);
   }
+  // AUBase must not retain a pointer to a member-owned lock during base destruction.
+  SetMutex(nullptr);
 }
 
 // the very very reduced state machine
@@ -883,6 +890,7 @@ OSStatus WrapAsAUV2::GetProperty(AudioUnitPropertyID inID, AudioUnitScope inScop
         //      return noErr;
       case kAudioUnitProperty_ClapWrapper_UIConnection_id:
         _uiconn._plugin = _plugin.get();
+        _uiconn._mainThreadMutex = _mainThreadMutex;
         _uiconn._window = nullptr;
         _uiconn._registerWindow = [this](auto *x, auto *y)
         {
@@ -1607,6 +1615,10 @@ void WrapAsAUV2::pushQueuedEventsToHost()
 
 void WrapAsAUV2::onIdle()
 {
+  // Preserve pending work when a host lifecycle call owns the CLAP main-thread state.
+  // Waiting here could block the real UI thread while host initialization waits for it.
+  const std::unique_lock<ausdk::AUMutex> mainThreadGuard(*_mainThreadMutex, std::try_to_lock);
+  if (!mainThreadGuard.owns_lock()) return;
   if (!_plugin) return;
 
   pushQueuedEventsToHost();
@@ -2262,6 +2274,9 @@ void WrapAsAUV2::PostConstructor()
     Inputs().GetElement(0)->SetName(CFSTR("Input"));
     LOGINFO("[clap-wrapper] PostConstructor: added placeholder silent input bus");
   }
+
+  // The timer must not enter the CLAP while its initial port configuration is being queried.
+  _os_attached.on();
 }
 
 UInt32 WrapAsAUV2::GetAudioChannelLayout(AudioUnitScope scope, AudioUnitElement element,

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -233,9 +233,8 @@ OSStatus WrapAsAUV2::Initialize()
   auto guarantee_mainthread = _plugin->AlwaysMainThread();
   if (!activateCLAP())
   {
-    // The host settled on a main-bus format pair the plugin does not accept
-    // (see activateCLAP). Refuse the initialization rather than render with
-    // buffers sized differently from the plugin's ports.
+    // A rejected configuration or lifecycle call leaves the CLAP deactivated.
+    // Report the failure so the host does not render an unavailable processor.
     return kAudioUnitErr_FormatNotSupported;
   }
 
@@ -1339,11 +1338,22 @@ bool WrapAsAUV2::activateCLAP()
       _flushAdapter.reset();
     }
 
-    _plugin->activate();
-    _plugin->start_processing();
+    _clapActivated = _plugin->activate();
+    if (!_clapActivated)
+    {
+      deactivateCLAP();
+      return false;
+    }
+    _clapProcessing = _plugin->start_processing();
+    if (!_clapProcessing)
+    {
+      deactivateCLAP();
+      return false;
+    }
     _initialized = true;
+    return true;
   }
-  return true;
+  return false;
 }
 
 void WrapAsAUV2::deactivateCLAP()
@@ -1357,8 +1367,16 @@ void WrapAsAUV2::deactivateCLAP()
       _initialized = false;
       _processAdapter.reset();
     }
-    _plugin->stop_processing();
-    _plugin->deactivate();
+    if (_clapProcessing)
+    {
+      _plugin->stop_processing();
+      _clapProcessing = false;
+    }
+    if (_clapActivated)
+    {
+      _plugin->deactivate();
+      _clapActivated = false;
+    }
   }
 }
 
@@ -1633,10 +1651,8 @@ void WrapAsAUV2::onIdle()
     if (wasInitialized)
     {
       deactivateCLAP();
-      // Cannot fail for the format-pair reason Initialize guards against:
-      // the formats have not changed since the last successful activation.
-      // If it fails anyway, _initialized stays false and renders return
-      // silence, the same state as before Initialize.
+      // Even unchanged formats can encounter a rejected CLAP lifecycle call.
+      // A failed restart leaves processing unavailable for a later retry.
       if (!activateCLAP())
       {
         LOGINFO("[clap-wrapper] restart: could not reactivate the plugin");


### PR DESCRIPTION
This PR addresses 4 issues I discovered while working on a plugin that serves as an offline audio generator.
If you would like me to split this into several PRs, please let me know.

These commits were made with the help of GPT-6 Astra and manually vetted and adjusted.

`3780585`
First of all, my plugin was not outputting any audio in Logic despite producing samples. 
As I mentioned, my plugin generates audio offline and can play it back on user demand, even when there is no incoming audio. The fix was to clear the "silent" flag from the output when it's set for the input.

`121fe78`
My plugin was erroring during the CLAP activate callback and returned `false`, but clap-wrapper reported it as fine to Logic. This commit properly respects the return value of `activate` and `start_processing`.

`0aedc9c`
Logic activates my plugin on a worker thread, while clap-wrapper can call on_main_thread or access the editor on the main thread. These calls could overlap and access the same plugin state at the same time. `AlwaysMainThread()` only changes the result returned by the thread check, it doesn't prevent this overlap. This commit adds a shared lock so these calls happen one at a time. If the plugin is busy, the idle callback is deferred to the next tick. 

`a1ac38b`
During cleanup, clap-wrapper called gui.destroy twice: once through the editor’s cleanup callback and then again directly.
