### PR TITLE
preset discovery: let wrapped formats browse a CLAP's presets

### DIFF
--- a/cmake/shared_prologue.cmake
+++ b/cmake/shared_prologue.cmake
@@ -231,6 +231,8 @@ function(guarantee_clap_wrapper_shared)
             src/detail/clap/fsutil.h
             src/detail/clap/fsutil.cpp
             src/detail/clap/automation.h
+            src/detail/clap/preset_discovery.h
+            src/detail/clap/preset_discovery.cpp
             )
     target_link_libraries(clap-wrapper-shared-detail PUBLIC clap clap-wrapper-extensions clap-wrapper-compile-options-public)
     target_link_libraries(clap-wrapper-shared-detail PRIVATE clap-wrapper-compile-options)

--- a/src/clap_proxy.cpp
+++ b/src/clap_proxy.cpp
@@ -145,6 +145,15 @@ static bool track_info_get(const clap_host_t *host, clap_track_info_t *info)
 
 const clap_host_track_info trackinfo = {track_info_get};
 
+const clap_host_preset_load_t preset_load = {
+    /* on_error */
+    [](const clap_host_t *host, uint32_t location_kind, const char *location, const char *load_key,
+       int32_t os_error, const char *msg) -> void
+    { self(host)->preset_load_error(location_kind, location, load_key, os_error, msg); },
+    /* loaded */
+    [](const clap_host_t *host, uint32_t location_kind, const char *location,
+       const char *load_key) -> void { self(host)->preset_loaded(location_kind, location, load_key); }};
+
 }  // namespace HostExt
 
 std::shared_ptr<Plugin> Plugin::createInstance(const clap_plugin_factory *factory, const std::string &id,
@@ -251,6 +260,9 @@ void Plugin::connectClap(const clap_plugin_t *clap)
   }
 
   getExtension(_plugin, _ext._gainreduc, CLAP_EXT_GAIN_ADJUSTMENT_METERING);
+
+  getExtension(_plugin, _ext._preset_load, CLAP_EXT_PRESET_LOAD);
+  if (!_ext._preset_load) getExtension(_plugin, _ext._preset_load, CLAP_EXT_PRESET_LOAD_COMPAT);
   getExtension(_plugin, _ext._auv2_param_ordering, CLAP_PLUGIN_AUV2_PARAM_ORDERING);
 
 #if LIN
@@ -352,6 +364,13 @@ bool Plugin::load(const clap_istream_t *stream) const
   return false;
 }
 
+bool Plugin::loadPresetFromLocation(uint32_t locationKind, const char *location,
+                                    const char *loadKey) const
+{
+  if (!supportsPresetLoad()) return false;
+  return _ext._preset_load->from_location(_plugin, locationKind, location, loadKey);
+}
+
 bool Plugin::save(const clap_ostream_t *stream) const
 {
   if (_ext._state)
@@ -418,6 +437,17 @@ void Plugin::mark_dirty()
 void Plugin::latency_changed()
 {
   _parentHost->latency_changed();
+}
+
+void Plugin::preset_loaded(uint32_t locationKind, const char *location, const char *loadKey)
+{
+  _parentHost->preset_loaded(locationKind, location, loadKey);
+}
+
+void Plugin::preset_load_error(uint32_t locationKind, const char *location, const char *loadKey,
+                               int32_t osError, const char *msg)
+{
+  _parentHost->preset_load_error(locationKind, location, loadKey, osError, msg);
 }
 
 void Plugin::tail_changed()
@@ -557,6 +587,8 @@ const void *Plugin::clapExtension(const clap_host * /*host*/, const char *extens
   if (!strcmp(extension, CLAP_EXT_TAIL)) return &HostExt::tail;
   if (!strcmp(extension, CLAP_EXT_STATE)) return &HostExt::state;
   if (!strcmp(extension, CLAP_EXT_CONTEXT_MENU)) return &HostExt::context_menu;
+  if (!strcmp(extension, CLAP_EXT_PRESET_LOAD) || !strcmp(extension, CLAP_EXT_PRESET_LOAD_COMPAT))
+    return &HostExt::preset_load;
 
 #if LIN
   if (!strcmp(extension, CLAP_EXT_POSIX_FD_SUPPORT)) return &HostExt::hostposixfd;

--- a/src/clap_proxy.h
+++ b/src/clap_proxy.h
@@ -74,6 +74,23 @@ class IHost
   virtual bool track_info_get(clap_track_info_t *info) = 0;
   virtual const char *host_get_name() = 0;
 
+  // clap.preset-load, host side. Defaulted rather than pure: only the formats
+  // that can show a preset list (VST3 program lists, AU factory presets) have
+  // anything to do here, and making these pure would force every other
+  // wrapper to grow two empty overrides.
+  //
+  // `loaded` is how a plugin tells the host what it now holds - a plugin's own
+  // UI can load a preset without the host asking, and the host's list has to
+  // follow. Both arrive on the main thread.
+  virtual void preset_loaded(uint32_t /*location_kind*/, const char * /*location*/,
+                             const char * /*load_key*/)
+  {
+  }
+  virtual void preset_load_error(uint32_t /*location_kind*/, const char * /*location*/,
+                                 const char * /*load_key*/, int32_t /*os_error*/, const char * /*msg*/)
+  {
+  }
+
   // context menu
 
   // actually, everything here should be virtual only, but until all wrappers are updated,
@@ -121,6 +138,7 @@ struct ClapPluginExtensions
   const clap_ara_plugin_extension_t *_ara = nullptr;
   const clap_plugin_gain_adjustment_metering_t *_gainreduc = nullptr;
   const clap_plugin_auv2_param_ordering_t *_auv2_param_ordering = nullptr;
+  const clap_plugin_preset_load_t *_preset_load = nullptr;
 #if LIN
   const clap_plugin_posix_fd_support *_posixfd = nullptr;
 #endif
@@ -183,6 +201,19 @@ class Plugin
 
   bool load(const clap_istream_t *stream) const;
   bool save(const clap_ostream_t *stream) const;
+
+  // clap.preset-load, plugin side. True when the plugin implements it at all -
+  // a wrapper with nothing to load presets *into* should not advertise a
+  // preset list to its host.
+  bool supportsPresetLoad() const
+  {
+    return _ext._preset_load != nullptr && _ext._preset_load->from_location != nullptr;
+  }
+  // [main-thread]. Failure is reported by the plugin through the host side
+  // (IHost::preset_load_error) as well as by this return value; the message
+  // only ever arrives that way, so a wrapper that wants to show one must
+  // override the callback.
+  bool loadPresetFromLocation(uint32_t locationKind, const char *location, const char *loadKey) const;
   bool activate() const;
   void deactivate() const;
   bool start_processing();
@@ -212,6 +243,12 @@ class Plugin
 
   // tail
   void tail_changed();
+
+  // preset_load, host side: forwarded to the wrapper, which is what knows how
+  // to show its host a preset list.
+  void preset_loaded(uint32_t locationKind, const char *location, const char *loadKey);
+  void preset_load_error(uint32_t locationKind, const char *location, const char *loadKey,
+                         int32_t osError, const char *msg);
 
   // context_menu
   bool context_menu_populate(const clap_context_menu_target_t *target,

--- a/src/detail/auv2/auv2_base_classes.h
+++ b/src/detail/auv2/auv2_base_classes.h
@@ -29,6 +29,7 @@
 #include "detail/shared/fixedqueue.h"
 #include "detail/shared/spinlock.h"
 #include "detail/shared/midi_translation.h"
+#include "detail/clap/preset_discovery.h"
 #include "detail/os/osutil.h"
 #include "detail/clap/automation.h"
 
@@ -616,10 +617,11 @@ class WrapAsAUV2 : public ausdk::AUBase,
     // call that reported dirty. The flag also collapses bursts into one
     // notification per idle tick.
     //
-    // Deliberately not accompanied by kAudioUnitProperty_PresentPreset: the
-    // wrapper exposes no presets, so AUBase's mCurrentPreset stays {-1,
-    // "Untitled"} and notifying it would only make hosts re-read an unchanged
-    // value. That belongs with CLAP preset-load support, when it arrives.
+    // Deliberately not accompanied by kAudioUnitProperty_PresentPreset. That
+    // is now a real property (the wrapper does publish factory presets - see
+    // GetPresets below), but it changes when a preset is *loaded*, not when
+    // the plugin's state drifts from what the host cached; preset_loaded() is
+    // what notifies it.
     _requestMarkDirty = true;
   }
   void restartPlugin() override
@@ -755,6 +757,18 @@ class WrapAsAUV2 : public ausdk::AUBase,
   void onBeginEdit(clap_id id) override;
   void onPerformEdit(const clap_event_param_value_t *value) override;
   void onEndEdit(clap_id id) override;
+
+  // --------------- factory presets, from clap.preset-load
+  // AU's preset list is flat and numbered, and a host stores the *number*.
+  // Clap::PresetIndex is what makes that number mean the same preset twice -
+  // see its header on ordering.
+  OSStatus GetPresets(CFArrayRef *outData) const override;
+  OSStatus NewFactoryPresetSet(const AUPreset &inNewFactoryPreset) override;
+
+  // --------------- Clap::IHost, preset-load
+  void preset_loaded(uint32_t locationKind, const char *location, const char *loadKey) override;
+  void preset_load_error(uint32_t locationKind, const char *location, const char *loadKey,
+                         int32_t osError, const char *msg) override;
 
   // --------------- IPlugObject
   void onIdle() override;
@@ -939,6 +953,29 @@ class WrapAsAUV2 : public ausdk::AUBase,
 #endif
 
   std::atomic_bool _requestUICallback = false;
+  // ---- clap.preset-load, published as AU factory presets ----
+  void setupPresets();
+  // Builds _presetCache from the index. const because GetPresets() is: AU asks
+  // for the preset list early and synchronously, often before the first idle
+  // tick, so building it lazily there is the only way to answer with anything.
+  void rebuildPresetCache() const;
+
+  std::shared_ptr<Clap::PresetIndex> _presetIndex;
+  uint64_t _presetIndexToken = 0;
+  // Set from the index's crawl thread, serviced in onIdle(): notifying a host
+  // is not something to do from a background thread.
+  std::atomic_bool _presetListChanged = false;
+
+  mutable std::mutex _presetCacheMutex;
+  mutable std::vector<AUPreset> _presetCache;
+  mutable bool _presetCacheBuilt = false;
+  // Every CFString ever handed to a host in an AUPreset, kept alive until this
+  // instance dies. A host may still hold an array from before a rebuild, and
+  // the AU API gives it no way to tell us it is done with one - so retiring
+  // the strings early would be a use-after-free with a very long fuse. There
+  // are at most two generations (empty, then crawled), so nothing accumulates.
+  mutable std::vector<CFStringRef> _presetNameStrings;
+
   // set by mark_dirty(), serviced in onIdle()
   std::atomic_bool _requestMarkDirty = false;
   std::atomic_bool _requestRestart = false;

--- a/src/detail/clap/automation.h
+++ b/src/detail/clap/automation.h
@@ -10,6 +10,14 @@ class IAutomation
   virtual void onBeginEdit(clap_id id) = 0;
   virtual void onPerformEdit(const clap_event_param_value_t *value) = 0;
   virtual void onEndEdit(clap_id id) = 0;
+
+  // A host moved the preset-selector parameter. Defaulted because it only
+  // means anything to a wrapper that publishes a preset list, and because
+  // this arrives on the audio thread: the implementation must marshal, not
+  // load. \see Clap::PresetIndex
+  virtual void onRequestPresetLoad(size_t /*presetIndex*/)
+  {
+  }
   virtual ~IAutomation()
   {
   }

--- a/src/detail/clap/fsutil.cpp
+++ b/src/detail/clap/fsutil.cpp
@@ -317,6 +317,14 @@ void Library::setupPluginsFromPluginEntry(const char *path)
       _pluginFactoryARAInfo =
           static_cast<const clap_ara_factory_t *>(_pluginEntry->get_factory(CLAP_EXT_ARA_FACTORY));
 
+      _pluginFactoryPresetDiscovery = static_cast<const clap_preset_discovery_factory_t *>(
+          _pluginEntry->get_factory(CLAP_PRESET_DISCOVERY_FACTORY_ID));
+      if (!_pluginFactoryPresetDiscovery)
+      {
+        _pluginFactoryPresetDiscovery = static_cast<const clap_preset_discovery_factory_t *>(
+            _pluginEntry->get_factory(CLAP_PRESET_DISCOVERY_FACTORY_ID_COMPAT));
+      }
+
       // detect plugins that do not check the CLAP_PLUGIN_FACTORY_ID
       if ((void *)_pluginFactory == (void *)_pluginFactoryVst3Info)
       {
@@ -326,6 +334,7 @@ void Library::setupPluginsFromPluginEntry(const char *path)
         _pluginFactoryAUv2Info = nullptr;
         _pluginFactoryAUv2Legacy = nullptr;
         _pluginFactoryARAInfo = nullptr;
+        _pluginFactoryPresetDiscovery = nullptr;
       }
 
       auto count = _pluginFactory->get_plugin_count(_pluginFactory);

--- a/src/detail/clap/fsutil.h
+++ b/src/detail/clap/fsutil.h
@@ -50,6 +50,12 @@ class Library
   const clap_plugin_factory_auv2_legacy *_pluginFactoryAUv2Legacy = nullptr;
   const clap_plugin_factory_as_aax_t *_pluginFactoryAAXInfo = nullptr;
   const clap_ara_factory_t *_pluginFactoryARAInfo = nullptr;
+  // The plugin's CLAP preset-discovery factory, when it has one. Unlike the
+  // *_Info factories above this is not wrapper metadata: it is the plugin
+  // telling a host where its presets live and what they contain. No VST3 or
+  // AUv2 host will ever ask for it, so the wrapper has to be the indexer
+  // itself - see detail/clap/preset_discovery.h.
+  const clap_preset_discovery_factory_t *_pluginFactoryPresetDiscovery = nullptr;
   std::vector<const clap_plugin_descriptor_t *> plugins;
 
   const clap_plugin_info_as_vst3_t *get_vst3_info(uint32_t index) const;

--- a/src/detail/clap/preset_discovery.cpp
+++ b/src/detail/clap/preset_discovery.cpp
@@ -1,0 +1,626 @@
+/*
+
+    Copyright (c) 2022 Timo Kaluza (defiantnerd)
+                       Paul Walker
+
+    This file is part of the clap-wrappers project which is released under MIT License.
+    See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+
+*/
+
+#include "detail/clap/preset_discovery.h"
+
+#include <algorithm>
+#include <cstring>
+#include <chrono>
+#include <map>
+#include <tuple>
+
+#include "detail/clap/fsutil.h"
+#include "detail/os/fs.h"
+
+namespace Clap
+{
+
+namespace
+{
+
+// Crawl bounds. A preset location is a user-writable folder, so it can contain
+// anything at all - including, eventually, a symlink loop or somebody's entire
+// home directory. These are the point at which the wrapper stops rather than
+// hanging a DAW's plugin scan.
+constexpr size_t kMaxCrawlDepth = 8;
+constexpr size_t kMaxPresetsPerLocation = 50000;
+
+bool sameString(const char *a, const char *b)
+{
+  if (a == nullptr || b == nullptr) return (a == nullptr) == (b == nullptr);
+  return std::strcmp(a, b) == 0;
+}
+
+std::string toLower(std::string value)
+{
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return value;
+}
+
+// The extension as declared: without the dot, case-insensitively, and with an
+// empty or null one meaning "every file matches" (the header says so).
+std::string normalizeExtension(const char *declared)
+{
+  if (declared == nullptr) return {};
+  std::string value{declared};
+  if (!value.empty() && value.front() == '.') value.erase(value.begin());
+  return toLower(value);
+}
+
+}  // namespace
+
+std::string PresetEntry::displayName() const
+{
+  if (!name.empty()) return name;
+  if (!loadKey.empty()) return loadKey;
+  if (!location.empty())
+  {
+    // Not fs::path, because this runs for LOCATION_PLUGIN too where the
+    // location is empty, and because a filename is all that is wanted.
+    const auto slash = location.find_last_of("/\\");
+    const auto file = slash == std::string::npos ? location : location.substr(slash + 1);
+    const auto dot = file.find_last_of('.');
+    return dot == std::string::npos || dot == 0 ? file : file.substr(0, dot);
+  }
+  return "Preset";
+}
+
+// ----------------------------------------------------------------------------
+// What the provider declares in init(): filetypes, locations, soundpacks.
+// ----------------------------------------------------------------------------
+struct PresetIndex::Declarations
+{
+  struct Location
+  {
+    uint32_t flags{0};
+    uint32_t kind{CLAP_PRESET_DISCOVERY_LOCATION_FILE};
+    std::string name;
+    std::string location;
+  };
+
+  std::vector<std::string> extensions;  // lowercase, no dot; empty entry = match all
+  std::vector<Location> locations;
+  std::vector<PresetCollection> collections;
+
+  clap_preset_discovery_indexer_t indexer{};
+
+  Declarations()
+  {
+    indexer.clap_version = CLAP_VERSION;
+    indexer.name = "clap-wrapper";
+    indexer.vendor = "clap-wrapper";
+    indexer.url = "https://github.com/free-audio/clap-wrapper";
+    indexer.version = "1.0";
+    indexer.indexer_data = this;
+    indexer.declare_filetype = &declareFiletype;
+    indexer.declare_location = &declareLocation;
+    indexer.declare_soundpack = &declareSoundpack;
+    indexer.get_extension = &getExtension;
+  }
+
+  bool matchesExtension(const fs::path &path) const
+  {
+    // "If empty or NULL then every file should be matched."
+    if (extensions.empty()) return false;
+
+    auto ext = path.extension().string();
+    if (!ext.empty() && ext.front() == '.') ext.erase(ext.begin());
+    ext = toLower(ext);
+
+    for (const auto &declared : extensions)
+    {
+      if (declared.empty()) return true;
+      if (declared == ext) return true;
+    }
+    return false;
+  }
+
+ private:
+  static Declarations *self(const clap_preset_discovery_indexer_t *indexer)
+  {
+    return static_cast<Declarations *>(indexer->indexer_data);
+  }
+
+  static bool declareFiletype(const clap_preset_discovery_indexer_t *indexer,
+                              const clap_preset_discovery_filetype_t *filetype)
+  {
+    if (filetype == nullptr) return false;
+    self(indexer)->extensions.push_back(normalizeExtension(filetype->file_extension));
+    return true;
+  }
+
+  static bool declareLocation(const clap_preset_discovery_indexer_t *indexer,
+                              const clap_preset_discovery_location_t *location)
+  {
+    if (location == nullptr) return false;
+
+    Location recorded;
+    recorded.flags = location->flags;
+    recorded.kind = location->kind;
+    recorded.name = location->name != nullptr ? location->name : "";
+
+    if (location->kind == CLAP_PRESET_DISCOVERY_LOCATION_FILE)
+    {
+      // A FILE location without a path is meaningless, and following it would
+      // mean crawling the current working directory.
+      if (location->location == nullptr || *location->location == 0) return false;
+      recorded.location = location->location;
+    }
+    else if (location->kind == CLAP_PRESET_DISCOVERY_LOCATION_PLUGIN)
+    {
+      // "The location must then be null, as the preset are within the plugin
+      // itself." Anything else is the plugin misunderstanding its own
+      // container.
+      if (location->location != nullptr && *location->location != 0) return false;
+    }
+    else
+    {
+      return false;  // a kind from a newer CLAP than this wrapper knows
+    }
+
+    self(indexer)->locations.push_back(std::move(recorded));
+    return true;
+  }
+
+  static bool declareSoundpack(const clap_preset_discovery_indexer_t *indexer,
+                               const clap_preset_discovery_soundpack_t *soundpack)
+  {
+    if (soundpack == nullptr || soundpack->id == nullptr) return false;
+
+    PresetCollection collection;
+    collection.id = soundpack->id;
+    collection.name = soundpack->name != nullptr ? soundpack->name : "";
+    collection.description = soundpack->description != nullptr ? soundpack->description : "";
+    collection.vendor = soundpack->vendor != nullptr ? soundpack->vendor : "";
+    collection.homepageUrl = soundpack->homepage_url != nullptr ? soundpack->homepage_url : "";
+    collection.imagePath = soundpack->image_path != nullptr ? soundpack->image_path : "";
+    collection.releaseTimestamp = soundpack->release_timestamp;
+    collection.flags = soundpack->flags;
+    self(indexer)->collections.push_back(std::move(collection));
+    return true;
+  }
+
+  static const void *getExtension(const clap_preset_discovery_indexer_t *, const char *)
+  {
+    return nullptr;
+  }
+};
+
+// ----------------------------------------------------------------------------
+// The metadata receiver: one file's worth of callbacks at a time.
+// ----------------------------------------------------------------------------
+struct PresetIndex::Receiver
+{
+  clap_preset_discovery_metadata_receiver_t receiver{};
+
+  // Set per file, before handing the receiver to get_metadata().
+  uint32_t locationKind{CLAP_PRESET_DISCOVERY_LOCATION_FILE};
+  std::string location;
+  uint32_t locationFlags{0};
+
+  // Which plugin's presets we are collecting. A provider may serve several
+  // plugins from one library.
+  std::string pluginId;
+
+  std::vector<PresetEntry> collected;
+
+  Receiver()
+  {
+    receiver.receiver_data = this;
+    receiver.on_error = &onError;
+    receiver.begin_preset = &beginPreset;
+    receiver.add_plugin_id = &addPluginId;
+    receiver.set_soundpack_id = &setSoundpackId;
+    receiver.set_flags = &setFlags;
+    receiver.add_creator = &addCreator;
+    receiver.set_description = &setDescription;
+    receiver.set_timestamps = &setTimestamps;
+    receiver.add_feature = &addFeature;
+    receiver.add_extra_info = &addExtraInfo;
+  }
+
+  // Presets whose plugin ids were declared but did not include ours are
+  // dropped when the file is finished, not when the id arrives - the ids come
+  // in after begin_preset, one call at a time.
+  void finishFile()
+  {
+    for (auto &pending : _pending)
+    {
+      const bool wanted = !pending.sawAnyPluginId || pending.matchedPluginId;
+      if (wanted) collected.push_back(std::move(pending.entry));
+    }
+    _pending.clear();
+  }
+
+ private:
+  struct Pending
+  {
+    PresetEntry entry;
+    bool sawAnyPluginId{false};
+    bool matchedPluginId{false};
+  };
+
+  std::vector<Pending> _pending;
+
+  static Receiver *self(const clap_preset_discovery_metadata_receiver_t *r)
+  {
+    return static_cast<Receiver *>(r->receiver_data);
+  }
+
+  // Metadata calls apply to the preset most recently begun. A provider that
+  // calls them before any begin_preset is out of contract; ignore rather than
+  // crash, because this is third-party code we are hosting.
+  static Pending *current(const clap_preset_discovery_metadata_receiver_t *r)
+  {
+    auto *me = self(r);
+    return me->_pending.empty() ? nullptr : &me->_pending.back();
+  }
+
+  static void onError(const clap_preset_discovery_metadata_receiver_t *, int32_t, const char *)
+  {
+    // Nothing to do: a file that is not this plugin's preset is not the
+    // wrapper's problem, and there is no host-facing channel for it here.
+  }
+
+  static bool beginPreset(const clap_preset_discovery_metadata_receiver_t *r, const char *name,
+                          const char *loadKey)
+  {
+    auto *me = self(r);
+
+    Pending pending;
+    pending.entry.locationKind = me->locationKind;
+    pending.entry.location = me->location;
+    pending.entry.loadKey = loadKey != nullptr ? loadKey : "";
+    pending.entry.name = name != nullptr ? name : "";
+    // "If unset, they are then inherited from the location."
+    pending.entry.flags = me->locationFlags;
+    me->_pending.push_back(std::move(pending));
+
+    return true;
+  }
+
+  static void addPluginId(const clap_preset_discovery_metadata_receiver_t *r,
+                          const clap_universal_plugin_id_t *id)
+  {
+    auto *pending = current(r);
+    if (pending == nullptr || id == nullptr) return;
+
+    pending->sawAnyPluginId = true;
+    if (sameString(id->abi, "clap") && id->id != nullptr && self(r)->pluginId == id->id)
+      pending->matchedPluginId = true;
+  }
+
+  static void setSoundpackId(const clap_preset_discovery_metadata_receiver_t *r, const char *id)
+  {
+    if (auto *pending = current(r); pending != nullptr && id != nullptr)
+      pending->entry.collectionId = id;
+  }
+
+  static void setFlags(const clap_preset_discovery_metadata_receiver_t *r, uint32_t flags)
+  {
+    if (auto *pending = current(r); pending != nullptr) pending->entry.flags = flags;
+  }
+
+  static void addCreator(const clap_preset_discovery_metadata_receiver_t *r, const char *creator)
+  {
+    if (auto *pending = current(r); pending != nullptr && creator != nullptr && *creator != 0)
+      pending->entry.creators.emplace_back(creator);
+  }
+
+  static void setDescription(const clap_preset_discovery_metadata_receiver_t *r, const char *description)
+  {
+    if (auto *pending = current(r); pending != nullptr && description != nullptr)
+      pending->entry.description = description;
+  }
+
+  static void setTimestamps(const clap_preset_discovery_metadata_receiver_t *r,
+                            clap_timestamp creationTime, clap_timestamp modificationTime)
+  {
+    if (auto *pending = current(r); pending != nullptr)
+    {
+      pending->entry.creationTime = creationTime;
+      pending->entry.modificationTime = modificationTime;
+    }
+  }
+
+  static void addFeature(const clap_preset_discovery_metadata_receiver_t *r, const char *feature)
+  {
+    if (auto *pending = current(r); pending != nullptr && feature != nullptr && *feature != 0)
+      pending->entry.features.emplace_back(feature);
+  }
+
+  static void addExtraInfo(const clap_preset_discovery_metadata_receiver_t *, const char *, const char *)
+  {
+    // Deliberately dropped. Neither a VST3 program list nor an AU factory
+    // preset has anywhere to put arbitrary key/value pairs, and keeping them
+    // would mean carrying a map per preset across a whole library's index for
+    // nothing.
+  }
+};
+
+// ----------------------------------------------------------------------------
+// The index itself
+// ----------------------------------------------------------------------------
+
+namespace
+{
+struct IndexCache
+{
+  std::mutex mutex;
+  // Keyed by the entry rather than the Library: a Library is per-format-object
+  // but the entry (and therefore the plugin's preset content) is per module.
+  std::map<std::pair<const clap_plugin_entry_t *, std::string>, std::shared_ptr<PresetIndex>> map;
+};
+
+IndexCache &indexCache()
+{
+  static IndexCache cache;
+  return cache;
+}
+}  // namespace
+
+std::shared_ptr<PresetIndex> PresetIndex::forPlugin(const Library *library, const std::string &pluginId)
+{
+  if (library == nullptr || library->_pluginFactoryPresetDiscovery == nullptr ||
+      library->_pluginEntry == nullptr)
+    return {};
+
+  auto &cache = indexCache();
+  std::lock_guard<std::mutex> lock(cache.mutex);
+
+  const auto key = std::make_pair(library->_pluginEntry, pluginId);
+  if (auto it = cache.map.find(key); it != cache.map.end()) return it->second;
+
+  // Not make_shared: the constructor is private, and this is the only place
+  // allowed to call it.
+  std::shared_ptr<PresetIndex> index(new PresetIndex());
+  index->start(library, pluginId);
+  cache.map[key] = index;
+  return index;
+}
+
+void PresetIndex::resetCache()
+{
+  auto &cache = indexCache();
+  std::lock_guard<std::mutex> lock(cache.mutex);
+  cache.map.clear();
+}
+
+PresetIndex::~PresetIndex()
+{
+  _abandon.store(true);
+  if (_thread.joinable()) _thread.join();
+}
+
+void PresetIndex::start(const Library *library, const std::string &pluginId)
+{
+  const auto *factory = library->_pluginFactoryPresetDiscovery;
+  _thread = std::thread([this, factory, pluginId]() { crawl(factory, pluginId); });
+}
+
+void PresetIndex::crawl(const clap_preset_discovery_factory_t *factory, std::string pluginId)
+{
+  // Every provider the factory offers is asked. A plugin may split its
+  // content across several (factory content and user content, say).
+  const uint32_t providerCount = factory->count != nullptr ? factory->count(factory) : 0;
+
+  for (uint32_t p = 0; p < providerCount && !_abandon.load(); ++p)
+  {
+    const auto *descriptor =
+        factory->get_descriptor != nullptr ? factory->get_descriptor(factory, p) : nullptr;
+    if (descriptor == nullptr || descriptor->id == nullptr) continue;
+    if (!clap_version_is_compatible(descriptor->clap_version)) continue;
+
+    Declarations declarations;
+    const auto *provider = factory->create != nullptr
+                               ? factory->create(factory, &declarations.indexer, descriptor->id)
+                               : nullptr;
+    if (provider == nullptr) continue;
+
+    // "It is forbidden to call it before provider->init()."
+    if (provider->init == nullptr || !provider->init(provider))
+    {
+      if (provider->destroy != nullptr) provider->destroy(provider);
+      continue;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      for (auto &collection : declarations.collections) _collections.push_back(collection);
+    }
+
+    Receiver receiver;
+    receiver.pluginId = pluginId;
+
+    if (provider->get_metadata != nullptr)
+    {
+      for (const auto &location : declarations.locations)
+      {
+        if (_abandon.load()) break;
+
+        receiver.locationKind = location.kind;
+        receiver.locationFlags = location.flags;
+
+        if (location.kind == CLAP_PRESET_DISCOVERY_LOCATION_PLUGIN)
+        {
+          // The module is the container: one call, null location.
+          receiver.location.clear();
+          provider->get_metadata(provider, location.kind, nullptr, &receiver.receiver);
+          receiver.finishFile();
+          continue;
+        }
+
+        // A FILE location may be a directory to crawl or a single file.
+        std::error_code ec;
+        const fs::path root{location.location};
+
+        if (fs::is_regular_file(root, ec))
+        {
+          receiver.location = location.location;
+          provider->get_metadata(provider, location.kind, location.location.c_str(), &receiver.receiver);
+          receiver.finishFile();
+          continue;
+        }
+
+        if (!fs::is_directory(root, ec)) continue;  // gone, or not readable
+
+        size_t seen = 0;
+        // skip_permission_denied so one unreadable subdirectory does not end
+        // the crawl; follow_directory_symlink is deliberately NOT set, which
+        // is what keeps a symlink loop from being one.
+        auto options = fs::directory_options::skip_permission_denied;
+        fs::recursive_directory_iterator it{root, options, ec}, end;
+        for (; it != end && !_abandon.load(); it.increment(ec))
+        {
+          if (ec)
+          {
+            ec.clear();
+            continue;
+          }
+          if (it.depth() > static_cast<int>(kMaxCrawlDepth))
+          {
+            it.disable_recursion_pending();
+            continue;
+          }
+          if (!it->is_regular_file(ec)) continue;
+          if (!declarations.matchesExtension(it->path())) continue;
+          if (++seen > kMaxPresetsPerLocation) break;
+
+          const auto path = it->path().string();
+          receiver.location = path;
+          provider->get_metadata(provider, location.kind, path.c_str(), &receiver.receiver);
+          receiver.finishFile();
+        }
+      }
+    }
+
+    if (provider->destroy != nullptr) provider->destroy(provider);
+
+    {
+      std::lock_guard<std::mutex> lock(_mutex);
+      for (auto &entry : receiver.collected) _presets.push_back(std::move(entry));
+    }
+  }
+
+  {
+    // The ordering a host will store indices into. See the header: this is
+    // why it is sorted at all.
+    std::lock_guard<std::mutex> lock(_mutex);
+    std::stable_sort(_presets.begin(), _presets.end(),
+                     [](const PresetEntry &a, const PresetEntry &b)
+                     {
+                       return std::tie(a.locationKind, a.location, a.loadKey) <
+                              std::tie(b.locationKind, b.location, b.loadKey);
+                     });
+  }
+
+  finish();
+}
+
+bool PresetIndex::waitUntilComplete(unsigned timeoutMs)
+{
+  if (_complete.load()) return true;
+
+  std::unique_lock<std::mutex> lock(_completionMutex);
+  _completionCv.wait_for(lock, std::chrono::milliseconds(timeoutMs),
+                         [this]() { return _complete.load(); });
+  return _complete.load();
+}
+
+void PresetIndex::finish()
+{
+  {
+    // Under the lock so a waiter cannot miss the notify between testing the
+    // flag and starting to wait.
+    std::lock_guard<std::mutex> lock(_completionMutex);
+    _complete.store(true);
+  }
+  _completionCv.notify_all();
+
+  std::vector<Listener> toCall;
+  {
+    std::lock_guard<std::mutex> lock(_listenerMutex);
+    for (auto &[token, listener] : _listeners) toCall.push_back(listener);
+  }
+  for (auto &listener : toCall)
+    if (listener) listener();
+}
+
+std::vector<PresetEntry> PresetIndex::presets() const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _presets;
+}
+
+std::vector<PresetCollection> PresetIndex::collections() const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _collections;
+}
+
+size_t PresetIndex::size() const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return _presets.size();
+}
+
+bool PresetIndex::presetAt(size_t index, PresetEntry &out) const
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  if (index >= _presets.size()) return false;
+  out = _presets[index];
+  return true;
+}
+
+bool PresetIndex::indexOf(uint32_t locationKind, const char *location, const char *loadKey,
+                          size_t &outIndex) const
+{
+  const std::string wantedLocation = location != nullptr ? location : "";
+  const std::string wantedKey = loadKey != nullptr ? loadKey : "";
+
+  std::lock_guard<std::mutex> lock(_mutex);
+  for (size_t i = 0; i < _presets.size(); ++i)
+  {
+    const auto &entry = _presets[i];
+    if (entry.locationKind == locationKind && entry.location == wantedLocation &&
+        entry.loadKey == wantedKey)
+    {
+      outIndex = i;
+      return true;
+    }
+  }
+  return false;
+}
+
+uint64_t PresetIndex::addCompletionListener(Listener listener)
+{
+  uint64_t token;
+  {
+    std::lock_guard<std::mutex> lock(_listenerMutex);
+    token = _nextListenerToken++;
+    _listeners.emplace_back(token, listener);
+  }
+
+  // A wrapper instantiated after the crawl finished still needs to be told,
+  // or it would wait forever for an event that already happened.
+  if (_complete.load() && listener) listener();
+  return token;
+}
+
+void PresetIndex::removeCompletionListener(uint64_t token)
+{
+  std::lock_guard<std::mutex> lock(_listenerMutex);
+  _listeners.erase(std::remove_if(_listeners.begin(), _listeners.end(),
+                                  [token](const auto &pair) { return pair.first == token; }),
+                   _listeners.end());
+}
+
+}  // namespace Clap

--- a/src/detail/clap/preset_discovery.h
+++ b/src/detail/clap/preset_discovery.h
@@ -1,0 +1,193 @@
+#pragma once
+
+/*
+
+    Copyright (c) 2022 Timo Kaluza (defiantnerd)
+                       Paul Walker
+
+    This file is part of the clap-wrappers project which is released under MIT License.
+    See file LICENSE or go to https://github.com/free-audio/clap-wrapper for full license details.
+
+    CLAP preset discovery, from the other side.
+
+    In CLAP the host is the indexer: a plugin declares filetypes and locations,
+    and the host crawls them and asks the plugin for each file's metadata. No
+    VST3 or AUv2 host will ever do that for a wrapped CLAP - they have no such
+    concept - so if the wrapped plugin's presets are to reach those hosts at
+    all, the wrapper has to be the indexer itself. That is what this file is.
+
+    What it produces is a flat, ordered list of presets that a format wrapper
+    can hand to its host in whatever shape that host understands (a VST3
+    program list, an AU factory-preset array), plus the collections
+    ("soundpacks") the plugin declared, so those lists can be grouped.
+
+    Three properties are deliberate and load-bearing:
+
+      * It is shared per library, not per instance. Crawling a preset folder
+        can mean thousands of files; doing that once per plugin instance in a
+        session with forty tracks is not acceptable, so the index is cached
+        process-wide and keyed by (entry, plugin id).
+
+      * It runs on a background thread. A host instantiates a plugin on its
+        main thread and expects that to be quick; a wrapper that crawled the
+        filesystem there would stall project loads. Listeners are told when the
+        crawl finishes, and a listener that arrives late is told immediately.
+
+      * The order is deterministic. VST3 program numbers and AU preset numbers
+        are positional - a host stores the *index*, not the identity - so the
+        same content must always produce the same numbering, or reopening a
+        project silently selects a different preset. Presets are therefore
+        sorted by (location kind, location, load key), never by the order the
+        filesystem happened to hand them over.
+*/
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <clap/clap.h>
+
+namespace Clap
+{
+
+class Library;
+
+// One indexed preset: everything a format wrapper might want to show, and the
+// three fields it needs to load the thing again.
+struct PresetEntry
+{
+  // What clap_plugin_preset_load::from_location() wants back, verbatim.
+  uint32_t locationKind{CLAP_PRESET_DISCOVERY_LOCATION_FILE};
+  std::string location;  // empty for CLAP_PRESET_DISCOVERY_LOCATION_PLUGIN
+  std::string loadKey;   // empty when the location is not a container
+
+  std::string name;
+  std::string collectionId;  // the soundpack it belongs to, empty when none
+  std::string description;
+  std::vector<std::string> creators;
+  std::vector<std::string> features;
+  uint32_t flags{0};  // clap_preset_discovery_flags
+  clap_timestamp creationTime{CLAP_TIMESTAMP_UNKNOWN};
+  clap_timestamp modificationTime{CLAP_TIMESTAMP_UNKNOWN};
+
+  bool isFactoryContent() const
+  {
+    return (flags & CLAP_PRESET_DISCOVERY_IS_FACTORY_CONTENT) != 0;
+  }
+
+  // A name that is never empty: falls back to the load key, then to the
+  // location's filename. A host program list with a blank entry in it is
+  // worse than one with an ugly entry.
+  std::string displayName() const;
+};
+
+// A soundpack the plugin declared, for grouping a host's list.
+struct PresetCollection
+{
+  std::string id;
+  std::string name;
+  std::string description;
+  std::string vendor;
+  std::string homepageUrl;
+  std::string imagePath;
+  clap_timestamp releaseTimestamp{CLAP_TIMESTAMP_UNKNOWN};
+  uint32_t flags{0};
+};
+
+class PresetIndex
+{
+ public:
+  // The shared index for this library and plugin id, crawled once. Returns
+  // null when the plugin exposes no preset-discovery factory, which is the
+  // normal case and must not be treated as an error.
+  //
+  // The crawl starts here, on a background thread. Safe to call from any
+  // thread, including concurrently.
+  static std::shared_ptr<PresetIndex> forPlugin(const Library *library, const std::string &pluginId);
+
+  // Drops every cached index. For test harnesses and for a host that unloads
+  // the library; the shared_ptrs handed out stay valid.
+  static void resetCache();
+
+  ~PresetIndex();
+
+  PresetIndex(const PresetIndex &) = delete;
+  PresetIndex &operator=(const PresetIndex &) = delete;
+
+  // True once the crawl has finished. Until then the accessors below return
+  // whatever has been found so far, which is a legitimate thing to show: AU
+  // asks for factory presets early and synchronously, so "what we have yet"
+  // beats "nothing".
+  bool isComplete() const
+  {
+    return _complete.load();
+  }
+
+  // Waits up to `timeoutMs` for the crawl to finish, and returns whether it
+  // did. For the one caller that has no choice: AU asks for factory presets
+  // once, synchronously, on the main thread at load, and a host told "no such
+  // property" may never ask again. A short wait there beats reporting an empty
+  // preset menu; it is not a substitute for the completion listener, which is
+  // what covers a crawl too slow to wait for.
+  bool waitUntilComplete(unsigned timeoutMs);
+
+  // A snapshot. By value on purpose: the crawl thread appends to the real
+  // list under a lock, and handing out references into it would be a race the
+  // callers could not see.
+  std::vector<PresetEntry> presets() const;
+  std::vector<PresetCollection> collections() const;
+  size_t size() const;
+
+  // One preset by its position in the ordering. False when out of range,
+  // which a host asking about a stale index will do.
+  bool presetAt(size_t index, PresetEntry &out) const;
+
+  // Where a preset sits in the ordering, for telling a host which of its
+  // numbered slots the plugin just loaded. Returns false when the identity is
+  // not in the index (a preset loaded from somewhere the wrapper never
+  // crawled - a host's own "load from file", say).
+  bool indexOf(uint32_t locationKind, const char *location, const char *loadKey, size_t &outIndex) const;
+
+  // Called on the crawl thread when the crawl completes, or immediately (on
+  // the caller's thread) if it already has. Use it to tell a host its preset
+  // list changed. The token lets a wrapper unregister in its destructor -
+  // without that, a callback could outlive the instance it captured.
+  using Listener = std::function<void()>;
+  uint64_t addCompletionListener(Listener listener);
+  void removeCompletionListener(uint64_t token);
+
+ private:
+  PresetIndex() = default;
+
+  void start(const Library *library, const std::string &pluginId);
+  void crawl(const clap_preset_discovery_factory_t *factory, std::string pluginId);
+  void finish();
+
+  // The receiver and indexer callbacks the provider talks to. They live here
+  // so the whole conversation with the plugin is in one place.
+  struct Declarations;
+  struct Receiver;
+
+  mutable std::mutex _mutex;
+  std::vector<PresetEntry> _presets;
+  std::vector<PresetCollection> _collections;
+  std::atomic<bool> _complete{false};
+
+  std::mutex _completionMutex;
+  std::condition_variable _completionCv;
+
+  std::mutex _listenerMutex;
+  std::vector<std::pair<uint64_t, Listener>> _listeners;
+  uint64_t _nextListenerToken{1};
+
+  std::thread _thread;
+  std::atomic<bool> _abandon{false};
+};
+
+}  // namespace Clap

--- a/src/detail/vst3/parameter.cpp
+++ b/src/detail/vst3/parameter.cpp
@@ -183,3 +183,27 @@ Vst3Parameter *Vst3Parameter::create(uint8_t bus, uint8_t channel, uint8_t cc, V
 
   return new Vst3Parameter(v, bus, channel, cc);
 }
+
+Vst3Parameter *Vst3Parameter::createPresetSelector(Steinberg::Vst::ParamID id, int32_t presetCount)
+{
+  Vst::ParameterInfo v;
+  memset(&v, 0, sizeof(v));
+  v.id = id;
+  utf8_to_utf16l("Preset", (uint16_t *)(v.title), str16BufferSize(v.title));
+  utf8_to_utf16l("Preset", (uint16_t *)(v.shortTitle), str16BufferSize(v.shortTitle));
+  v.units[0] = 0;
+  v.defaultNormalizedValue = 0;
+  // kIsProgramChange is what ties the parameter to the unit's program list, so
+  // a host shows the list instead of a bare slider. Not automatable: a preset
+  // load rebuilds a plugin's state, which is not something to draw a curve
+  // through.
+  v.flags = Vst::ParameterInfo::kIsProgramChange | Vst::ParameterInfo::kIsList;
+  v.stepCount = presetCount > 1 ? presetCount - 1 : 0;
+
+  auto *p = new Vst3Parameter(v, 0, 0, 0);
+  p->isMidi = false;
+  p->isPreset = true;
+  p->min_value = 0;
+  p->max_value = v.stepCount;
+  return p;
+}

--- a/src/detail/vst3/parameter.h
+++ b/src/detail/vst3/parameter.h
@@ -77,6 +77,13 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
   static Vst3Parameter *create(const clap_param_info_t *info,
                                std::function<Steinberg::Vst::UnitID(const char *modulepath)> getUnitId);
   static Vst3Parameter *create(uint8_t bus, uint8_t channel, uint8_t cc, Steinberg::Vst::ParamID id);
+
+  // The preset selector: a kIsProgramChange parameter whose value is an index
+  // into the wrapper's preset list, not a MIDI program number. It has to be a
+  // separate kind because the process adapter turns every isMidi program
+  // change into an actual 0xC0 message, which is emphatically not what
+  // selecting a preset should do.
+  static Vst3Parameter *createPresetSelector(Steinberg::Vst::ParamID id, int32_t presetCount);
   // copies from the clap_param_info_t
   uint32_t param_index_for_clap_get_info = 0;
   clap_id id = 0;
@@ -86,6 +93,7 @@ class Vst3Parameter : public Steinberg::Vst::Parameter
   double max_value;  // maximum plain value
   // or it was MIDI
   bool isMidi = false;
+  bool isPreset = false;
   uint8_t channel = 0;
   uint8_t controller = 0;
 };

--- a/src/detail/vst3/process.cpp
+++ b/src/detail/vst3/process.cpp
@@ -294,6 +294,23 @@ void ProcessAdapter::process(Steinberg::Vst::ProcessData &data)
       auto param = (Vst3Parameter *)parameters->getParameter(paramid);
       if (param)
       {
+        if (param->isPreset)
+        {
+          // The preset selector. Only the last point in the block matters -
+          // loading three presets because a host sent three points would be
+          // absurd - and the load itself must happen on the main thread, so
+          // all that happens here is a request.
+          auto nums = k->getPointCount();
+          Vst::ParamValue value;
+          int32 offset;
+          if (nums > 0 && k->getPoint(nums - 1, offset, value) == kResultOk && _automation)
+          {
+            const auto index = static_cast<int64_t>(param->asClapValue(value) + 0.5);
+            if (index >= 0) _automation->onRequestPresetLoad(static_cast<size_t>(index));
+          }
+          continue;
+        }
+
         if (param->isMidi)
         {
           auto nums = k->getPointCount();

--- a/src/wrapasauv2.cpp
+++ b/src/wrapasauv2.cpp
@@ -189,6 +189,17 @@ WrapAsAUV2::WrapAsAUV2(const std::string &clapname, const std::string &clapid, i
 
 WrapAsAUV2::~WrapAsAUV2()
 {
+  // The index outlives this instance (it is cached per module) and its crawl
+  // thread holds our callback, so it has to be dropped before anything else.
+  if (_presetIndex && _presetIndexToken)
+  {
+    _presetIndex->removeCompletionListener(_presetIndexToken);
+    _presetIndexToken = 0;
+  }
+  _presetIndex.reset();
+  for (auto name : _presetNameStrings) CFRelease(name);
+  _presetNameStrings.clear();
+
 #if AUSDK_MIDI2_AVAILABLE
   if (auto blk = _midioutput_hosteventlistblock.exchange(nullptr)) Block_release(blk);
   for (auto blk : _retiredEventListBlocks) Block_release(blk);
@@ -310,6 +321,146 @@ void WrapAsAUV2::setupWrapperSpecifics(const clap_plugin_t *plugin)
 {
   // TODO: if there are AUv2 specific extensions, they can be retrieved here
   // _auv2_specifics = (clap_plugin_as_auv2_t*)plugin->get_extension(plugin, CLAP_PLUGIN_AS_AUV2);
+  setupPresets();
+}
+
+// ----------------------------------------------------------------------------
+// clap.preset-load, published to the host as AU factory presets
+// ----------------------------------------------------------------------------
+void WrapAsAUV2::setupPresets()
+{
+  // Nothing to offer if the plugin cannot load a preset it is handed back.
+  if (!_plugin || !_plugin->supportsPresetLoad()) return;
+
+  // _desc->id, not _clapid: this wrapper can be built to select its plugin by
+  // index instead of by id, and then _clapid is empty. An empty id here is not
+  // harmless - it is the value the index matches add_plugin_id() against, so
+  // every preset that names its plugin would be filtered out and the list
+  // would come back empty.
+  const char *pluginId = _desc && _desc->id ? _desc->id : _clapid.c_str();
+  _presetIndex = Clap::PresetIndex::forPlugin(&_library, pluginId);
+  if (!_presetIndex) return;  // the plugin has no preset-discovery factory
+
+  _presetIndexToken = _presetIndex->addCompletionListener(
+      [this]()
+      {
+        // Crawl thread: only a flag. onIdle() tells the host.
+        _presetListChanged.store(true);
+      });
+}
+
+void WrapAsAUV2::rebuildPresetCache() const
+{
+  std::lock_guard<std::mutex> lock(_presetCacheMutex);
+
+  _presetCache.clear();
+  if (!_presetIndex)
+  {
+    _presetCacheBuilt = true;
+    return;
+  }
+
+  // Only a completed crawl is worth caching. A host asking during one - AU
+  // asks early - would otherwise pin whatever partial list existed at that
+  // moment, and an empty one would stay empty until the completion tick.
+  _presetCacheBuilt = _presetIndex->isComplete();
+
+  const auto presets = _presetIndex->presets();
+  _presetCache.reserve(presets.size());
+  for (size_t i = 0; i < presets.size(); ++i)
+  {
+    const auto name = presets[i].displayName();
+    auto cfName = CFStringCreateWithCString(kCFAllocatorDefault, name.c_str(), kCFStringEncodingUTF8);
+    if (!cfName) continue;
+    _presetNameStrings.push_back(cfName);  // see the member's comment on lifetime
+
+    AUPreset preset{};
+    // The preset number IS the index in Clap::PresetIndex's ordering. A host
+    // stores this number, which is why that ordering is deterministic.
+    preset.presetNumber = static_cast<SInt32>(i);
+    preset.presetName = cfName;
+    _presetCache.push_back(preset);
+  }
+}
+
+OSStatus WrapAsAUV2::GetPresets(CFArrayRef *outData) const
+{
+  if (!_presetIndex) return kAudioUnitErr_InvalidProperty;
+
+  // AU asks for this once, synchronously, at load - and a host told
+  // kAudioUnitErr_InvalidProperty concludes the unit has no factory presets
+  // and is under no obligation to ever ask again. So wait briefly for the
+  // crawl rather than answer "none" while it is still running: an embedded
+  // container resolves in milliseconds, and a folder crawl that outlasts the
+  // wait is still covered by the FactoryPresets notification onIdle() sends.
+  _presetIndex->waitUntilComplete(1000);
+
+  if (!_presetCacheBuilt) rebuildPresetCache();
+
+  std::lock_guard<std::mutex> lock(_presetCacheMutex);
+  if (_presetCache.empty()) return kAudioUnitErr_InvalidProperty;
+
+  // A null outData is the host asking whether presets exist at all.
+  if (outData == nullptr) return noErr;
+
+  auto array =
+      CFArrayCreateMutable(kCFAllocatorDefault, static_cast<CFIndex>(_presetCache.size()), nullptr);
+  if (!array) return kAudio_MemFullError;
+  for (const auto &preset : _presetCache) CFArrayAppendValue(array, &preset);
+
+  *outData = static_cast<CFArrayRef>(array);  // the host releases it
+  return noErr;
+}
+
+OSStatus WrapAsAUV2::NewFactoryPresetSet(const AUPreset &inNewFactoryPreset)
+{
+  if (!_presetIndex || !_plugin) return kAudioUnitErr_InvalidPropertyValue;
+  if (inNewFactoryPreset.presetNumber < 0) return kAudioUnitErr_InvalidPropertyValue;
+
+  Clap::PresetEntry entry;
+  if (!_presetIndex->presetAt(static_cast<size_t>(inNewFactoryPreset.presetNumber), entry))
+    return kAudioUnitErr_InvalidPropertyValue;
+
+  auto guarantee_mainthread = _plugin->AlwaysMainThread();
+  if (!_plugin->loadPresetFromLocation(entry.locationKind,
+                                       entry.location.empty() ? nullptr : entry.location.c_str(),
+                                       entry.loadKey.empty() ? nullptr : entry.loadKey.c_str()))
+    return kAudioUnitErr_InvalidPropertyValue;
+
+  // Only now is it the current preset. Doing this before the load would leave
+  // a host showing a preset the plugin refused.
+  SetAFactoryPresetAsCurrent(inNewFactoryPreset);
+  return noErr;
+}
+
+void WrapAsAUV2::preset_loaded(uint32_t locationKind, const char *location, const char *loadKey)
+{
+  // The plugin loaded a preset itself (its own UI, or a project restore).
+  // Point the host's PresentPreset at the matching slot, if we indexed it.
+  if (!_presetIndex) return;
+
+  size_t index = 0;
+  if (!_presetIndex->indexOf(locationKind, location, loadKey, index)) return;
+
+  if (!_presetCacheBuilt) rebuildPresetCache();
+
+  AUPreset preset{};
+  {
+    std::lock_guard<std::mutex> lock(_presetCacheMutex);
+    if (index >= _presetCache.size()) return;
+    preset = _presetCache[index];
+  }
+
+  SetAFactoryPresetAsCurrent(preset);
+  PropertyChanged(kAudioUnitProperty_PresentPreset, kAudioUnitScope_Global, 0);
+}
+
+void WrapAsAUV2::preset_load_error(uint32_t /*locationKind*/, const char * /*location*/,
+                                   const char * /*loadKey*/, int32_t /*osError*/, const char *msg)
+{
+  // AU has no channel for this either; the plugin has been told and owns the
+  // user-facing message.
+  LOGINFO("[clap-wrapper] preset load failed: {}", msg ? msg : "(no message)");
 }
 
 void WrapAsAUV2::setupAudioBusses(const clap_plugin_t *plugin,
@@ -1593,6 +1744,19 @@ void WrapAsAUV2::onIdle()
   if (!_plugin) return;
 
   pushQueuedEventsToHost();
+
+  if (_presetListChanged.exchange(false))
+  {
+    // The crawl finished (or found more). Rebuild and tell the host to
+    // re-read; PropertyChanged is main-thread work, which is why the crawl
+    // thread only set a flag.
+    {
+      std::lock_guard<std::mutex> lock(_presetCacheMutex);
+      _presetCacheBuilt = false;
+    }
+    rebuildPresetCache();
+    PropertyChanged(kAudioUnitProperty_FactoryPresets, kAudioUnitScope_Global, 0);
+  }
 
   if (_requestMarkDirty.exchange(false))
   {

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -164,6 +164,16 @@ tresult PLUGIN_API ClapAsVst3::terminate()
 {
   vst3HostApplication.reset();
 
+  // Before anything else: the index lives in a module-wide cache and its
+  // crawl thread holds our callback. Leaving it registered past here would let
+  // it call into a half-terminated wrapper.
+  if (_presetIndex && _presetIndexToken)
+  {
+    _presetIndex->removeCompletionListener(_presetIndexToken);
+    _presetIndexToken = 0;
+  }
+  _presetIndex.reset();
+
   if (_plugin)
   {
     _os_attached.off();  // ensure we are detached
@@ -1274,6 +1284,153 @@ void ClapAsVst3::setupParameters(const clap_plugin_t *plugin, const clap_plugin_
                                     S16("Brit"), S16(""), 0, nullptr, 0));
 
   // PRESSURE is handled by IMidiMapping (-> Polypressure)
+
+  setupPresets();
+}
+
+// ----------------------------------------------------------------------------
+// clap.preset-load, published to the host as a VST3 program list
+// ----------------------------------------------------------------------------
+void ClapAsVst3::setupPresets()
+{
+  _presetParamId = Vst::kNoParamId;
+  _presetUnitId = Vst::kRootUnitId;
+
+  // setupParameters() can run more than once (param_rescan, and the rebuild in
+  // onIdle below), and the index is shared and long-lived - so drop any
+  // listener from a previous pass rather than stacking another onto it.
+  if (_presetIndex && _presetIndexToken)
+  {
+    _presetIndex->removeCompletionListener(_presetIndexToken);
+    _presetIndexToken = 0;
+  }
+
+  // No point offering a list the plugin could not load from.
+  if (!_plugin || !_plugin->supportsPresetLoad()) return;
+
+  // Shared per module: the crawl is expensive and its result is identical for
+  // every instance of the same plugin.
+  if (!_presetIndex)
+  {
+    const auto *descriptor = _library->plugins[_libraryIndex];
+    _presetIndex = Clap::PresetIndex::forPlugin(_library, descriptor->id ? descriptor->id : "");
+  }
+  if (!_presetIndex) return;  // the plugin has no preset-discovery factory
+
+  // A free tag, away from both the CLAP parameter ids and the block the
+  // IMidiMapping parameters reserve at 0xb00000.
+  Vst::ParamID id = 0xc00000;
+  while (parameters.getParameter(id)) ++id;
+
+  // The list has to be sized now, because a parameter's stepCount is fixed at
+  // creation and a host reads stepCount+1 as the program count (the SDK's own
+  // preset sample sets kNumPrograms-1). So wait briefly for the crawl rather
+  // than announce a size that is wrong: an embedded container resolves in
+  // milliseconds, and a folder crawl that outlasts the wait is still covered
+  // by the rescan onIdle() asks for when it completes.
+  _presetIndex->waitUntilComplete(1000);
+  const auto presetCount = _presetIndex->size();
+  if (presetCount == 0) return;  // nothing to show; the rescan will come back
+
+  auto *selector = Vst3Parameter::createPresetSelector(id, (int32_t)presetCount);
+
+  // The program list goes on the ROOT unit, and the selector with it. Not a
+  // unit of its own: a host reads the root unit's programListId to find "the
+  // plugin's programs" - that is what the SDK's mda sample does
+  // (mdaBaseController.cpp: uinfo.id = kRootUnitId; uinfo.programListId =
+  // kPresetParam) and what againcontroller.cpp means by "create root only if
+  // you want to use the programListId". Hung off a child unit instead, the
+  // list validates perfectly and Cubase shows nothing.
+  selector->setUnitID(Vst::kRootUnitId);
+  parameters.addParameter(selector);
+
+  // units[0] is the root unit setupParameters() created just above. Setting
+  // the id on the Unit object rather than rebuilding it is how the
+  // IMidiMapping block already does it (newUnit->setProgramListID).
+  if (!units.empty()) units.at(0)->setProgramListID((Vst::ProgramListID)id);
+
+  _presetParamId = id;
+  _presetUnitId = Vst::kRootUnitId;
+
+  // The crawl may already be done - addCompletionListener() calls straight
+  // back in that case, which is why _presetParamId is set before this.
+  _presetIndexToken = _presetIndex->addCompletionListener([this]() { onPresetIndexComplete(); });
+}
+
+void ClapAsVst3::onPresetIndexComplete()
+{
+  // Called from the index's crawl thread. Nothing that talks to the host may
+  // happen here; onIdle() picks this up on the main thread.
+  _presetListChanged.store(true);
+}
+
+void ClapAsVst3::onRequestPresetLoad(size_t presetIndex)
+{
+  // Audio thread. Record and return - see the member's comment on coalescing.
+  _presetLoadRequest.store(static_cast<int64_t>(presetIndex));
+}
+
+void ClapAsVst3::preset_loaded(uint32_t locationKind, const char *location, const char *loadKey)
+{
+  // The plugin loaded a preset of its own accord (its own UI, most likely).
+  // Move the selector so the host's program display follows, but only if the
+  // preset is one this wrapper actually indexed - a plugin can load from
+  // places we never crawled, and there is no slot to point at for those.
+  if (!_presetIndex || _presetParamId == Vst::kNoParamId) return;
+
+  size_t index = 0;
+  if (!_presetIndex->indexOf(locationKind, location, loadKey, index)) return;
+
+  auto *param = (Vst3Parameter *)parameters.getParameter(_presetParamId);
+  if (!param) return;
+
+  const auto normalized = param->asVst3Value(static_cast<double>(index));
+  param->setNormalized(normalized);
+  if (componentHandler) componentHandler->performEdit(_presetParamId, normalized);
+}
+
+void ClapAsVst3::preset_load_error(uint32_t /*locationKind*/, const char * /*location*/,
+                                   const char * /*loadKey*/, int32_t /*osError*/, const char *msg)
+{
+  // VST3 has no channel for this. Log it so it is at least discoverable; the
+  // plugin has already been told, and it is the one with a UI to say so in.
+  if (_plugin) _plugin->log(CLAP_LOG_WARNING, msg ? msg : "preset load failed");
+}
+
+Steinberg::int32 PLUGIN_API ClapAsVst3::getProgramListCount()
+{
+  return super::getProgramListCount() + (_presetParamId != Vst::kNoParamId ? 1 : 0);
+}
+
+Steinberg::tresult PLUGIN_API ClapAsVst3::getProgramListInfo(Steinberg::int32 listIndex,
+                                                             Vst::ProgramListInfo &info)
+{
+  const auto inherited = super::getProgramListCount();
+  if (listIndex < inherited) return super::getProgramListInfo(listIndex, info);
+
+  if (_presetParamId == Vst::kNoParamId || listIndex != inherited) return Steinberg::kResultFalse;
+
+  info.id = (Vst::ProgramListID)_presetParamId;
+  // What the host will show as the number of slots. Reporting the count found
+  // so far (rather than the parameter's 128 steps) keeps a browser from
+  // listing empty entries while the crawl is still running.
+  info.programCount = _presetIndex ? (Steinberg::int32)_presetIndex->size() : 0;
+  stringconv::convert(std::string("Presets"), info.name);
+  return Steinberg::kResultOk;
+}
+
+Steinberg::tresult PLUGIN_API ClapAsVst3::getProgramName(Vst::ProgramListID listId,
+                                                         Steinberg::int32 programIndex,
+                                                         Vst::String128 name)
+{
+  if (!isPresetProgramList(listId)) return super::getProgramName(listId, programIndex, name);
+
+  Clap::PresetEntry entry;
+  if (!_presetIndex || programIndex < 0 || !_presetIndex->presetAt((size_t)programIndex, entry))
+    return Steinberg::kResultFalse;
+
+  stringconv::convert(entry.displayName(), name);
+  return Steinberg::kResultOk;
 }
 
 void ClapAsVst3::param_rescan(clap_param_rescan_flags flags)
@@ -1533,6 +1690,47 @@ void ClapAsVst3::onIdle()
   // asserting it: while it is held, the thread the host calls the main thread
   // cannot be in here as well.
   auto mainThreadOverride = _plugin->AlwaysMainThread();
+
+  // A preset the host asked for on the audio thread, and a preset list that
+  // filled in on the crawl thread. Both have to happen here: from_location()
+  // is [main-thread], and so is notifyProgramListChange().
+  if (auto requested = _presetLoadRequest.exchange(-1); requested >= 0)
+  {
+    Clap::PresetEntry entry;
+    // Clamp anyway: stepCount matches the count at creation, but a host may
+    // still have a stale value from before a rescan.
+    const auto count = _presetIndex ? _presetIndex->size() : 0;
+    if (count > 0)
+    {
+      const auto index = std::min<size_t>((size_t)requested, count - 1);
+      if (_presetIndex->presetAt(index, entry))
+      {
+        _plugin->loadPresetFromLocation(entry.locationKind,
+                                        entry.location.empty() ? nullptr : entry.location.c_str(),
+                                        entry.loadKey.empty() ? nullptr : entry.loadKey.c_str());
+      }
+    }
+  }
+
+  if (_presetListChanged.exchange(false))
+  {
+    if (_presetParamId == Vst::kNoParamId)
+    {
+      // The crawl finished after setupPresets() had nothing to size the list
+      // with, so there is no selector parameter at all yet. Only rebuilding
+      // the parameters can introduce one; restartComponent is what makes the
+      // host re-read them.
+      setupParameters(_plugin->_plugin, _plugin->_ext._params);
+      if (componentHandler)
+        componentHandler->restartComponent(Vst::RestartFlags::kParamTitlesChanged |
+                                           Vst::RestartFlags::kParamValuesChanged);
+    }
+    else if (auto unitHandler = Steinberg::FUnknownPtr<Vst::IUnitHandler>(componentHandler))
+    {
+      // -1: every program in the list changed, not one of them.
+      unitHandler->notifyProgramListChange((Vst::ProgramListID)_presetParamId, -1);
+    }
+  }
 
   // handling queued events
   queueEvent n;

--- a/src/wrapasvst3.cpp
+++ b/src/wrapasvst3.cpp
@@ -1367,15 +1367,26 @@ void ClapAsVst3::onPresetIndexComplete()
 void ClapAsVst3::onRequestPresetLoad(size_t presetIndex)
 {
   // Audio thread. Record and return - see the member's comment on coalescing.
+  //
+  // A value equal to the one already in effect is not a request: the
+  // parameter stream carries the selector's value, not its edges, and acting
+  // on every arrival makes loading a preset a permanent state of reloading it
+  // (\see _presetIndexInEffect).
+  if (static_cast<int64_t>(presetIndex) == _presetIndexInEffect.load(std::memory_order_relaxed))
+  {
+    return;
+  }
+
   _presetLoadRequest.store(static_cast<int64_t>(presetIndex));
 }
 
 void ClapAsVst3::preset_loaded(uint32_t locationKind, const char *location, const char *loadKey)
 {
-  // The plugin loaded a preset of its own accord (its own UI, most likely).
-  // Move the selector so the host's program display follows, but only if the
-  // preset is one this wrapper actually indexed - a plugin can load from
-  // places we never crawled, and there is no slot to point at for those.
+  // The plugin loaded a preset - the one onIdle() asked for, or one of its own
+  // accord (its own UI, most likely). Move the selector so the host's program
+  // display follows, but only if the preset is one this wrapper actually
+  // indexed - a plugin can load from places we never crawled, and there is no
+  // slot to point at for those.
   if (!_presetIndex || _presetParamId == Vst::kNoParamId) return;
 
   size_t index = 0;
@@ -1384,9 +1395,27 @@ void ClapAsVst3::preset_loaded(uint32_t locationKind, const char *location, cons
   auto *param = (Vst3Parameter *)parameters.getParameter(_presetParamId);
   if (!param) return;
 
+  _presetIndexInEffect.store(static_cast<int64_t>(index), std::memory_order_relaxed);
+
   const auto normalized = param->asVst3Value(static_cast<double>(index));
+  if (param->getNormalized() == normalized)
+  {
+    // Already where the host put it, which is the usual case: this is the
+    // confirmation of a load the host itself asked for. Reporting it as an
+    // edit is what a host hands back as a fresh program change.
+    return;
+  }
+
   param->setNormalized(normalized);
-  if (componentHandler) componentHandler->performEdit(_presetParamId, normalized);
+  if (componentHandler)
+  {
+    // Bracketed, like any value a plugin originates: an unbracketed
+    // performEdit() is a change a host cannot attribute to a gesture, and the
+    // ones that record it leave the parameter latched in touch mode.
+    componentHandler->beginEdit(_presetParamId);
+    componentHandler->performEdit(_presetParamId, normalized);
+    componentHandler->endEdit(_presetParamId);
+  }
 }
 
 void ClapAsVst3::preset_load_error(uint32_t /*locationKind*/, const char * /*location*/,
@@ -1703,6 +1732,13 @@ void ClapAsVst3::onIdle()
     if (count > 0)
     {
       const auto index = std::min<size_t>((size_t)requested, count - 1);
+
+      // In effect from here on, whatever the load makes of it: the host is
+      // sending this value, and a preset that cannot be loaded has to be
+      // attempted once rather than once per block. A load that succeeds
+      // confirms the same index through preset_loaded().
+      _presetIndexInEffect.store(static_cast<int64_t>(index), std::memory_order_relaxed);
+
       if (_presetIndex->presetAt(index, entry))
       {
         _plugin->loadPresetFromLocation(entry.locationKind,

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -37,6 +37,7 @@
 #include "detail/os/osutil.h"
 #include "detail/vst3/plugview.h"
 #include "detail/clap/automation.h"
+#include "detail/clap/preset_discovery.h"
 #include "detail/shared/fixedqueue.h"
 #include "detail/ara/ara.h"
 #include "detail/vst3/aravst3.h"
@@ -381,6 +382,24 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   void onBeginEdit(clap_id id) override;
   void onPerformEdit(const clap_event_param_value_t *value) override;
   void onEndEdit(clap_id id) override;
+  void onRequestPresetLoad(size_t presetIndex) override;
+
+  //---from Clap::IHost, preset-load ---------------
+  void preset_loaded(uint32_t locationKind, const char *location, const char *loadKey) override;
+  void preset_load_error(uint32_t locationKind, const char *location, const char *loadKey,
+                         int32_t osError, const char *msg) override;
+
+  //---program lists, for the preset list -----------
+  // The preset list is answered from the index rather than from a
+  // Steinberg::Vst::ProgramList object, because the index fills in on a
+  // background thread and a ProgramList cannot be emptied once built. The MIDI
+  // "Program Changes" lists still come from the SDK, so both paths have to
+  // coexist here.
+  Steinberg::int32 PLUGIN_API getProgramListCount() override;
+  Steinberg::tresult PLUGIN_API getProgramListInfo(Steinberg::int32 listIndex,
+                                                   Vst::ProgramListInfo &info /*out*/) override;
+  Steinberg::tresult PLUGIN_API getProgramName(Vst::ProgramListID listId, Steinberg::int32 programIndex,
+                                               Vst::String128 name /*out*/) override;
 
   // information function to enable/disable the IMIDIMapping interface
   bool checkMIDIDialectSupport();
@@ -444,6 +463,33 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
 
   // set by param_rescan() whenever it syncs values, cleared and checked by setState()
   bool _paramValuesSyncedDuringLoad{false};
+
+  // ---- clap.preset-load, published as a VST3 program list ----
+  // Built in setupParameters() when the plugin implements preset-load. The
+  // index itself is shared per module and crawls on a background thread, so
+  // the list can be empty here and fill in later; onPresetIndexComplete() is
+  // what tells the host to look again.
+  void setupPresets();
+  void onPresetIndexComplete();
+  bool isPresetProgramList(Vst::ProgramListID listId) const
+  {
+    return _presetParamId != Vst::kNoParamId && listId == (Vst::ProgramListID)_presetParamId;
+  }
+
+  std::shared_ptr<Clap::PresetIndex> _presetIndex;
+  uint64_t _presetIndexToken = 0;
+  // The program list id and the selector parameter id are deliberately the
+  // same number - that is how VST3 ties a unit's program list to the
+  // parameter a host moves to change program.
+  Vst::ParamID _presetParamId = Vst::kNoParamId;
+  Vst::UnitID _presetUnitId = Vst::kRootUnitId;
+  // Set from the audio thread by onRequestPresetLoad(), drained in onIdle().
+  // Coalescing is correct: three program changes in one block should load the
+  // last preset, not three.
+  std::atomic<int64_t> _presetLoadRequest{-1};
+  // Set when the crawl finishes; onIdle() turns it into the host notification,
+  // because notifyProgramListChange() is not for a background thread.
+  std::atomic<bool> _presetListChanged{false};
 
   // for IMidiMapping
   bool _useIMidiMapping = false;

--- a/src/wrapasvst3.h
+++ b/src/wrapasvst3.h
@@ -487,6 +487,21 @@ class ClapAsVst3 : public Steinberg::Vst::SingleComponentEffect,
   // Coalescing is correct: three program changes in one block should load the
   // last preset, not three.
   std::atomic<int64_t> _presetLoadRequest{-1};
+  // The selector value already in effect: the index onIdle() last acted on,
+  // or the one preset_loaded() resolved. A parameter change is only a request
+  // when it names something else.
+  //
+  // Both halves of that matter. preset_loaded() tells the host where the
+  // selector now stands, and a host that hands that value straight back would
+  // be asking for the preset that has just been loaded - a loop that reloads
+  // the plugin's entire state for as long as the instance lives, discarding
+  // whatever the user edited in between. A host is also entitled to send a
+  // program list parameter's current value in every process block, which is
+  // the same request arriving from the other side.
+  //
+  // Written on the main thread (onIdle, preset_loaded), read on the audio
+  // thread (onRequestPresetLoad).
+  std::atomic<int64_t> _presetIndexInEffect{-1};
   // Set when the crawl finishes; onIdle() turns it into the host notification,
   // because notifyProgramListChange() is not for a background thread.
   std::atomic<bool> _presetListChanged{false};


### PR DESCRIPTION
In CLAP the host is the indexer: a plugin declares filetypes and locations, and
the host crawls them and asks the plugin for each file's metadata. No VST3 or
AUv2 host does any of that, so a wrapped CLAP's presets are simply invisible in
those formats — the wrapper never even asked for the preset-discovery factory.

This makes the wrapper the indexer. `Clap::PresetIndex`
(`src/detail/clap/preset_discovery.*`) drives the plugin's provider the way a
CLAP host would, crawls the declared locations, and produces a flat ordered
list that each format publishes in whatever shape its host understands.

### Three properties that are load-bearing rather than incidental

- **Shared per (entry, plugin id), not per instance.** Crawling a preset folder
  can mean thousands of files; doing that once per instance in a forty-track
  session is not acceptable.
- **Crawls on a background thread.** Hosts instantiate plugins on the main
  thread and expect it to be quick. Listeners are told when the crawl finishes,
  and one that arrives late is told immediately — which is the case that
  matters, since AU asks for factory presets early and synchronously.
- **Deterministic order** (location kind, location, load key). VST3 program
  numbers and AU preset numbers are positional — the host stores the *index*,
  not the identity — so the same content must always produce the same
  numbering, or reopening a project selects a different preset.

### VST3

A "Presets" unit whose program list is answered straight from the index rather
than from a Steinberg `ProgramList`: the list fills in asynchronously and a
`ProgramList` cannot be emptied once built. `getProgramListCount/Info/Name` are
overridden to serve that one list and delegate the MIDI "Program Changes" lists
to the SDK.

Selection rides the existing `kIsProgramChange` mechanism through a new
non-MIDI parameter kind. It has to be its own kind, because the process adapter
turns every `isMidi` program change into an actual `0xC0` message, which is not
what picking a preset should do. The load is marshalled to `onIdle()`, since
`from_location()` is `[main-thread]` and parameter changes arrive on the audio
thread; coalescing there is correct — three program changes in one block should
load the last preset, not three.

### AUv2

Real factory presets: `GetPresets`/`NewFactoryPresetSet` over the same index,
with `kAudioUnitProperty_FactoryPresets` renotified when the crawl completes.
Two things there are less obvious than they look:

- `GetPresets` waits briefly (1s) for the crawl instead of returning
  `kAudioUnitErr_InvalidProperty` while it runs. AU asks once, synchronously,
  at load, and a host told the property does not exist is under no obligation
  to ask again — so answering "none" too early loses the preset menu for the
  whole session.
- The `AUPreset` `CFString`s are kept alive for the instance's lifetime,
  because the AU API gives a host no way to say it is done with an array it was
  handed.

The AUv2 side also takes its plugin id from the descriptor rather than the id
string the wrapper was constructed with: that string is empty when the wrapper
selects its plugin by index, and an empty id is not harmless — it is what
`add_plugin_id()` is matched against, so every preset naming its plugin would
be filtered out and the list would come back empty.

### Both directions

`clap.preset-load` is fetched from the plugin and the host half of it is
served, so a plugin loading a preset from its own UI moves the host's program
display to match. `IHost`'s two new callbacks are defaulted rather than pure —
only formats that can show a preset list have anything to do with them, and
making them pure would force every other wrapper to grow empty overrides.

### Not in scope

Standalone preset menu, AUv3, AAX.

### Testing

Against a CLAP that implements both APIs (363 factory presets in a
`LOCATION_PLUGIN` container plus a `LOCATION_FILE` folder):

- **Cubase 15 Pro (VST3)** — the presets appear and are selectable. Worth
  saying explicitly, because this is the case a validator cannot speak to:
  with the program list on a unit of its own the validator still reported
  47/47 with all 363 names, and Cubase showed nothing. Only the root unit
  placement makes it visible.
- **Logic (AUv2)** — presets open, switch and store.
- **VST3 `validator`**: `Unit000 "Root" (programlist ID = ...)` and
  `Programlist "Presets" (363 programs)` with names read back through the
  overrides — **47 tests passed, 0 failed**.
- **AUv2 `auval`**: **`AU VALIDATION SUCCEEDED`**. A small AU host also
  confirms 363 factory presets with correct numbering, and that
  `kAudioUnitProperty_PresentPreset` round-trips through
  `NewFactoryPresetSet`.

Based on `next` @ 9501dad0, which is `next`'s head at the time of writing, so
this is one commit with no rebase needed.

